### PR TITLE
feat: add global dark mode toggle via URL flag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { PaymentLinkProvider } from './contexts/payment-link.context';
 import { PersonalIbanConfirmationContextProvider } from './contexts/personal-iban-confirmation.context';
 import { RealunitContextProvider } from './contexts/realunit.context';
 import { SettingsContextProvider } from './contexts/settings.context';
+import { ThemeContextProvider } from './contexts/theme.context';
 import { WalletContextProvider } from './contexts/wallet.context';
 import { WindowContextProvider } from './contexts/window.context';
 import ComplianceUserScreen from './screens/compliance-user.screen';
@@ -628,28 +629,30 @@ function App({ routerFactory, params, personalIbanOccurrence }: AppProps) {
 
   return (
     <WindowContextProvider>
-      <DfxContextProvider api={{}} data={{}} includePrivateAssets={true}>
-        <BalanceContextProvider>
-          <OrderUIContextProvider>
-            <AppHandlingContextProvider
-              isWidget={params != null}
-              service={params?.service}
-              closeCallback={params?.onClose}
-              params={params}
-              personalIbanOccurrence={personalIbanOccurrence}
-              router={router}
-            >
-              <SettingsContextProvider>
-                <WalletContextProvider router={router}>
-                  <PersonalIbanConfirmationContextProvider>
-                    <RouterProvider router={router} />
-                  </PersonalIbanConfirmationContextProvider>
-                </WalletContextProvider>
-              </SettingsContextProvider>
-            </AppHandlingContextProvider>
-          </OrderUIContextProvider>
-        </BalanceContextProvider>
-      </DfxContextProvider>
+      <ThemeContextProvider>
+        <DfxContextProvider api={{}} data={{}} includePrivateAssets={true}>
+          <BalanceContextProvider>
+            <OrderUIContextProvider>
+              <AppHandlingContextProvider
+                isWidget={params != null}
+                service={params?.service}
+                closeCallback={params?.onClose}
+                params={params}
+                personalIbanOccurrence={personalIbanOccurrence}
+                router={router}
+              >
+                <SettingsContextProvider>
+                  <WalletContextProvider router={router}>
+                    <PersonalIbanConfirmationContextProvider>
+                      <RouterProvider router={router} />
+                    </PersonalIbanConfirmationContextProvider>
+                  </WalletContextProvider>
+                </SettingsContextProvider>
+              </AppHandlingContextProvider>
+            </OrderUIContextProvider>
+          </BalanceContextProvider>
+        </DfxContextProvider>
+      </ThemeContextProvider>
     </WindowContextProvider>
   );
 }

--- a/src/__tests__/store.hook.test.ts
+++ b/src/__tests__/store.hook.test.ts
@@ -152,6 +152,44 @@ describe('useStore', () => {
     });
   });
 
+  describe('darkMode', () => {
+    it('should set and get darkMode true', () => {
+      const { result } = renderHook(() => useStore());
+
+      act(() => {
+        result.current.darkMode.set(true);
+      });
+
+      expect(result.current.darkMode.get()).toBe(true);
+    });
+
+    it('should set and get darkMode false', () => {
+      const { result } = renderHook(() => useStore());
+
+      act(() => {
+        result.current.darkMode.set(false);
+      });
+
+      expect(result.current.darkMode.get()).toBe(false);
+    });
+
+    it('should return undefined when not set', () => {
+      const { result } = renderHook(() => useStore());
+      expect(result.current.darkMode.get()).toBeUndefined();
+    });
+
+    it('should remove darkMode', () => {
+      const { result } = renderHook(() => useStore());
+
+      act(() => {
+        result.current.darkMode.set(true);
+        result.current.darkMode.remove();
+      });
+
+      expect(result.current.darkMode.get()).toBeUndefined();
+    });
+  });
+
   describe('persistence', () => {
     it('should persist data across hook instances', () => {
       const { result: result1 } = renderHook(() => useStore());

--- a/src/__tests__/theme.context.test.tsx
+++ b/src/__tests__/theme.context.test.tsx
@@ -1,4 +1,4 @@
-import { render, renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 import { ThemeContextProvider, useThemeContext } from '../contexts/theme.context';
 
@@ -114,16 +114,24 @@ describe('ThemeContext', () => {
     });
   });
 
-  describe('cleanup', () => {
-    it('removes dark class from html and body when switched off', () => {
-      localStorageMock.setItem('dfx.srv.darkMode', 'true');
-      const { unmount } = render(
-        <ThemeContextProvider>
-          <span>child</span>
-        </ThemeContextProvider>,
-      );
+  describe('setDark', () => {
+    it('switches mode and updates dom + localStorage', () => {
+      const { result } = renderHook(() => useThemeContext(), { wrapper });
+      expect(result.current.isDark).toBe(false);
+
+      act(() => result.current.setDark(true));
+
+      expect(result.current.isDark).toBe(true);
       expect(document.documentElement.classList.contains('dark')).toBe(true);
-      unmount();
+      expect(document.body.classList.contains('dark')).toBe(true);
+      expect(localStorageMock.getItem('dfx.srv.darkMode')).toBe('true');
+
+      act(() => result.current.setDark(false));
+
+      expect(result.current.isDark).toBe(false);
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+      expect(document.body.classList.contains('dark')).toBe(false);
+      expect(localStorageMock.getItem('dfx.srv.darkMode')).toBe('false');
     });
   });
 });

--- a/src/__tests__/theme.context.test.tsx
+++ b/src/__tests__/theme.context.test.tsx
@@ -1,0 +1,129 @@
+import { render, renderHook } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import { ThemeContextProvider, useThemeContext } from '../contexts/theme.context';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+function setUrl(search: string) {
+  window.history.replaceState(undefined, '', `/${search}`);
+}
+
+function wrapper({ children }: PropsWithChildren): JSX.Element {
+  return <ThemeContextProvider>{children}</ThemeContextProvider>;
+}
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    document.documentElement.classList.remove('dark');
+    document.body.classList.remove('dark');
+    setUrl('');
+  });
+
+  describe('initial state', () => {
+    it('defaults to light mode when nothing is set', () => {
+      const { result } = renderHook(() => useThemeContext(), { wrapper });
+      expect(result.current.isDark).toBe(false);
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+
+    it('restores dark mode from localStorage', () => {
+      localStorageMock.setItem('dfx.srv.darkMode', 'true');
+      const { result } = renderHook(() => useThemeContext(), { wrapper });
+      expect(result.current.isDark).toBe(true);
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+      expect(document.body.classList.contains('dark')).toBe(true);
+    });
+
+    it('restores light mode from localStorage', () => {
+      localStorageMock.setItem('dfx.srv.darkMode', 'false');
+      const { result } = renderHook(() => useThemeContext(), { wrapper });
+      expect(result.current.isDark).toBe(false);
+    });
+  });
+
+  describe('URL parameter activation', () => {
+    it('enables dark mode via ?dark=1', () => {
+      setUrl('?dark=1');
+      const { result } = renderHook(() => useThemeContext(), { wrapper });
+      expect(result.current.isDark).toBe(true);
+      expect(localStorageMock.getItem('dfx.srv.darkMode')).toBe('true');
+      expect(window.location.search).toBe('');
+    });
+
+    it('disables dark mode via ?dark=0', () => {
+      localStorageMock.setItem('dfx.srv.darkMode', 'true');
+      setUrl('?dark=0');
+      const { result } = renderHook(() => useThemeContext(), { wrapper });
+      expect(result.current.isDark).toBe(false);
+      expect(localStorageMock.getItem('dfx.srv.darkMode')).toBe('false');
+      expect(window.location.search).toBe('');
+    });
+
+    it('enables dark mode via ?theme=dark', () => {
+      setUrl('?theme=dark');
+      const { result } = renderHook(() => useThemeContext(), { wrapper });
+      expect(result.current.isDark).toBe(true);
+      expect(window.location.search).toBe('');
+    });
+
+    it('disables dark mode via ?theme=light', () => {
+      localStorageMock.setItem('dfx.srv.darkMode', 'true');
+      setUrl('?theme=light');
+      const { result } = renderHook(() => useThemeContext(), { wrapper });
+      expect(result.current.isDark).toBe(false);
+      expect(window.location.search).toBe('');
+    });
+
+    it('preserves other URL parameters', () => {
+      setUrl('?dark=1&foo=bar');
+      renderHook(() => useThemeContext(), { wrapper });
+      expect(window.location.search).toBe('?foo=bar');
+    });
+  });
+
+  describe('tokens', () => {
+    it('returns dark palette when in dark mode', () => {
+      localStorageMock.setItem('dfx.srv.darkMode', 'true');
+      const { result } = renderHook(() => useThemeContext(), { wrapper });
+      expect(result.current.tokens.background).toBe('#072440');
+      expect(result.current.tokens.surface).toBe('#082948');
+      expect(result.current.tokens.textPrimary).toBe('#ffffff');
+    });
+
+    it('returns light palette when in light mode', () => {
+      const { result } = renderHook(() => useThemeContext(), { wrapper });
+      expect(result.current.tokens.background).toBe('#ffffff');
+      expect(result.current.tokens.textPrimary).toBe('#111827');
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes dark class from html and body when switched off', () => {
+      localStorageMock.setItem('dfx.srv.darkMode', 'true');
+      const { unmount } = render(
+        <ThemeContextProvider>
+          <span>child</span>
+        </ThemeContextProvider>,
+      );
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+      unmount();
+    });
+  });
+});

--- a/src/components/dashboard/balance-by-type-area-chart.tsx
+++ b/src/components/dashboard/balance-by-type-area-chart.tsx
@@ -7,6 +7,7 @@ import { TimeRange } from 'src/util/chart';
 interface Props {
   entries: FinancialLogEntry[];
   timeRange?: TimeRange;
+  dark?: boolean;
 }
 
 const TYPE_COLORS: Record<string, string> = {
@@ -31,7 +32,7 @@ function useFinancialTypes(entries: FinancialLogEntry[]) {
   }, [entries]);
 }
 
-function makeOptions(financialTypes: string[], timeRange?: TimeRange): ApexOptions {
+function makeOptions(financialTypes: string[], timeRange?: TimeRange, dark?: boolean): ApexOptions {
   return {
     chart: {
       type: 'area',
@@ -40,10 +41,11 @@ function makeOptions(financialTypes: string[], timeRange?: TimeRange): ApexOptio
       zoom: { enabled: true },
       background: '0',
     },
+    theme: { mode: dark ? 'dark' : 'light' },
     stroke: { width: 1, curve: 'smooth' },
     colors: financialTypes.map((t) => TYPE_COLORS[t] ?? DEFAULT_COLOR),
     dataLabels: { enabled: false },
-    grid: { borderColor: '#e5e7eb' },
+    grid: { borderColor: dark ? '#0A355C' : '#e5e7eb' },
     xaxis: {
       type: 'datetime',
       labels: { datetimeUTC: false, format: 'dd MMM yy' },
@@ -64,9 +66,9 @@ function makeOptions(financialTypes: string[], timeRange?: TimeRange): ApexOptio
   };
 }
 
-export function BalanceByTypePlusChart({ entries, timeRange }: Props) {
+export function BalanceByTypePlusChart({ entries, timeRange, dark }: Props) {
   const financialTypes = useFinancialTypes(entries);
-  const options = useMemo(() => makeOptions(financialTypes, timeRange), [financialTypes, timeRange]);
+  const options = useMemo(() => makeOptions(financialTypes, timeRange, dark), [financialTypes, timeRange, dark]);
 
   const series = useMemo(() => financialTypes.map((type) => ({
     name: type,
@@ -81,9 +83,9 @@ export function BalanceByTypePlusChart({ entries, timeRange }: Props) {
   );
 }
 
-export function BalanceByTypeMinusChart({ entries, timeRange }: Props) {
+export function BalanceByTypeMinusChart({ entries, timeRange, dark }: Props) {
   const financialTypes = useFinancialTypes(entries);
-  const options = useMemo(() => makeOptions(financialTypes, timeRange), [financialTypes, timeRange]);
+  const options = useMemo(() => makeOptions(financialTypes, timeRange, dark), [financialTypes, timeRange, dark]);
 
   const series = useMemo(() => financialTypes.map((type) => ({
     name: type,
@@ -98,9 +100,9 @@ export function BalanceByTypeMinusChart({ entries, timeRange }: Props) {
   );
 }
 
-export function BalanceByTypeTotalChart({ entries, timeRange }: Props) {
+export function BalanceByTypeTotalChart({ entries, timeRange, dark }: Props) {
   const financialTypes = useFinancialTypes(entries);
-  const options = useMemo(() => makeOptions(financialTypes, timeRange), [financialTypes, timeRange]);
+  const options = useMemo(() => makeOptions(financialTypes, timeRange, dark), [financialTypes, timeRange, dark]);
 
   const series = useMemo(() => financialTypes.map((type) => ({
     name: type,

--- a/src/components/dashboard/financial-changes-chart.tsx
+++ b/src/components/dashboard/financial-changes-chart.tsx
@@ -7,11 +7,12 @@ import { TimeRange } from 'src/util/chart';
 interface FinancialChangesChartProps {
   entries: FinancialChangesEntry[];
   timeRange?: TimeRange;
+  dark?: boolean;
 }
 
 const FOUR_DAYS_MS = 4 * 24 * 60 * 60 * 1000;
 
-function makeBaseOptions(timeRange?: TimeRange): ApexOptions {
+function makeBaseOptions(timeRange?: TimeRange, dark?: boolean): ApexOptions {
   const isShortRange = timeRange && (timeRange.max - timeRange.min) < FOUR_DAYS_MS;
 
   return {
@@ -21,10 +22,11 @@ function makeBaseOptions(timeRange?: TimeRange): ApexOptions {
       zoom: { enabled: true },
       background: '0',
     },
+    theme: { mode: dark ? 'dark' : 'light' },
     stroke: { width: 2, curve: 'smooth' },
     dataLabels: { enabled: false },
     fill: { type: 'gradient', gradient: { opacityFrom: 0.3, opacityTo: 0.05 } },
-    grid: { borderColor: '#e5e7eb' },
+    grid: { borderColor: dark ? '#0A355C' : '#e5e7eb' },
     xaxis: {
       type: 'datetime',
       labels: { datetimeUTC: false, format: isShortRange ? 'dd MMM HH:mm' : 'dd MMM yy' },
@@ -44,8 +46,8 @@ function makeBaseOptions(timeRange?: TimeRange): ApexOptions {
   };
 }
 
-export function FinancialChangesTotalChart({ entries, timeRange }: FinancialChangesChartProps) {
-  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange), colors: ['#22c55e'] }), [timeRange]);
+export function FinancialChangesTotalChart({ entries, timeRange, dark }: FinancialChangesChartProps) {
+  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange, dark), colors: ['#22c55e'] }), [timeRange, dark]);
 
   const series = useMemo(() => [
     { name: 'Net Total', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.total)]) },
@@ -59,8 +61,8 @@ export function FinancialChangesTotalChart({ entries, timeRange }: FinancialChan
   );
 }
 
-export function FinancialChangesPlusChart({ entries, timeRange }: FinancialChangesChartProps) {
-  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange), colors: ['#3b82f6', '#f97316', '#8b5cf6', '#64748b'] }), [timeRange]);
+export function FinancialChangesPlusChart({ entries, timeRange, dark }: FinancialChangesChartProps) {
+  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange, dark), colors: ['#3b82f6', '#f97316', '#8b5cf6', '#64748b'] }), [timeRange, dark]);
 
   const series = useMemo(() => [
     { name: 'BuyCrypto', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.plus.buyCrypto)]) },
@@ -81,8 +83,8 @@ interface FinancialChangesMinusChartProps extends FinancialChangesChartProps {
   onDetails?: () => void;
 }
 
-export function FinancialChangesMinusChart({ entries, timeRange, onDetails }: FinancialChangesMinusChartProps) {
-  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange), colors: ['#ef4444', '#f97316', '#64748b', '#6366f1', '#14b8a6'] }), [timeRange]);
+export function FinancialChangesMinusChart({ entries, timeRange, dark, onDetails }: FinancialChangesMinusChartProps) {
+  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange, dark), colors: ['#ef4444', '#f97316', '#64748b', '#6366f1', '#14b8a6'] }), [timeRange, dark]);
 
   const series = useMemo(() => [
     { name: 'Referral', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minus.ref.total)]) },
@@ -97,7 +99,14 @@ export function FinancialChangesMinusChart({ entries, timeRange, onDetails }: Fi
       <div className="flex justify-between items-center mb-2">
         <h3 className="text-sm font-semibold">Expenses / Minus (cumulative)</h3>
         {onDetails && (
-          <button onClick={onDetails} className="text-xs font-medium px-3 py-1 rounded" style={{ color: '#3b82f6', background: '#eff6ff' }}>
+          <button
+            onClick={onDetails}
+            className="text-xs font-medium px-3 py-1 rounded"
+            style={{
+              color: dark ? '#93c5fd' : '#3b82f6',
+              background: dark ? '#082948' : '#eff6ff',
+            }}
+          >
             Details
           </button>
         )}

--- a/src/components/dashboard/total-balance-short-chart.tsx
+++ b/src/components/dashboard/total-balance-short-chart.tsx
@@ -7,9 +7,10 @@ import { TimeRange } from 'src/util/chart';
 interface Props {
   entries: FinancialLogEntry[];
   timeRange?: TimeRange;
+  dark?: boolean;
 }
 
-function makeBaseOptions(timeRange?: TimeRange): ApexOptions {
+function makeBaseOptions(timeRange?: TimeRange, dark?: boolean): ApexOptions {
   return {
     chart: {
       type: 'line',
@@ -17,9 +18,10 @@ function makeBaseOptions(timeRange?: TimeRange): ApexOptions {
       zoom: { enabled: true },
       background: '0',
     },
+    theme: { mode: dark ? 'dark' : 'light' },
     stroke: { width: 2, curve: 'smooth' },
     dataLabels: { enabled: false },
-    grid: { borderColor: '#e5e7eb' },
+    grid: { borderColor: dark ? '#0A355C' : '#e5e7eb' },
     xaxis: {
       type: 'datetime',
       labels: { datetimeUTC: false, format: 'dd MMM HH:mm' },
@@ -39,8 +41,8 @@ function makeBaseOptions(timeRange?: TimeRange): ApexOptions {
   };
 }
 
-export function ShortTermPlusChart({ entries, timeRange }: Props) {
-  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange), colors: ['#22c55e'] }), [timeRange]);
+export function ShortTermPlusChart({ entries, timeRange, dark }: Props) {
+  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange, dark), colors: ['#22c55e'] }), [timeRange, dark]);
   const series = useMemo(() => [
     { name: 'Plus Balance', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.plusBalanceChf)]) },
   ], [entries]);
@@ -53,8 +55,8 @@ export function ShortTermPlusChart({ entries, timeRange }: Props) {
   );
 }
 
-export function ShortTermMinusChart({ entries, timeRange }: Props) {
-  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange), colors: ['#ef4444'] }), [timeRange]);
+export function ShortTermMinusChart({ entries, timeRange, dark }: Props) {
+  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange, dark), colors: ['#ef4444'] }), [timeRange, dark]);
   const series = useMemo(() => [
     { name: 'Minus Balance', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.minusBalanceChf)]) },
   ], [entries]);
@@ -67,8 +69,8 @@ export function ShortTermMinusChart({ entries, timeRange }: Props) {
   );
 }
 
-export function ShortTermTotalChart({ entries, timeRange }: Props) {
-  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange), colors: ['#3b82f6'] }), [timeRange]);
+export function ShortTermTotalChart({ entries, timeRange, dark }: Props) {
+  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(timeRange, dark), colors: ['#3b82f6'] }), [timeRange, dark]);
   const series = useMemo(() => [
     { name: 'Total Balance', data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.totalBalanceChf)]) },
   ], [entries]);

--- a/src/contexts/theme.context.tsx
+++ b/src/contexts/theme.context.tsx
@@ -36,10 +36,12 @@ interface ThemeContextInterface {
   tokens: ThemeTokens;
 }
 
-const ThemeContext = createContext<ThemeContextInterface>(undefined as any);
+const ThemeContext = createContext<ThemeContextInterface | undefined>(undefined);
 
 export function useThemeContext(): ThemeContextInterface {
-  return useContext(ThemeContext);
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useThemeContext must be used within ThemeContextProvider');
+  return ctx;
 }
 
 // Reads dark-mode preference from URL (?dark=1, ?dark=0, ?theme=dark, ?theme=light) and persists it.

--- a/src/contexts/theme.context.tsx
+++ b/src/contexts/theme.context.tsx
@@ -1,0 +1,107 @@
+import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
+import { useStore } from '../hooks/store.hook';
+
+// Brand-aligned dark palette tokens for use in inline styles where Tailwind classes are not practical.
+// Light tokens mirror the values previously hardcoded throughout dashboard components.
+export interface ThemeTokens {
+  background: string;
+  surface: string;
+  surfaceMuted: string;
+  textPrimary: string;
+  textMuted: string;
+  border: string;
+}
+
+const LIGHT_TOKENS: ThemeTokens = {
+  background: '#ffffff',
+  surface: '#ffffff',
+  surfaceMuted: '#f3f4f6',
+  textPrimary: '#111827',
+  textMuted: '#6b7280',
+  border: '#e5e7eb',
+};
+
+const DARK_TOKENS: ThemeTokens = {
+  background: '#072440', // dfxBlue.800
+  surface: '#082948', // dfxBlue.700
+  surfaceMuted: '#0A355C', // dfxBlue.500
+  textPrimary: '#ffffff',
+  textMuted: '#9AA5B8', // dfxGray.700
+  border: '#0A355C', // dfxBlue.500
+};
+
+interface ThemeContextInterface {
+  isDark: boolean;
+  setDark: (value: boolean) => void;
+  tokens: ThemeTokens;
+}
+
+const ThemeContext = createContext<ThemeContextInterface>(undefined as any);
+
+export function useThemeContext(): ThemeContextInterface {
+  return useContext(ThemeContext);
+}
+
+// Reads dark-mode preference from URL (?dark=1, ?dark=0, ?theme=dark, ?theme=light) and persists it.
+// Once consumed, the URL param is removed so the rest of the app sees a clean URL.
+function readUrlOverride(): boolean | undefined {
+  if (typeof window === 'undefined') return undefined;
+
+  const params = new URLSearchParams(window.location.search);
+  const dark = params.get('dark');
+  const theme = params.get('theme');
+
+  let value: boolean | undefined;
+  if (dark != null) value = dark === '1' || dark.toLowerCase() === 'true';
+  else if (theme != null) value = theme.toLowerCase() === 'dark';
+
+  if (value === undefined) return undefined;
+
+  params.delete('dark');
+  params.delete('theme');
+  const newSearch = params.toString();
+  const newUrl =
+    window.location.pathname + (newSearch ? `?${newSearch}` : '') + window.location.hash;
+  window.history.replaceState(undefined, '', newUrl);
+
+  return value;
+}
+
+export function ThemeContextProvider({ children }: PropsWithChildren): JSX.Element {
+  const { darkMode: storedDarkMode } = useStore();
+
+  const [isDark, setIsDark] = useState<boolean>(() => {
+    const fromUrl = readUrlOverride();
+    if (fromUrl !== undefined) {
+      storedDarkMode.set(fromUrl);
+      return fromUrl;
+    }
+    return storedDarkMode.get() ?? false;
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const body = document.body;
+    if (isDark) {
+      root.classList.add('dark');
+      body.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+      body.classList.remove('dark');
+    }
+  }, [isDark]);
+
+  const context = useMemo<ThemeContextInterface>(
+    () => ({
+      isDark,
+      setDark: (value: boolean) => {
+        storedDarkMode.set(value);
+        setIsDark(value);
+      },
+      tokens: isDark ? DARK_TOKENS : LIGHT_TOKENS,
+    }),
+    [isDark],
+  );
+
+  return <ThemeContext.Provider value={context}>{children}</ThemeContext.Provider>;
+}

--- a/src/hooks/store.hook.ts
+++ b/src/hooks/store.hook.ts
@@ -15,6 +15,7 @@ export interface StoreInterface {
   activeWallet: StoreItem<WalletType>;
   infoBanner: StoreItem<InfoBanner>;
   queryParams: StoreItem<AppParams>;
+  darkMode: StoreItem<boolean>;
 }
 
 enum StoreKey {
@@ -25,6 +26,7 @@ enum StoreKey {
   ACTIVE_WALLET = 'dfx.srv.activeWallet',
   INFO_BANNER = 'dfx.srv.infoBanner',
   QUERY_PARAMS = 'dfx.srv.queryParams',
+  DARK_MODE = 'dfx.srv.darkMode',
 }
 
 export function useStore(): StoreInterface {
@@ -81,6 +83,14 @@ export function useStore(): StoreInterface {
       get: () => getJson<AppParams>(StoreKey.QUERY_PARAMS),
       set: (value: AppParams) => setJson(StoreKey.QUERY_PARAMS, value),
       remove: () => remove(StoreKey.QUERY_PARAMS),
+    },
+    darkMode: {
+      get: () => {
+        const value = get(StoreKey.DARK_MODE);
+        return value === undefined ? undefined : value === 'true';
+      },
+      set: (value: boolean) => set(StoreKey.DARK_MODE, value ? 'true' : 'false'),
+      remove: () => remove(StoreKey.DARK_MODE),
     },
   };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -41,6 +41,12 @@ input[type='number'] {
     line-height: 1.5;
   }
 
+  html.dark,
+  html.dark #app-root {
+    background-color: #072440; /* dfxBlue.800 */
+    color: #ffffff;
+  }
+
   html {
     overflow-x: hidden;
     height: 100%;
@@ -48,6 +54,10 @@ input[type='number'] {
 
   body {
     height: 100%;
+  }
+
+  body.dark {
+    background-color: #072440; /* dfxBlue.800 */
   }
 
   body > div {
@@ -79,6 +89,21 @@ input[type='number'] {
     linear-gradient(transparent, white 70%) center bottom,
     radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.12), transparent) center top,
     radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.12), transparent) center bottom;
+  background-repeat: no-repeat;
+  background-size:
+    100% 40px,
+    100% 40px,
+    100% 10px,
+    100% 10px;
+  background-attachment: local, local, scroll, scroll;
+}
+
+html.dark .scroll-shadow {
+  background:
+    linear-gradient(#072440 30%, transparent) center top,
+    linear-gradient(transparent, #072440 70%) center bottom,
+    radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.6), transparent) center top,
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.6), transparent) center bottom;
   background-repeat: no-repeat;
   background-size:
     100% 40px,

--- a/src/screens/dashboard-financial-expenses.screen.tsx
+++ b/src/screens/dashboard-financial-expenses.screen.tsx
@@ -3,36 +3,40 @@ import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { ApexOptions } from 'apexcharts';
 import { useEffect, useMemo, useState } from 'react';
 import Chart from 'react-apexcharts';
+import { useThemeContext } from 'src/contexts/theme.context';
 import { FinancialChangesEntry, RefRewardRecipient } from 'src/dto/dashboard.dto';
+import { useDashboard } from 'src/hooks/dashboard.hook';
+import { useAdminGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 
 const KNOWN_USERS: Record<number, string> = {
   8938: 'Fab',
   187402: 'Cake Wallet',
 };
-import { useDashboard } from 'src/hooks/dashboard.hook';
-import { useAdminGuard } from 'src/hooks/guard.hook';
-import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 
-const baseOptions: ApexOptions = {
-  chart: { type: 'area', toolbar: { show: true, offsetY: -5 }, zoom: { enabled: true }, background: '0' },
-  stroke: { width: 2, curve: 'smooth' },
-  dataLabels: { enabled: false },
-  fill: { type: 'gradient', gradient: { opacityFrom: 0.3, opacityTo: 0.05 } },
-  grid: { borderColor: '#e5e7eb' },
-  xaxis: { type: 'datetime', labels: { datetimeUTC: false, format: 'dd MMM yy' } },
-  yaxis: {
-    title: { text: 'CHF (cumulative)' },
-    labels: { formatter: (val: number) => (val >= 1000 ? `${(val / 1000).toFixed(0)}k` : val.toFixed(0)) },
-  },
-  tooltip: {
-    x: { format: 'dd MMM yyyy HH:mm' },
-    y: { formatter: (val: number) => `${val.toLocaleString('de-CH', { maximumFractionDigits: 0 })} CHF` },
-  },
-  legend: { position: 'bottom' },
-};
+function makeBaseOptions(dark?: boolean): ApexOptions {
+  return {
+    chart: { type: 'area', toolbar: { show: true, offsetY: -5 }, zoom: { enabled: true }, background: '0' },
+    theme: { mode: dark ? 'dark' : 'light' },
+    stroke: { width: 2, curve: 'smooth' },
+    dataLabels: { enabled: false },
+    fill: { type: 'gradient', gradient: { opacityFrom: 0.3, opacityTo: 0.05 } },
+    grid: { borderColor: dark ? '#0A355C' : '#e5e7eb' },
+    xaxis: { type: 'datetime', labels: { datetimeUTC: false, format: 'dd MMM yy' } },
+    yaxis: {
+      title: { text: 'CHF (cumulative)' },
+      labels: { formatter: (val: number) => (val >= 1000 ? `${(val / 1000).toFixed(0)}k` : val.toFixed(0)) },
+    },
+    tooltip: {
+      x: { format: 'dd MMM yyyy HH:mm' },
+      y: { formatter: (val: number) => `${val.toLocaleString('de-CH', { maximumFractionDigits: 0 })} CHF` },
+    },
+    legend: { position: 'bottom' },
+  };
+}
 
-function RefDetailChart({ entries }: { entries: FinancialChangesEntry[] }) {
-  const options = useMemo((): ApexOptions => ({ ...baseOptions, colors: ['#ef4444', '#f97316'] }), []);
+function RefDetailChart({ entries, dark }: { entries: FinancialChangesEntry[]; dark?: boolean }) {
+  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(dark), colors: ['#ef4444', '#f97316'] }), [dark]);
   const series = useMemo(
     () => [
       {
@@ -52,8 +56,8 @@ function RefDetailChart({ entries }: { entries: FinancialChangesEntry[] }) {
   );
 }
 
-function BinanceDetailChart({ entries }: { entries: FinancialChangesEntry[] }) {
-  const options = useMemo((): ApexOptions => ({ ...baseOptions, colors: ['#f97316', '#8b5cf6'] }), []);
+function BinanceDetailChart({ entries, dark }: { entries: FinancialChangesEntry[]; dark?: boolean }) {
+  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(dark), colors: ['#f97316', '#8b5cf6'] }), [dark]);
   const series = useMemo(
     () => [
       {
@@ -76,8 +80,8 @@ function BinanceDetailChart({ entries }: { entries: FinancialChangesEntry[] }) {
   );
 }
 
-function BlockchainDetailChart({ entries }: { entries: FinancialChangesEntry[] }) {
-  const options = useMemo((): ApexOptions => ({ ...baseOptions, colors: ['#3b82f6', '#ef4444', '#64748b'] }), []);
+function BlockchainDetailChart({ entries, dark }: { entries: FinancialChangesEntry[]; dark?: boolean }) {
+  const options = useMemo((): ApexOptions => ({ ...makeBaseOptions(dark), colors: ['#3b82f6', '#ef4444', '#64748b'] }), [dark]);
   const series = useMemo(
     () => [
       {
@@ -110,6 +114,7 @@ export default function DashboardFinancialExpensesScreen(): JSX.Element {
 
   const { isLoggedIn } = useSessionContext();
   const { getFinancialChanges, getRefRecipients } = useDashboard();
+  const { isDark, tokens } = useThemeContext();
 
   const [entries, setEntries] = useState<FinancialChangesEntry[]>([]);
   const [recipients, setRecipients] = useState<RefRewardRecipient[]>([]);
@@ -135,16 +140,16 @@ export default function DashboardFinancialExpensesScreen(): JSX.Element {
   }
 
   return (
-    <div className="space-y-4 p-4 w-full self-stretch" style={{ color: '#111827' }}>
-      <div className="bg-white rounded-lg shadow p-4">
-        <RefDetailChart entries={entries} />
+    <div className="space-y-4 p-4 w-full self-stretch" style={{ color: tokens.textPrimary }}>
+      <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+        <RefDetailChart entries={entries} dark={isDark} />
       </div>
-      <div className="bg-white rounded-lg shadow p-4">
+      <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
         <h3 className="text-sm font-semibold mb-2">Referral Recipients</h3>
         <div className="overflow-auto max-h-[400px]">
           <table className="w-full text-sm">
-            <thead className="sticky top-0 bg-white">
-              <tr className="border-b border-gray-200">
+            <thead className="sticky top-0 bg-white dark:bg-dfxBlue-700">
+              <tr className="border-b border-gray-200 dark:border-dfxBlue-500">
                 <th className="text-left py-2 px-3 font-semibold">UserData ID</th>
                 <th className="text-right py-2 px-3 font-semibold">Payouts</th>
                 <th className="text-right py-2 px-3 font-semibold">Total (CHF)</th>
@@ -152,7 +157,10 @@ export default function DashboardFinancialExpensesScreen(): JSX.Element {
             </thead>
             <tbody>
               {recipients.map((r) => (
-                <tr key={r.userDataId} className="border-b border-gray-100 hover:bg-gray-50">
+                <tr
+                  key={r.userDataId}
+                  className="border-b border-gray-100 dark:border-dfxBlue-600 hover:bg-gray-50 dark:hover:bg-dfxBlue-600"
+                >
                   <td className="py-1.5 px-3">{KNOWN_USERS[r.userDataId] ?? r.userDataId}</td>
                   <td className="py-1.5 px-3 text-right">{r.count}</td>
                   <td className="py-1.5 px-3 text-right font-medium">
@@ -164,11 +172,11 @@ export default function DashboardFinancialExpensesScreen(): JSX.Element {
           </table>
         </div>
       </div>
-      <div className="bg-white rounded-lg shadow p-4">
-        <BinanceDetailChart entries={entries} />
+      <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+        <BinanceDetailChart entries={entries} dark={isDark} />
       </div>
-      <div className="bg-white rounded-lg shadow p-4">
-        <BlockchainDetailChart entries={entries} />
+      <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+        <BlockchainDetailChart entries={entries} dark={isDark} />
       </div>
     </div>
   );

--- a/src/screens/dashboard-financial-history.screen.tsx
+++ b/src/screens/dashboard-financial-history.screen.tsx
@@ -5,6 +5,7 @@ import { BalanceByTypeMinusChart, BalanceByTypePlusChart, BalanceByTypeTotalChar
 import { FinancialChangesMinusChart, FinancialChangesPlusChart, FinancialChangesTotalChart } from 'src/components/dashboard/financial-changes-chart';
 import { TotalBalanceLongChart } from 'src/components/dashboard/total-balance-long-chart';
 import { ShortTermMinusChart, ShortTermPlusChart, ShortTermTotalChart } from 'src/components/dashboard/total-balance-short-chart';
+import { useThemeContext } from 'src/contexts/theme.context';
 import { FinancialChangesEntry, FinancialLogEntry } from 'src/dto/dashboard.dto';
 import { useDashboard } from 'src/hooks/dashboard.hook';
 import { useAdminGuard } from 'src/hooks/guard.hook';
@@ -21,6 +22,7 @@ export default function DashboardFinancialLogScreen(): JSX.Element {
   const { navigate } = useNavigation();
   const { isLoggedIn } = useSessionContext();
   const { getFinancialLog, getFinancialChanges } = useDashboard();
+  const { isDark, tokens } = useThemeContext();
 
   const [timeframe, setTimeframe] = useState<Timeframe>(Timeframe.DAY);
   const [logEntries, setLogEntries] = useState<FinancialLogEntry[]>([]);
@@ -53,8 +55,11 @@ export default function DashboardFinancialLogScreen(): JSX.Element {
     return { min: Math.min(...allTimestamps), max: Math.max(...allTimestamps) };
   }, [logEntries, changesEntries]);
 
+  const inactiveBtnBg = isDark ? '#082948' : '#f3f4f6';
+  const inactiveBtnColor = isDark ? '#D6DBE2' : '#374151';
+
   return (
-    <div className="space-y-4 p-4 w-full self-stretch" style={{ color: '#111827' }}>
+    <div className="space-y-4 p-4 w-full self-stretch" style={{ color: tokens.textPrimary }}>
       {/* Timeframe Selector */}
       <div className="flex gap-2">
         {TIMEFRAME_OPTIONS.map((tf) => (
@@ -63,8 +68,8 @@ export default function DashboardFinancialLogScreen(): JSX.Element {
             onClick={() => setTimeframe(tf)}
             className="px-4 py-1.5 rounded text-sm font-medium transition-colors"
             style={{
-              background: tf === timeframe ? '#3b82f6' : '#f3f4f6',
-              color: tf === timeframe ? '#ffffff' : '#374151',
+              background: tf === timeframe ? '#3b82f6' : inactiveBtnBg,
+              color: tf === timeframe ? '#ffffff' : inactiveBtnColor,
             }}
           >
             {tf}
@@ -79,41 +84,41 @@ export default function DashboardFinancialLogScreen(): JSX.Element {
       ) : (
         <>
           {/* Fee Income */}
-          <div className="bg-white rounded-lg shadow p-4">
-            <FinancialChangesPlusChart entries={changesEntries} timeRange={timeRange} />
+          <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+            <FinancialChangesPlusChart entries={changesEntries} timeRange={timeRange} dark={isDark} />
           </div>
-          <div className="bg-white rounded-lg shadow p-4">
-            <FinancialChangesMinusChart entries={changesEntries} timeRange={timeRange} onDetails={() => navigate('/dashboard/financial/history/expenses')} />
+          <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+            <FinancialChangesMinusChart entries={changesEntries} timeRange={timeRange} dark={isDark} onDetails={() => navigate('/dashboard/financial/history/expenses')} />
           </div>
-          <div className="bg-white rounded-lg shadow p-4">
-            <FinancialChangesTotalChart entries={changesEntries} timeRange={timeRange} />
+          <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+            <FinancialChangesTotalChart entries={changesEntries} timeRange={timeRange} dark={isDark} />
           </div>
 
           {/* Total Balance vs BTC */}
-          <div className="bg-white rounded-lg shadow p-4">
-            <TotalBalanceLongChart entries={logEntries} timeRange={timeRange} />
+          <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+            <TotalBalanceLongChart entries={logEntries} timeRange={timeRange} dark={isDark} />
           </div>
 
           {/* Balance Breakdown */}
-          <div className="bg-white rounded-lg shadow p-4">
-            <ShortTermPlusChart entries={logEntries} timeRange={timeRange} />
+          <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+            <ShortTermPlusChart entries={logEntries} timeRange={timeRange} dark={isDark} />
           </div>
-          <div className="bg-white rounded-lg shadow p-4">
-            <ShortTermMinusChart entries={logEntries} timeRange={timeRange} />
+          <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+            <ShortTermMinusChart entries={logEntries} timeRange={timeRange} dark={isDark} />
           </div>
-          <div className="bg-white rounded-lg shadow p-4">
-            <ShortTermTotalChart entries={logEntries} timeRange={timeRange} />
+          <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+            <ShortTermTotalChart entries={logEntries} timeRange={timeRange} dark={isDark} />
           </div>
 
           {/* Balance by Financial Type */}
-          <div className="bg-white rounded-lg shadow p-4">
-            <BalanceByTypePlusChart entries={logEntries} timeRange={timeRange} />
+          <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+            <BalanceByTypePlusChart entries={logEntries} timeRange={timeRange} dark={isDark} />
           </div>
-          <div className="bg-white rounded-lg shadow p-4">
-            <BalanceByTypeMinusChart entries={logEntries} timeRange={timeRange} />
+          <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+            <BalanceByTypeMinusChart entries={logEntries} timeRange={timeRange} dark={isDark} />
           </div>
-          <div className="bg-white rounded-lg shadow p-4">
-            <BalanceByTypeTotalChart entries={logEntries} timeRange={timeRange} />
+          <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+            <BalanceByTypeTotalChart entries={logEntries} timeRange={timeRange} dark={isDark} />
           </div>
         </>
       )}

--- a/src/screens/dashboard-financial-liquidity.screen.tsx
+++ b/src/screens/dashboard-financial-liquidity.screen.tsx
@@ -3,6 +3,7 @@ import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useEffect, useMemo, useState } from 'react';
 import { BalanceBarChart } from 'src/components/dashboard/latest-balance-bar-chart';
 import { SummaryCard } from 'src/components/dashboard/summary-card';
+import { useThemeContext } from 'src/contexts/theme.context';
 import { LatestBalanceResponse } from 'src/dto/dashboard.dto';
 import { useDashboard } from 'src/hooks/dashboard.hook';
 import { useAdminGuard } from 'src/hooks/guard.hook';
@@ -15,6 +16,7 @@ export default function DashboardFinancialLiquidityScreen(): JSX.Element {
 
   const { isLoggedIn } = useSessionContext();
   const { getLatestBalance } = useDashboard();
+  const { isDark, tokens } = useThemeContext();
 
   const [latestBalance, setLatestBalance] = useState<LatestBalanceResponse>();
   const [isLoading, setIsLoading] = useState(true);
@@ -44,13 +46,13 @@ export default function DashboardFinancialLiquidityScreen(): JSX.Element {
   }
 
   return (
-    <div className="space-y-4 p-4 w-full self-stretch" style={{ color: '#111827' }}>
+    <div className="space-y-4 p-4 w-full self-stretch" style={{ color: tokens.textPrimary }}>
       <div className="max-w-xs">
-        <SummaryCard label="Total Balance" value={formatChfOrDash(totalBalance)} />
+        <SummaryCard label="Total Balance" value={formatChfOrDash(totalBalance)} dark={isDark} />
       </div>
 
-      <div className="bg-white rounded-lg shadow p-4">
-        <BalanceBarChart title="Liquidity by Provider" data={latestBalance?.byBlockchain ?? []} />
+      <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+        <BalanceBarChart title="Liquidity by Provider" data={latestBalance?.byBlockchain ?? []} dark={isDark} />
       </div>
     </div>
   );

--- a/src/screens/dashboard-financial-live.screen.tsx
+++ b/src/screens/dashboard-financial-live.screen.tsx
@@ -3,6 +3,7 @@ import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useEffect, useMemo, useState } from 'react';
 import { BalanceBarChart } from 'src/components/dashboard/latest-balance-bar-chart';
 import { SummaryCard } from 'src/components/dashboard/summary-card';
+import { useThemeContext } from 'src/contexts/theme.context';
 import { LatestBalanceResponse } from 'src/dto/dashboard.dto';
 import { useDashboard } from 'src/hooks/dashboard.hook';
 import { useAdminGuard } from 'src/hooks/guard.hook';
@@ -15,6 +16,7 @@ export default function DashboardFinancialLiveScreen(): JSX.Element {
 
   const { isLoggedIn } = useSessionContext();
   const { getLatestBalance } = useDashboard();
+  const { isDark, tokens } = useThemeContext();
 
   const [latestBalance, setLatestBalance] = useState<LatestBalanceResponse>();
   const [isLoading, setIsLoading] = useState(true);
@@ -48,19 +50,20 @@ export default function DashboardFinancialLiveScreen(): JSX.Element {
   }
 
   return (
-    <div className="space-y-4 p-4 w-full self-stretch" style={{ color: '#111827' }}>
+    <div className="space-y-4 p-4 w-full self-stretch" style={{ color: tokens.textPrimary }}>
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <SummaryCard label="Total Balance" value={formatChfOrDash(totalBalance)} />
-        <SummaryCard label="Plus Balance" value={formatChfOrDash(totalPlus)} color="#22c55e" />
-        <SummaryCard label="Minus Balance" value={formatChfOrDash(totalMinus)} color="#ef4444" />
+        <SummaryCard label="Total Balance" value={formatChfOrDash(totalBalance)} dark={isDark} />
+        <SummaryCard label="Plus Balance" value={formatChfOrDash(totalPlus)} color="#22c55e" dark={isDark} />
+        <SummaryCard label="Minus Balance" value={formatChfOrDash(totalMinus)} color="#ef4444" dark={isDark} />
         <SummaryCard
           label="Timestamp"
           value={latestBalance ? new Date(latestBalance.timestamp).toLocaleString('de-CH') : '-'}
+          dark={isDark}
         />
       </div>
 
-      <div className="bg-white rounded-lg shadow p-4">
-        <BalanceBarChart title="Balance by Type" data={latestBalance?.byType ?? []} />
+      <div className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-4">
+        <BalanceBarChart title="Balance by Type" data={latestBalance?.byType ?? []} dark={isDark} />
       </div>
     </div>
   );

--- a/src/screens/dashboard-financial.screen.tsx
+++ b/src/screens/dashboard-financial.screen.tsx
@@ -1,6 +1,7 @@
-import { useNavigation } from 'src/hooks/navigation.hook';
+import { useThemeContext } from 'src/contexts/theme.context';
 import { useAdminGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
 
 const pages = [
   { path: '/dashboard/financial/overview', title: 'Overview', description: 'Summary cards, balance history and liquidity' },
@@ -20,18 +21,19 @@ export default function DashboardFinancialScreen(): JSX.Element {
   useLayoutOptions({ title: 'Financial Dashboard' });
 
   const { navigate } = useNavigation();
+  const { tokens } = useThemeContext();
 
   return (
-    <div className="space-y-4 p-4 w-full" style={{ color: '#111827' }}>
+    <div className="space-y-4 p-4 w-full" style={{ color: tokens.textPrimary }}>
       <div className="grid grid-cols-2 gap-4">
         {pages.map((page) => (
           <div
             key={page.path}
-            className="bg-white rounded-lg shadow p-6 cursor-pointer hover:bg-gray-50"
+            className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-6 cursor-pointer hover:bg-gray-50 dark:hover:bg-dfxBlue-600"
             onClick={() => navigate(page.path)}
           >
             <div className="text-lg font-semibold">{page.title}</div>
-            <div className="text-sm mt-1" style={{ color: '#6b7280' }}>
+            <div className="text-sm mt-1" style={{ color: tokens.textMuted }}>
               {page.description}
             </div>
           </div>

--- a/src/screens/dashboard.screen.tsx
+++ b/src/screens/dashboard.screen.tsx
@@ -1,21 +1,23 @@
-import { useNavigation } from 'src/hooks/navigation.hook';
+import { useThemeContext } from 'src/contexts/theme.context';
 import { useAdminGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
 
 export default function DashboardScreen(): JSX.Element {
   useAdminGuard();
   useLayoutOptions({ title: 'Dashboard' });
 
   const { navigate } = useNavigation();
+  const { tokens } = useThemeContext();
 
   return (
-    <div className="space-y-4 p-4 w-full" style={{ color: '#111827' }}>
+    <div className="space-y-4 p-4 w-full" style={{ color: tokens.textPrimary }}>
       <div
-        className="bg-white rounded-lg shadow p-6 cursor-pointer hover:bg-gray-50"
+        className="bg-white dark:bg-dfxBlue-700 rounded-lg shadow p-6 cursor-pointer hover:bg-gray-50 dark:hover:bg-dfxBlue-600"
         onClick={() => navigate('/dashboard/financial')}
       >
         <div className="text-lg font-semibold">Financial</div>
-        <div className="text-sm mt-1" style={{ color: '#6b7280' }}>
+        <div className="text-sm mt-1" style={{ color: tokens.textMuted }}>
           Balance overview, history, liquidity & expenses
         </div>
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}', './node_modules/@dfx.swiss/react-components/**/*.{vue,js,ts,jsx,tsx}'],
-  darkMode: 'media',
+  darkMode: 'class',
   theme: {
     colors: {
       white: '#ffffff',


### PR DESCRIPTION
## Summary

- Switch Tailwind from `darkMode: 'media'` (system-preference) to `'class'` so dark mode is opt-in via JavaScript instead of OS-driven.
- New `ThemeContextProvider` reads `?dark=1`/`?dark=0` (also `?theme=dark`/`?theme=light`) from the URL on mount, persists the choice in `localStorage` under `dfx.srv.darkMode`, and toggles a `dark` class on `<html>` and `<body>`. The flag is stripped from the URL after consumption.
- Globally, `html.dark` / `body.dark` flip the background to `#072440` (`dfxBlue.800`) so library components (Buy/Sell/Swap/KYC/Compliance/etc.) inherit a dark surface even without per-component `dark:` variants.
- Dashboard screens (which used hardcoded inline styles) now consume theme tokens from `useThemeContext()` and forward an `isDark` flag to the dashboard chart components so ApexCharts pick up the dark theme. The Financial Overview page keeps its always-dark rendering and now integrates cleanly with the global theme.

The flag is intentionally URL-only — no UI toggle is exposed yet (internal/staging use).

## Activation

| URL param           | Effect              |
| ------------------- | ------------------- |
| `?dark=1`           | enable dark mode    |
| `?theme=dark`       | enable dark mode    |
| `?dark=0`           | disable dark mode   |
| `?theme=light`      | disable dark mode   |

Once set, the choice persists across navigations and reloads via `localStorage`. The param itself is removed from the URL on consumption.

## Files

- `tailwind.config.js` — `darkMode: 'media'` -> `'class'`
- `src/index.css` — `html.dark` / `body.dark` background + dark-aware `.scroll-shadow`
- `src/contexts/theme.context.tsx` (new) — provider, hook, light/dark token palette
- `src/hooks/store.hook.ts` — new `darkMode` storage entry
- `src/App.tsx` — wrap routes in `ThemeContextProvider`
- `src/screens/dashboard*.screen.tsx` — consume theme tokens, forward `isDark` to charts
- `src/components/dashboard/{financial-changes,balance-by-type-area,total-balance-short}-chart.tsx` — accept `dark` prop, switch Apex theme + grid color
- Tests: `src/__tests__/theme.context.test.tsx` (new), extended `store.hook.test.ts`

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` — 298/298 passing (incl. new theme.context test suite)
- [x] `npm run build:dev` succeeds (only pre-existing source-map warnings from `@dfx.swiss/core`)
- [ ] Manual: open `https://services.dfx.swiss/?dark=1`, verify whole app renders dark and URL param is stripped
- [ ] Manual: reload without param — dark mode persists
- [ ] Manual: open with `?dark=0` — switches back to light
- [ ] Manual: dashboard screens render dark cards and dark chart theme
- [ ] Manual: Financial Overview keeps its dark rendering in either mode