### PR TITLE
feat: redirect / to login or account based on session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
-import { DfxContextProvider, PaymentRoutesContextProvider, SupportChatContextProvider } from '@dfx.swiss/react';
+import { DfxContextProvider, PaymentRoutesContextProvider, SupportChatContextProvider, useSessionContext } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { Router } from '@remix-run/router';
 import { Suspense, lazy } from 'react';
-import { LoaderFunctionArgs, Outlet, RouteObject, RouterProvider, redirect } from 'react-router-dom';
+import { LoaderFunctionArgs, Navigate, Outlet, RouteObject, RouterProvider, redirect, useLocation } from 'react-router-dom';
 import { LayoutWrapper } from './components/layout-wrapper';
 import { AppHandlingContextProvider, AppParams, CloseMessageData } from './contexts/app-handling.context';
 import { BalanceContextProvider } from './contexts/balance.context';
@@ -96,6 +96,21 @@ const SitemapScreen = lazy(() => import('./screens/sitemap.screen'));
 
 setupLanguages();
 
+function IndexRoute(): JSX.Element {
+  const { isInitialized, isLoggedIn } = useSessionContext();
+  const { search } = useLocation();
+
+  if (!isInitialized) {
+    return (
+      <div className="mt-4 flex justify-center">
+        <StyledLoadingSpinner size={SpinnerSize.LG} />
+      </div>
+    );
+  }
+
+  return <Navigate to={{ pathname: isLoggedIn ? '/account' : '/login', search }} replace />;
+}
+
 export const Routes = [
   {
     path: '/',
@@ -112,7 +127,7 @@ export const Routes = [
     children: [
       {
         index: true,
-        element: <HomeScreen />,
+        element: <IndexRoute />,
       },
       {
         path: 'account',


### PR DESCRIPTION
## Summary
- `/` ist jetzt eine Weiche statt direkt die Tile-/Asset-Auswahl zu zeigen
- Ausgeloggte User landen auf `/login`, eingeloggte User auf `/account`
- Search-Params (z.B. OAuth-Callback `?session=...`, `?mode=...`) werden an die Ziel-Route durchgereicht
- Spinner während `!isInitialized`, um Flicker zu vermeiden
- Alle Deeplinks (`/buy`, `/sell`, `/swap`, `/connect`, `/login/*`, Widget-Routes) unverändert

## Test plan
- [ ] Ausgeloggt `/` aufrufen → landet auf `/login`
- [ ] Eingeloggt `/` aufrufen → landet auf `/account`
- [ ] `/buy`, `/sell`, `/swap` direkt aufrufen → unverändertes Verhalten
- [ ] Widget-Embed mit `service=buy` → startet weiterhin auf `/buy`
- [ ] OAuth-Callback `/?session=...` → Session wird verarbeitet, danach Redirect