### PR TITLE
feat: reconciliation screen with accounting overview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,9 @@ const DashboardFinancialHistoryScreen = lazy(() => import('./screens/dashboard-f
 const DashboardFinancialLiveScreen = lazy(() => import('./screens/dashboard-financial-live.screen'));
 const DashboardFinancialExpensesScreen = lazy(() => import('./screens/dashboard-financial-expenses.screen'));
 const DashboardFinancialLiquidityScreen = lazy(() => import('./screens/dashboard-financial-liquidity.screen'));
+const DashboardFinancialReconciliationScreen = lazy(
+  () => import('./screens/dashboard-financial-reconciliation.screen'),
+);
 
 setupLanguages();
 
@@ -446,6 +449,10 @@ export const Routes = [
               {
                 path: 'liquidity',
                 element: withSuspense(<DashboardFinancialLiquidityScreen />),
+              },
+              {
+                path: 'reconciliation',
+                element: withSuspense(<DashboardFinancialReconciliationScreen />),
               },
             ],
           },

--- a/src/components/dashboard/financial-changes-chart.tsx
+++ b/src/components/dashboard/financial-changes-chart.tsx
@@ -88,8 +88,8 @@ export function FinancialChangesMinusChart({ entries, timeRange, onDetails }: Fi
     { name: 'Referral', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.ref.total)]) },
     { name: 'Binance', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.binance.total)]) },
     { name: 'Blockchain', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.blockchain.total)]) },
-    { name: 'Bank', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.bank)]) },
-    { name: 'Kraken', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.kraken.total)]) },
+    { name: 'Bank', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.bank ?? 0)]) },
+    { name: 'Kraken', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.kraken?.total ?? 0)]) },
   ], [entries]);
 
   return (

--- a/src/components/dashboard/financial-changes-chart.tsx
+++ b/src/components/dashboard/financial-changes-chart.tsx
@@ -9,7 +9,11 @@ interface FinancialChangesChartProps {
   timeRange?: TimeRange;
 }
 
+const FOUR_DAYS_MS = 4 * 24 * 60 * 60 * 1000;
+
 function makeBaseOptions(timeRange?: TimeRange): ApexOptions {
+  const isShortRange = timeRange && (timeRange.max - timeRange.min) < FOUR_DAYS_MS;
+
   return {
     chart: {
       type: 'area',
@@ -23,7 +27,7 @@ function makeBaseOptions(timeRange?: TimeRange): ApexOptions {
     grid: { borderColor: '#e5e7eb' },
     xaxis: {
       type: 'datetime',
-      labels: { datetimeUTC: false, format: 'dd MMM yy' },
+      labels: { datetimeUTC: false, format: isShortRange ? 'dd MMM HH:mm' : 'dd MMM yy' },
       ...(timeRange && { min: timeRange.min, max: timeRange.max }),
     },
     yaxis: {
@@ -78,12 +82,14 @@ interface FinancialChangesMinusChartProps extends FinancialChangesChartProps {
 }
 
 export function FinancialChangesMinusChart({ entries, timeRange, onDetails }: FinancialChangesMinusChartProps) {
-  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange), colors: ['#ef4444', '#f97316', '#64748b'] }), [timeRange]);
+  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange), colors: ['#ef4444', '#f97316', '#64748b', '#6366f1', '#14b8a6'] }), [timeRange]);
 
   const series = useMemo(() => [
     { name: 'Referral', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.ref.total)]) },
     { name: 'Binance', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.binance.total)]) },
     { name: 'Blockchain', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.blockchain.total)]) },
+    { name: 'Bank', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.bank)]) },
+    { name: 'Kraken', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.kraken.total)]) },
   ], [entries]);
 
   return (

--- a/src/dto/dashboard.dto.ts
+++ b/src/dto/dashboard.dto.ts
@@ -23,6 +23,8 @@ export interface FinancialChangesEntry {
   };
   minus: {
     total: number;
+    bank: number;
+    kraken: { total: number; withdraw: number; trading: number };
     ref: { total: number; amount: number; fee: number };
     binance: { total: number; withdraw: number; trading: number };
     blockchain: { total: number; txIn: number; txOut: number; trading: number };

--- a/src/dto/reconciliation.dto.ts
+++ b/src/dto/reconciliation.dto.ts
@@ -8,6 +8,7 @@ export interface FlowItem {
 export interface FlowGroup {
   type: string;
   counterAccount?: string;
+  counterAssetId?: number;
   count: number;
   totalAmount: number;
   items: FlowItem[];

--- a/src/dto/reconciliation.dto.ts
+++ b/src/dto/reconciliation.dto.ts
@@ -14,6 +14,22 @@ export interface FlowGroup {
   items: FlowItem[];
 }
 
+export interface Position {
+  asset: { id: number; uniqueName: string; blockchain: string; type: string };
+  category: 'blockchain' | 'exchange' | 'bank';
+  startBalance: number;
+  endBalance: number;
+  totalInflows: number;
+  totalOutflows: number;
+  expectedEndBalance: number;
+  difference: number;
+}
+
+export interface ReconciliationOverview {
+  period: { from: string; to: string; actualFrom: string; actualTo: string };
+  positions: Position[];
+}
+
 export interface ReconciliationResult {
   asset: { id: number; uniqueName: string; blockchain: string; type: string };
   period: { from: string; to: string; actualFrom: string; actualTo: string };

--- a/src/dto/reconciliation.dto.ts
+++ b/src/dto/reconciliation.dto.ts
@@ -1,0 +1,27 @@
+export interface FlowItem {
+  id: number;
+  date: string;
+  amount: number;
+  reference?: string;
+}
+
+export interface FlowGroup {
+  type: string;
+  counterAccount?: string;
+  count: number;
+  totalAmount: number;
+  items: FlowItem[];
+}
+
+export interface ReconciliationResult {
+  asset: { id: number; uniqueName: string; blockchain: string; type: string };
+  period: { from: string; to: string; actualFrom: string; actualTo: string };
+  startBalance: number;
+  endBalance: number;
+  inflows: FlowGroup[];
+  outflows: FlowGroup[];
+  totalInflows: number;
+  totalOutflows: number;
+  expectedEndBalance: number;
+  difference: number;
+}

--- a/src/hooks/reconciliation.hook.ts
+++ b/src/hooks/reconciliation.hook.ts
@@ -1,6 +1,6 @@
 import { useApi } from '@dfx.swiss/react';
 import { useMemo } from 'react';
-import { ReconciliationResult } from 'src/dto/reconciliation.dto';
+import { ReconciliationOverview, ReconciliationResult } from 'src/dto/reconciliation.dto';
 
 export function useReconciliation() {
   const { call } = useApi();
@@ -13,5 +13,13 @@ export function useReconciliation() {
     });
   }
 
-  return useMemo(() => ({ getReconciliation }), [call]);
+  async function getOverview(from: string, to: string): Promise<ReconciliationOverview> {
+    const params = new URLSearchParams({ from, to });
+    return call<ReconciliationOverview>({
+      url: `balance/reconciliation/overview?${params}`,
+      method: 'GET',
+    });
+  }
+
+  return useMemo(() => ({ getReconciliation, getOverview }), [call]);
 }

--- a/src/hooks/reconciliation.hook.ts
+++ b/src/hooks/reconciliation.hook.ts
@@ -1,0 +1,17 @@
+import { useApi } from '@dfx.swiss/react';
+import { useMemo } from 'react';
+import { ReconciliationResult } from 'src/dto/reconciliation.dto';
+
+export function useReconciliation() {
+  const { call } = useApi();
+
+  async function getReconciliation(assetId: number, from: string, to: string): Promise<ReconciliationResult> {
+    const params = new URLSearchParams({ assetId: String(assetId), from, to });
+    return call<ReconciliationResult>({
+      url: `balance/reconciliation?${params}`,
+      method: 'GET',
+    });
+  }
+
+  return useMemo(() => ({ getReconciliation }), [call]);
+}

--- a/src/screens/dashboard-financial-reconciliation.screen.tsx
+++ b/src/screens/dashboard-financial-reconciliation.screen.tsx
@@ -74,6 +74,7 @@ function flowLabel(type: string, counterAccount?: string): string {
 interface FlowEntry {
   key: string;
   label: string;
+  counterAssetId?: number;
   count: number;
   amount: number;
   side: 'soll' | 'haben';
@@ -81,7 +82,13 @@ interface FlowEntry {
   items: FlowGroup['items'];
 }
 
-function ReconciliationTable({ data }: { data: ReconciliationResult }) {
+function ReconciliationTable({
+  data,
+  onAssetChange,
+}: {
+  data: ReconciliationResult;
+  onAssetChange: (id: number) => void;
+}) {
   const [expanded, setExpanded] = useState<string>();
   const dec = getDecimals(data.asset.blockchain);
   const unit = data.asset.uniqueName.split('/')[1] ?? '';
@@ -102,6 +109,7 @@ function ReconciliationTable({ data }: { data: ReconciliationResult }) {
         merged.set(key, {
           key,
           label: ca,
+          counterAssetId: g.counterAssetId,
           count: g.count,
           amount: g.totalAmount,
           side,
@@ -176,7 +184,20 @@ function ReconciliationTable({ data }: { data: ReconciliationResult }) {
               >
                 <td className="py-1.5 pl-4" style={e.isDiff ? { fontStyle: 'italic', color: '#9ca3af' } : undefined}>
                   {!e.isDiff && <span className="mr-1 text-xs">{expanded === e.key ? '▼' : '▶'}</span>}
-                  {e.label}
+                  {e.counterAssetId ? (
+                    <span
+                      className="cursor-pointer hover:underline"
+                      style={{ color: '#2563eb' }}
+                      onClick={(ev) => {
+                        ev.stopPropagation();
+                        onAssetChange(e.counterAssetId!);
+                      }}
+                    >
+                      {e.label}
+                    </span>
+                  ) : (
+                    e.label
+                  )}
                 </td>
                 <td className="py-1.5 text-right" style={e.isDiff ? { color: '#9ca3af' } : undefined}>
                   {e.count > 0 ? e.count : ''}
@@ -293,12 +314,14 @@ export default function DashboardFinancialReconciliationScreen(): JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>();
 
-  function runQuery() {
-    if (!isLoggedIn || !assetId) return;
+  function runQuery(overrideAssetId?: number) {
+    const id = overrideAssetId ?? Number(assetId);
+    if (!isLoggedIn || !id) return;
 
+    if (overrideAssetId) setAssetId(String(overrideAssetId));
     setIsLoading(true);
     setError(undefined);
-    getReconciliation(Number(assetId), from, to)
+    getReconciliation(id, from, to)
       .then(setData)
       .catch((e) => setError(e.message ?? 'Request failed'))
       .finally(() => setIsLoading(false));
@@ -349,7 +372,7 @@ export default function DashboardFinancialReconciliationScreen(): JSX.Element {
             />
           </div>
           <button
-            onClick={runQuery}
+            onClick={() => runQuery()}
             disabled={isLoading}
             className="px-4 py-2 rounded text-sm font-medium text-white"
             style={{ backgroundColor: '#2563eb' }}
@@ -381,7 +404,7 @@ export default function DashboardFinancialReconciliationScreen(): JSX.Element {
           </div>
 
           {/* Reconciliation Table */}
-          <ReconciliationTable data={data} />
+          <ReconciliationTable data={data} onAssetChange={(id) => runQuery(id)} />
         </>
       )}
     </div>

--- a/src/screens/dashboard-financial-reconciliation.screen.tsx
+++ b/src/screens/dashboard-financial-reconciliation.screen.tsx
@@ -313,12 +313,16 @@ export default function DashboardFinancialReconciliationScreen(): JSX.Element {
   const [data, setData] = useState<ReconciliationResult>();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>();
+  const [history, setHistory] = useState<string[]>([]);
 
-  function runQuery(overrideAssetId?: number) {
+  function runQuery(overrideAssetId?: number, pushHistory = true) {
     const id = overrideAssetId ?? Number(assetId);
     if (!isLoggedIn || !id) return;
 
-    if (overrideAssetId) setAssetId(String(overrideAssetId));
+    if (overrideAssetId) {
+      if (pushHistory) setHistory((h) => [...h, assetId]);
+      setAssetId(String(overrideAssetId));
+    }
     setIsLoading(true);
     setError(undefined);
     getReconciliation(id, from, to)
@@ -394,7 +398,22 @@ export default function DashboardFinancialReconciliationScreen(): JSX.Element {
         <>
           {/* Asset & Period */}
           <div className="bg-white rounded-lg shadow p-4">
-            <div className="text-lg font-semibold">{data.asset.uniqueName}</div>
+            <div className="flex items-center gap-3">
+              {history.length > 0 && (
+                <button
+                  className="text-sm px-2 py-1 rounded hover:bg-gray-100"
+                  style={{ color: '#2563eb' }}
+                  onClick={() => {
+                    const prev = history[history.length - 1];
+                    setHistory((h) => h.slice(0, -1));
+                    runQuery(Number(prev), false);
+                  }}
+                >
+                  ← Zurück
+                </button>
+              )}
+              <div className="text-lg font-semibold">{data.asset.uniqueName}</div>
+            </div>
             <div className="text-sm mt-1" style={{ color: '#6b7280' }}>
               {data.asset.blockchain} &middot; {data.asset.type} &middot; ID {data.asset.id}
             </div>

--- a/src/screens/dashboard-financial-reconciliation.screen.tsx
+++ b/src/screens/dashboard-financial-reconciliation.screen.tsx
@@ -1,0 +1,389 @@
+import { useSessionContext } from '@dfx.swiss/react';
+import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
+import { Fragment, useEffect, useState } from 'react';
+import { FlowGroup, ReconciliationResult } from 'src/dto/reconciliation.dto';
+import { useAdminGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useReconciliation } from 'src/hooks/reconciliation.hook';
+
+const TX_EXPLORERS: Record<string, string> = {
+  Bitcoin: 'https://mempool.space/tx/',
+  Ethereum: 'https://etherscan.io/tx/',
+  Arbitrum: 'https://arbiscan.io/tx/',
+  Optimism: 'https://optimistic.etherscan.io/tx/',
+  Polygon: 'https://polygonscan.com/tx/',
+  Base: 'https://basescan.org/tx/',
+  BinanceSmartChain: 'https://bscscan.com/tx/',
+  Monero: 'https://xmrchain.net/tx/',
+  Solana: 'https://solscan.io/tx/',
+  Tron: 'https://tronscan.org/#/transaction/',
+};
+
+function getTxUrl(blockchain: string, reference: string): string | undefined {
+  const base = TX_EXPLORERS[blockchain];
+  if (!base || !reference || !/^[a-fA-F0-9]{64}$/.test(reference)) return undefined;
+  return `${base}${reference}`;
+}
+
+function formatAmount(value: number, decimals = 8): string {
+  return value.toLocaleString('de-CH', { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString('de-CH', { dateStyle: 'short', timeStyle: 'short' });
+}
+
+function defaultFrom(): string {
+  const d = new Date();
+  d.setDate(1);
+  return d.toISOString().slice(0, 10);
+}
+
+function defaultTo(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+const BANK_BLOCKCHAINS = new Set(['Yapeal', 'Olkypay', 'MaerkiBaumann', 'Checkout', 'Sumixx', 'Kaleido']);
+
+function getDecimals(blockchain: string): number {
+  return BANK_BLOCKCHAINS.has(blockchain) ? 2 : 8;
+}
+
+const FLOW_TYPE_LABELS: Record<string, string> = {
+  LmDeficit: 'LM Zufluss',
+  LmRedundancy: 'LM Abfluss',
+  ExchangeWithdrawal: 'Auszahlung',
+  CryptoInput: 'Eingang',
+  PayoutOrder: 'Auszahlung',
+  Deposit: 'Einzahlung',
+  Withdrawal: 'Auszahlung',
+  TradeBuy: 'Kauf',
+  TradeSell: 'Verkauf',
+  TradeSellQuoteInflow: 'Verkauf (Quote)',
+  TradeBuyQuoteOutflow: 'Kauf (Quote)',
+  Fee: 'Gebühren',
+  BankCredit: 'Gutschrift',
+  BankDebit: 'Belastung',
+};
+
+function flowLabel(type: string, counterAccount?: string): string {
+  const typeLabel = FLOW_TYPE_LABELS[type] ?? type;
+  return counterAccount ? `${counterAccount} (${typeLabel})` : typeLabel;
+}
+
+interface FlowEntry {
+  key: string;
+  label: string;
+  count: number;
+  amount: number;
+  side: 'soll' | 'haben';
+  isDiff?: boolean;
+  items: FlowGroup['items'];
+}
+
+function ReconciliationTable({ data }: { data: ReconciliationResult }) {
+  const [expanded, setExpanded] = useState<string>();
+  const dec = getDecimals(data.asset.blockchain);
+  const unit = data.asset.uniqueName.split('/')[1] ?? '';
+  const diff = data.difference;
+
+  // Merge flow groups by counterAccount + side
+  const mergeFlows = (groups: FlowGroup[], side: 'soll' | 'haben'): FlowEntry[] => {
+    const merged = new Map<string, FlowEntry>();
+    for (const g of groups) {
+      const ca = g.counterAccount ?? flowLabel(g.type);
+      const key = `${side}-${ca}`;
+      const existing = merged.get(key);
+      if (existing) {
+        existing.count += g.count;
+        existing.amount += g.totalAmount;
+        existing.items = [...existing.items, ...g.items];
+      } else {
+        merged.set(key, {
+          key,
+          label: ca,
+          count: g.count,
+          amount: g.totalAmount,
+          side,
+          items: [...g.items],
+        });
+      }
+    }
+    return [...merged.values()];
+  };
+
+  const entries: FlowEntry[] = [...mergeFlows(data.inflows, 'soll'), ...mergeFlows(data.outflows, 'haben')];
+
+  if (Math.abs(diff) > 1e-10) {
+    entries.push({
+      key: 'diff',
+      label: 'Differenz (ungeklärt)',
+      count: 0,
+      amount: Math.abs(diff),
+      side: diff > 0 ? 'soll' : 'haben',
+      isDiff: true,
+      items: [],
+    });
+  }
+
+  const totalSoll = data.startBalance + data.totalInflows + Math.max(0, diff);
+  const totalCount = entries.filter((e) => !e.isDiff).reduce((s, e) => s + e.count, 0);
+  const diffColor = Math.abs(diff) < 0.01 ? '#22c55e' : '#ef4444';
+
+  return (
+    <div className="bg-white rounded-lg shadow overflow-hidden">
+      <div className="text-center text-sm font-semibold p-3 border-b" style={{ backgroundColor: '#f8fafc' }}>
+        Konto: {data.asset.uniqueName}
+      </div>
+      <table className="w-full text-sm" style={{ borderCollapse: 'collapse' }}>
+        <colgroup>
+          <col style={{ width: '40%' }} />
+          <col style={{ width: '10%' }} />
+          <col style={{ width: '25%' }} />
+          <col style={{ width: '25%' }} />
+        </colgroup>
+        <thead>
+          <tr style={{ borderBottom: '2px solid #111827' }}>
+            <th className="py-2 pl-4 text-left font-medium">Buchungsart</th>
+            <th className="py-2 text-right font-medium">Anz.</th>
+            <th className="py-2 pr-4 text-right font-medium" style={{ color: '#166534' }}>
+              Soll ({unit})
+            </th>
+            <th className="py-2 pr-4 text-right font-medium" style={{ color: '#991b1b' }}>
+              Haben ({unit})
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {/* Anfangsbestand */}
+          <tr style={{ borderBottom: '1px solid #e5e7eb' }}>
+            <td className="py-1.5 pl-4 font-bold">Anfangsbestand</td>
+            <td></td>
+            <td className="py-1.5 pr-4 text-right font-mono font-bold">{formatAmount(data.startBalance, dec)}</td>
+            <td></td>
+          </tr>
+
+          {/* Buchungen */}
+          {entries.map((e) => (
+            <Fragment key={e.key}>
+              <tr
+                className={e.isDiff ? '' : 'cursor-pointer hover:bg-gray-50'}
+                style={{
+                  borderBottom: '1px solid #e5e7eb',
+                  ...(e.isDiff && { borderTop: '1px dashed #d97706', backgroundColor: '#fffbeb' }),
+                }}
+                onClick={() => !e.isDiff && setExpanded(expanded === e.key ? undefined : e.key)}
+              >
+                <td className="py-1.5 pl-4" style={e.isDiff ? { fontStyle: 'italic', color: '#9ca3af' } : undefined}>
+                  {!e.isDiff && <span className="mr-1 text-xs">{expanded === e.key ? '▼' : '▶'}</span>}
+                  {e.label}
+                </td>
+                <td className="py-1.5 text-right" style={e.isDiff ? { color: '#9ca3af' } : undefined}>
+                  {e.count > 0 ? e.count : ''}
+                </td>
+                <td
+                  className="py-1.5 pr-4 text-right font-mono"
+                  style={e.isDiff ? { fontStyle: 'italic', color: '#9ca3af' } : { color: '#166534' }}
+                >
+                  {e.side === 'soll' ? formatAmount(e.amount, dec) : ''}
+                </td>
+                <td
+                  className="py-1.5 pr-4 text-right font-mono"
+                  style={e.isDiff ? { fontStyle: 'italic', color: '#9ca3af' } : { color: '#991b1b' }}
+                >
+                  {e.side === 'haben' ? formatAmount(e.amount, dec) : ''}
+                </td>
+              </tr>
+              {expanded === e.key && e.items.length > 0 && (
+                <tr>
+                  <td colSpan={4} className="p-0">
+                    <div className="max-h-64 overflow-y-auto" style={{ backgroundColor: '#f9fafb' }}>
+                      <table className="w-full text-xs">
+                        <thead>
+                          <tr className="border-b">
+                            <th className="text-left p-2 pl-8">ID</th>
+                            <th className="text-left p-2">Datum</th>
+                            <th className="text-right p-2 pr-4">Betrag</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {e.items.map((item) => {
+                            const url = item.reference ? getTxUrl(data.asset.blockchain, item.reference) : undefined;
+                            return (
+                              <tr key={item.id} className="border-b border-gray-100">
+                                <td className="p-2 pl-8 font-mono">{item.id}</td>
+                                <td className="p-2">{formatDate(item.date)}</td>
+                                <td className="text-right p-2 pr-4 font-mono">
+                                  {url ? (
+                                    <a
+                                      href={url}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="hover:underline"
+                                      style={{ color: '#2563eb' }}
+                                    >
+                                      {formatAmount(item.amount, dec)}
+                                    </a>
+                                  ) : (
+                                    formatAmount(item.amount, dec)
+                                  )}
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </Fragment>
+          ))}
+
+          {/* Endbestand (Saldo) */}
+          <tr style={{ borderBottom: '1px solid #e5e7eb' }}>
+            <td className="py-1.5 pl-4 font-bold">Endbestand (Saldo)</td>
+            <td></td>
+            <td></td>
+            <td className="py-1.5 pr-4 text-right font-mono font-bold">{formatAmount(data.endBalance, dec)}</td>
+          </tr>
+
+          {/* Summe */}
+          <tr style={{ borderTop: '2px solid #111827', borderBottom: '4px double #111827' }}>
+            <td className="py-1.5 pl-4 font-bold">Summe</td>
+            <td className="py-1.5 text-right font-bold">{totalCount}</td>
+            <td className="py-1.5 pr-4 text-right font-mono font-bold" style={{ color: '#166534' }}>
+              {formatAmount(totalSoll, dec)}
+            </td>
+            <td className="py-1.5 pr-4 text-right font-mono font-bold" style={{ color: '#991b1b' }}>
+              {formatAmount(totalSoll, dec)}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      {/* Differenz-Info */}
+      <div className="p-3 font-mono text-xs text-center" style={{ backgroundColor: '#f8fafc', color: '#6b7280' }}>
+        {formatAmount(data.startBalance, dec)} + {formatAmount(data.totalInflows, dec)} −{' '}
+        {formatAmount(data.totalOutflows, dec)} = {formatAmount(data.expectedEndBalance, dec)}
+        <span className="mx-2">|</span>
+        Ist:{' '}
+        <span className="font-bold" style={{ color: '#111827' }}>
+          {formatAmount(data.endBalance, dec)}
+        </span>
+        <span className="mx-2">|</span>
+        Diff: <span style={{ color: diffColor, fontWeight: 'bold' }}>{formatAmount(data.difference, dec)}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function DashboardFinancialReconciliationScreen(): JSX.Element {
+  useAdminGuard();
+  useLayoutOptions({ title: 'Reconciliation', noMaxWidth: true });
+
+  const { isLoggedIn } = useSessionContext();
+  const { getReconciliation } = useReconciliation();
+
+  const [assetId, setAssetId] = useState('113');
+  const [from, setFrom] = useState(defaultFrom);
+  const [to, setTo] = useState(defaultTo);
+
+  const [data, setData] = useState<ReconciliationResult>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+
+  function runQuery() {
+    if (!isLoggedIn || !assetId) return;
+
+    setIsLoading(true);
+    setError(undefined);
+    getReconciliation(Number(assetId), from, to)
+      .then(setData)
+      .catch((e) => setError(e.message ?? 'Request failed'))
+      .finally(() => setIsLoading(false));
+  }
+
+  useEffect(() => {
+    if (isLoggedIn) runQuery();
+  }, [isLoggedIn]);
+
+  const dec = data ? getDecimals(data.asset.blockchain) : 8;
+
+  return (
+    <div className="space-y-4 p-4 w-full self-stretch" style={{ color: '#111827' }}>
+      {/* Query Form */}
+      <div className="bg-white rounded-lg shadow p-4">
+        <div className="flex flex-wrap gap-4 items-end">
+          <div>
+            <label className="block text-xs font-medium mb-1" style={{ color: '#6b7280' }}>
+              Asset ID
+            </label>
+            <input
+              type="number"
+              value={assetId}
+              onChange={(e) => setAssetId(e.target.value)}
+              className="border rounded px-3 py-2 w-24 text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium mb-1" style={{ color: '#6b7280' }}>
+              From
+            </label>
+            <input
+              type="date"
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+              className="border rounded px-3 py-2 text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium mb-1" style={{ color: '#6b7280' }}>
+              To
+            </label>
+            <input
+              type="date"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              className="border rounded px-3 py-2 text-sm"
+            />
+          </div>
+          <button
+            onClick={runQuery}
+            disabled={isLoading}
+            className="px-4 py-2 rounded text-sm font-medium text-white"
+            style={{ backgroundColor: '#2563eb' }}
+          >
+            {isLoading ? 'Loading...' : 'Run'}
+          </button>
+        </div>
+      </div>
+
+      {error && <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 text-sm">{error}</div>}
+
+      {isLoading && (
+        <div className="flex justify-center items-center w-full h-48">
+          <StyledLoadingSpinner size={SpinnerSize.LG} />
+        </div>
+      )}
+
+      {data && !isLoading && (
+        <>
+          {/* Asset & Period */}
+          <div className="bg-white rounded-lg shadow p-4">
+            <div className="text-lg font-semibold">{data.asset.uniqueName}</div>
+            <div className="text-sm mt-1" style={{ color: '#6b7280' }}>
+              {data.asset.blockchain} &middot; {data.asset.type} &middot; ID {data.asset.id}
+            </div>
+            <div className="text-xs mt-2" style={{ color: '#9ca3af' }}>
+              Effektiver Zeitraum: {formatDate(data.period.actualFrom)} — {formatDate(data.period.actualTo)}
+            </div>
+          </div>
+
+          {/* Reconciliation Table */}
+          <ReconciliationTable data={data} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/screens/dashboard-financial-reconciliation.screen.tsx
+++ b/src/screens/dashboard-financial-reconciliation.screen.tsx
@@ -1,7 +1,7 @@
 import { useSessionContext } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { Fragment, useEffect, useState } from 'react';
-import { FlowGroup, ReconciliationResult } from 'src/dto/reconciliation.dto';
+import { FlowGroup, Position, ReconciliationOverview, ReconciliationResult } from 'src/dto/reconciliation.dto';
 import { useAdminGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useReconciliation } from 'src/hooks/reconciliation.hook';
@@ -299,60 +299,137 @@ function ReconciliationTable({
   );
 }
 
+const CATEGORY_LABELS: Record<string, string> = { blockchain: 'Blockchain', exchange: 'Exchange', bank: 'Bank' };
+
+function OverviewTable({ overview, onSelect }: { overview: ReconciliationOverview; onSelect: (id: number) => void }) {
+  let lastCategory = '';
+  const ok = overview.positions.filter((p) => Math.abs(p.difference) < 0.01).length;
+  const warn = overview.positions.length - ok;
+
+  return (
+    <div className="bg-white rounded-lg shadow overflow-hidden">
+      <div className="text-center text-sm font-semibold p-3 border-b" style={{ backgroundColor: '#f8fafc' }}>
+        Saldenliste — {ok} abgestimmt, {warn} mit Differenz
+      </div>
+      <table className="w-full text-sm" style={{ borderCollapse: 'collapse' }}>
+        <thead>
+          <tr style={{ borderBottom: '2px solid #111827' }}>
+            <th className="py-2 pl-4 text-left font-medium">Konto</th>
+            <th className="py-2 pr-4 text-right font-medium">Anfang</th>
+            <th className="py-2 pr-4 text-right font-medium" style={{ color: '#166534' }}>
+              Zugänge
+            </th>
+            <th className="py-2 pr-4 text-right font-medium" style={{ color: '#991b1b' }}>
+              Abgänge
+            </th>
+            <th className="py-2 pr-4 text-right font-medium">Ende</th>
+            <th className="py-2 pr-4 text-right font-medium">Diff</th>
+          </tr>
+        </thead>
+        <tbody>
+          {overview.positions.map((p) => {
+            const showHeader = p.category !== lastCategory;
+            lastCategory = p.category;
+            const dec = BANK_BLOCKCHAINS.has(p.asset.blockchain) ? 2 : 8;
+            const diffOk = Math.abs(p.difference) < 0.01;
+            const diffColor = diffOk ? '#22c55e' : '#ef4444';
+
+            return (
+              <Fragment key={p.asset.id}>
+                {showHeader && (
+                  <tr style={{ backgroundColor: '#f8fafc' }}>
+                    <td colSpan={6} className="py-2 pl-4 text-xs font-bold uppercase" style={{ color: '#6b7280' }}>
+                      {CATEGORY_LABELS[p.category] ?? p.category}
+                    </td>
+                  </tr>
+                )}
+                <tr className="border-b cursor-pointer hover:bg-gray-50" onClick={() => onSelect(p.asset.id)}>
+                  <td className="py-1.5 pl-8" style={{ color: '#2563eb' }}>
+                    {p.asset.uniqueName}
+                  </td>
+                  <td className="py-1.5 pr-4 text-right font-mono">{formatAmount(p.startBalance, dec)}</td>
+                  <td className="py-1.5 pr-4 text-right font-mono" style={{ color: '#166534' }}>
+                    {p.totalInflows ? formatAmount(p.totalInflows, dec) : ''}
+                  </td>
+                  <td className="py-1.5 pr-4 text-right font-mono" style={{ color: '#991b1b' }}>
+                    {p.totalOutflows ? formatAmount(p.totalOutflows, dec) : ''}
+                  </td>
+                  <td className="py-1.5 pr-4 text-right font-mono">{formatAmount(p.endBalance, dec)}</td>
+                  <td className="py-1.5 pr-4 text-right font-mono font-bold" style={{ color: diffColor }}>
+                    {formatAmount(p.difference, dec)}
+                  </td>
+                </tr>
+              </Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+      <div className="p-3 text-xs text-center" style={{ backgroundColor: '#f8fafc', color: '#9ca3af' }}>
+        {overview.positions.length} Konten &middot; Zeitraum: {formatDate(overview.period.actualFrom)} —{' '}
+        {formatDate(overview.period.actualTo)}
+      </div>
+    </div>
+  );
+}
+
 export default function DashboardFinancialReconciliationScreen(): JSX.Element {
   useAdminGuard();
   useLayoutOptions({ title: 'Reconciliation', noMaxWidth: true });
 
   const { isLoggedIn } = useSessionContext();
-  const { getReconciliation } = useReconciliation();
+  const { getReconciliation, getOverview } = useReconciliation();
 
-  const [assetId, setAssetId] = useState('113');
   const [from, setFrom] = useState(defaultFrom);
   const [to, setTo] = useState(defaultTo);
 
-  const [data, setData] = useState<ReconciliationResult>();
+  const [overview, setOverview] = useState<ReconciliationOverview>();
+  const [detail, setDetail] = useState<ReconciliationResult>();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>();
-  const [history, setHistory] = useState<string[]>([]);
+  const [history, setHistory] = useState<number[]>([]);
 
-  function runQuery(overrideAssetId?: number, pushHistory = true) {
-    const id = overrideAssetId ?? Number(assetId);
-    if (!isLoggedIn || !id) return;
-
-    if (overrideAssetId) {
-      if (pushHistory) setHistory((h) => [...h, assetId]);
-      setAssetId(String(overrideAssetId));
-    }
+  function loadOverview() {
+    if (!isLoggedIn) return;
     setIsLoading(true);
     setError(undefined);
-    getReconciliation(id, from, to)
-      .then(setData)
+    setDetail(undefined);
+    setHistory([]);
+    getOverview(from, to)
+      .then(setOverview)
       .catch((e) => setError(e.message ?? 'Request failed'))
       .finally(() => setIsLoading(false));
   }
 
-  useEffect(() => {
-    if (isLoggedIn) runQuery();
-  }, [isLoggedIn]);
+  function loadDetail(assetId: number, pushHistory = true) {
+    if (!isLoggedIn) return;
+    if (pushHistory && detail) setHistory((h) => [...h, detail.asset.id]);
+    setIsLoading(true);
+    setError(undefined);
+    getReconciliation(assetId, from, to)
+      .then(setDetail)
+      .catch((e) => setError(e.message ?? 'Request failed'))
+      .finally(() => setIsLoading(false));
+  }
 
-  const dec = data ? getDecimals(data.asset.blockchain) : 8;
+  function goBack() {
+    if (history.length > 0) {
+      const prev = history[history.length - 1];
+      setHistory((h) => h.slice(0, -1));
+      loadDetail(prev, false);
+    } else {
+      setDetail(undefined);
+    }
+  }
+
+  useEffect(() => {
+    if (isLoggedIn) loadOverview();
+  }, [isLoggedIn]);
 
   return (
     <div className="space-y-4 p-4 w-full self-stretch" style={{ color: '#111827' }}>
       {/* Query Form */}
       <div className="bg-white rounded-lg shadow p-4">
         <div className="flex flex-wrap gap-4 items-end">
-          <div>
-            <label className="block text-xs font-medium mb-1" style={{ color: '#6b7280' }}>
-              Asset ID
-            </label>
-            <input
-              type="number"
-              value={assetId}
-              onChange={(e) => setAssetId(e.target.value)}
-              className="border rounded px-3 py-2 w-24 text-sm"
-            />
-          </div>
           <div>
             <label className="block text-xs font-medium mb-1" style={{ color: '#6b7280' }}>
               From
@@ -376,7 +453,7 @@ export default function DashboardFinancialReconciliationScreen(): JSX.Element {
             />
           </div>
           <button
-            onClick={() => runQuery()}
+            onClick={loadOverview}
             disabled={isLoading}
             className="px-4 py-2 rounded text-sm font-medium text-white"
             style={{ backgroundColor: '#2563eb' }}
@@ -394,36 +471,30 @@ export default function DashboardFinancialReconciliationScreen(): JSX.Element {
         </div>
       )}
 
-      {data && !isLoading && (
+      {!isLoading && !detail && overview && <OverviewTable overview={overview} onSelect={(id) => loadDetail(id)} />}
+
+      {!isLoading && detail && (
         <>
-          {/* Asset & Period */}
           <div className="bg-white rounded-lg shadow p-4">
             <div className="flex items-center gap-3">
-              {history.length > 0 && (
-                <button
-                  className="text-sm px-2 py-1 rounded hover:bg-gray-100"
-                  style={{ color: '#2563eb' }}
-                  onClick={() => {
-                    const prev = history[history.length - 1];
-                    setHistory((h) => h.slice(0, -1));
-                    runQuery(Number(prev), false);
-                  }}
-                >
-                  ← Zurück
-                </button>
-              )}
-              <div className="text-lg font-semibold">{data.asset.uniqueName}</div>
+              <button
+                className="text-sm px-2 py-1 rounded hover:bg-gray-100"
+                style={{ color: '#2563eb' }}
+                onClick={goBack}
+              >
+                ← {history.length > 0 ? 'Zurück' : 'Übersicht'}
+              </button>
+              <div className="text-lg font-semibold">{detail.asset.uniqueName}</div>
             </div>
             <div className="text-sm mt-1" style={{ color: '#6b7280' }}>
-              {data.asset.blockchain} &middot; {data.asset.type} &middot; ID {data.asset.id}
+              {detail.asset.blockchain} &middot; {detail.asset.type} &middot; ID {detail.asset.id}
             </div>
             <div className="text-xs mt-2" style={{ color: '#9ca3af' }}>
-              Effektiver Zeitraum: {formatDate(data.period.actualFrom)} — {formatDate(data.period.actualTo)}
+              Effektiver Zeitraum: {formatDate(detail.period.actualFrom)} — {formatDate(detail.period.actualTo)}
             </div>
           </div>
 
-          {/* Reconciliation Table */}
-          <ReconciliationTable data={data} onAssetChange={(id) => runQuery(id)} />
+          <ReconciliationTable data={detail} onAssetChange={(id) => loadDetail(id)} />
         </>
       )}
     </div>

--- a/src/screens/dashboard-financial.screen.tsx
+++ b/src/screens/dashboard-financial.screen.tsx
@@ -7,6 +7,7 @@ const pages = [
   { path: '/dashboard/financial/history', title: 'History', description: 'Balance history over time' },
   { path: '/dashboard/financial/liquidity', title: 'Liquidity', description: 'Balance breakdown by type' },
   { path: '/dashboard/financial/history/expenses', title: 'Expenses', description: 'Revenue and cost details' },
+  { path: '/dashboard/financial/reconciliation', title: 'Reconciliation', description: 'Asset balance audit tool' },
 ];
 
 export default function DashboardFinancialScreen(): JSX.Element {


### PR DESCRIPTION
## Summary
- Single unified reconciliation table with Soll/Haben columns, expandable detail rows, and clickable blockchain tx links
- Counter-accounts shown as proper account names (Binance/BTC, Kunden, etc.)
- Full Saldenliste overview showing all accounts with start/end balance, inflows, outflows, and reconciliation difference
- Click counter-account to navigate between assets, back button for navigation history
- Swiss number formatting (de-CH locale), 8 decimals for crypto, 2 for fiat

## Test plan
- [ ] Open `/dashboard/financial/reconciliation` — verify Saldenliste loads with all positions
- [ ] Click on any account — verify detail reconciliation opens
- [ ] Click counter-account link — verify navigation to that asset
- [ ] Click back button — verify return to overview
- [ ] Verify clickable tx amounts open correct blockchain explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)