### PR TITLE
test: add dotenv and PRD validation to KYC stats e2e

### DIFF
--- a/e2e/compliance-kyc-stats.spec.ts
+++ b/e2e/compliance-kyc-stats.spec.ts
@@ -1,9 +1,21 @@
 import { test, expect, APIRequestContext } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as dotenv from 'dotenv';
 import { createTestCredentials } from './test-wallet';
 
+dotenv.config({ path: path.join(__dirname, '../.env') });
+
 const API_URL = process.env.REACT_APP_API_URL! + '/v1';
+
+// Expected KYC stats data from PRD (as of 2026-02-04)
+const EXPECTED_KYC_STATS = {
+  2021: { startCount: 0, reopened: 0, newFiles: 250, addedDuringYear: 250, activeDuringYear: 250, closedDuringYear: 0, endCount: 250, highestFileNr: 250 },
+  2022: { startCount: 250, reopened: 0, newFiles: 1947, addedDuringYear: 1947, activeDuringYear: 2197, closedDuringYear: 5, endCount: 2192, highestFileNr: 2197 },
+  2023: { startCount: 2192, reopened: 0, newFiles: 509, addedDuringYear: 509, activeDuringYear: 2701, closedDuringYear: 2127, endCount: 574, highestFileNr: 2706 },
+  2024: { startCount: 574, reopened: 87, newFiles: 611, addedDuringYear: 698, activeDuringYear: 1272, closedDuringYear: 253, endCount: 1019, highestFileNr: 3317 },
+  2025: { startCount: 1019, reopened: 8, newFiles: 2022, addedDuringYear: 2030, activeDuringYear: 3049, closedDuringYear: 2, endCount: 3047, highestFileNr: 5339 },
+};
 
 function getAdminSeed(): string {
   const apiEnvPath = path.join(__dirname, '../../api/.env');
@@ -61,5 +73,31 @@ test.describe('KYC Stats Page - Smoke Test', () => {
     });
 
     console.log('Screenshot saved to e2e/test-results/kyc-stats-smoke-test.png');
+  });
+
+  test('verifies KYC stats data matches expected PRD values', async ({ request }) => {
+    const response = await request.get(`${API_URL}/support/kycFileStats`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.ok()).toBeTruthy();
+    const stats = await response.json();
+
+    // Verify data for each year
+    for (const yearStats of stats) {
+      const year = yearStats.year as keyof typeof EXPECTED_KYC_STATS;
+      const expected = EXPECTED_KYC_STATS[year];
+
+      if (expected) {
+        expect(yearStats.startCount, `${year} startCount`).toBe(expected.startCount);
+        expect(yearStats.reopened, `${year} reopened`).toBe(expected.reopened);
+        expect(yearStats.newFiles, `${year} newFiles`).toBe(expected.newFiles);
+        expect(yearStats.addedDuringYear, `${year} addedDuringYear`).toBe(expected.addedDuringYear);
+        expect(yearStats.activeDuringYear, `${year} activeDuringYear`).toBe(expected.activeDuringYear);
+        expect(yearStats.closedDuringYear, `${year} closedDuringYear`).toBe(expected.closedDuringYear);
+        expect(yearStats.endCount, `${year} endCount`).toBe(expected.endCount);
+        expect(yearStats.highestFileNr, `${year} highestFileNr`).toBe(expected.highestFileNr);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Load `.env` via `dotenv` so `REACT_APP_API_URL` is available in Playwright context (consistent with all other e2e tests)
- Add expected PRD values (2021-2025) and verify API response matches

## Test plan
- [ ] Run `npx playwright test e2e/compliance-kyc-stats.spec.ts` against local or dev API with admin credentials
- [ ] Verify all 40 data points (2021-2025) match production values