### PR TITLE
perf(dashboard): cut re-render cost + lazy-load ApexCharts

### DIFF
--- a/src/__tests__/dashboard-financial-overview.helpers.test.ts
+++ b/src/__tests__/dashboard-financial-overview.helpers.test.ts
@@ -1,0 +1,115 @@
+// Mock @dfx.swiss/react to avoid ES module issues during screen import
+jest.mock('@dfx.swiss/react', () => ({
+  useSessionContext: jest.fn(() => ({ isLoggedIn: false })),
+  useApi: jest.fn(() => ({ call: jest.fn() })),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  SpinnerSize: { LG: 'lg' },
+  StyledLoadingSpinner: () => null,
+}));
+
+jest.mock('src/components/dashboard/age-badge', () => ({ AgeBadge: () => null }));
+jest.mock('src/components/dashboard/latest-balance-bar-chart', () => ({ BalanceBarChart: () => null }));
+jest.mock('src/components/dashboard/summary-card', () => ({ SummaryCard: () => null }));
+jest.mock('src/components/dashboard/total-balance-long-chart', () => ({ TotalBalanceLongChart: () => null }));
+jest.mock('src/hooks/dashboard.hook', () => ({ useDashboard: jest.fn(() => ({})) }));
+jest.mock('src/hooks/guard.hook', () => ({ useAdminGuard: jest.fn() }));
+jest.mock('src/hooks/layout-config.hook', () => ({ useLayoutOptions: jest.fn() }));
+
+import { FinancialLogEntry, LatestBalanceResponse } from 'src/dto/dashboard.dto';
+import { sameLatestBalance, sameLogEntries } from '../screens/dashboard-financial-overview.screen';
+
+function makeBalance(timestamp: string, byTypeCount = 0): LatestBalanceResponse {
+  return {
+    timestamp,
+    byType: Array.from({ length: byTypeCount }, (_, i) => ({
+      name: `t${i}`,
+      plusBalanceChf: 0,
+      minusBalanceChf: 0,
+      netBalanceChf: 0,
+    })),
+    byBlockchain: [],
+  };
+}
+
+function makeLogEntry(timestamp: string): FinancialLogEntry {
+  return {
+    timestamp,
+    totalBalanceChf: 0,
+    plusBalanceChf: 0,
+    minusBalanceChf: 0,
+    btcPriceChf: 0,
+    balancesByType: {},
+  };
+}
+
+describe('sameLatestBalance', () => {
+  it('returns true for identical references', () => {
+    const a = makeBalance('2026-05-19T10:00:00Z', 2);
+    expect(sameLatestBalance(a, a)).toBe(true);
+  });
+
+  it('returns true when both are undefined', () => {
+    expect(sameLatestBalance(undefined, undefined)).toBe(true);
+  });
+
+  it('returns false when only one side is undefined', () => {
+    const a = makeBalance('2026-05-19T10:00:00Z');
+    expect(sameLatestBalance(a, undefined)).toBe(false);
+    expect(sameLatestBalance(undefined, a)).toBe(false);
+  });
+
+  it('returns true when timestamps and byType lengths match', () => {
+    const a = makeBalance('2026-05-19T10:00:00Z', 3);
+    const b = makeBalance('2026-05-19T10:00:00Z', 3);
+    expect(sameLatestBalance(a, b)).toBe(true);
+  });
+
+  it('returns false when timestamps differ', () => {
+    const a = makeBalance('2026-05-19T10:00:00Z', 3);
+    const b = makeBalance('2026-05-19T10:01:00Z', 3);
+    expect(sameLatestBalance(a, b)).toBe(false);
+  });
+
+  it('returns false when byType lengths differ', () => {
+    const a = makeBalance('2026-05-19T10:00:00Z', 3);
+    const b = makeBalance('2026-05-19T10:00:00Z', 4);
+    expect(sameLatestBalance(a, b)).toBe(false);
+  });
+});
+
+describe('sameLogEntries', () => {
+  it('returns true for identical references', () => {
+    const entries = [makeLogEntry('2026-05-19T10:00:00Z')];
+    expect(sameLogEntries(entries, entries)).toBe(true);
+  });
+
+  it('returns true for two empty arrays', () => {
+    expect(sameLogEntries([], [])).toBe(true);
+  });
+
+  it('returns false when lengths differ', () => {
+    const a = [makeLogEntry('2026-05-19T10:00:00Z')];
+    const b = [makeLogEntry('2026-05-19T10:00:00Z'), makeLogEntry('2026-05-19T11:00:00Z')];
+    expect(sameLogEntries(a, b)).toBe(false);
+  });
+
+  it('returns true when last timestamps match', () => {
+    const a = [makeLogEntry('2026-05-19T09:00:00Z'), makeLogEntry('2026-05-19T10:00:00Z')];
+    const b = [makeLogEntry('2026-05-19T09:00:00Z'), makeLogEntry('2026-05-19T10:00:00Z')];
+    expect(sameLogEntries(a, b)).toBe(true);
+  });
+
+  it('returns false when last timestamps differ', () => {
+    const a = [makeLogEntry('2026-05-19T09:00:00Z'), makeLogEntry('2026-05-19T10:00:00Z')];
+    const b = [makeLogEntry('2026-05-19T09:00:00Z'), makeLogEntry('2026-05-19T10:05:00Z')];
+    expect(sameLogEntries(a, b)).toBe(false);
+  });
+
+  it('treats append-only update with new tail as different', () => {
+    const a = [makeLogEntry('2026-05-19T09:00:00Z'), makeLogEntry('2026-05-19T10:00:00Z')];
+    const b = [makeLogEntry('2026-05-19T09:00:00Z'), makeLogEntry('2026-05-19T10:00:00Z'), makeLogEntry('2026-05-19T11:00:00Z')];
+    expect(sameLogEntries(a, b)).toBe(false);
+  });
+});

--- a/src/components/dashboard/balance-by-type-area-chart.tsx
+++ b/src/components/dashboard/balance-by-type-area-chart.tsx
@@ -1,8 +1,9 @@
 import { ApexOptions } from 'apexcharts';
-import { useMemo } from 'react';
-import Chart from 'react-apexcharts';
+import { lazy, Suspense, useMemo } from 'react';
 import { FinancialLogEntry } from 'src/dto/dashboard.dto';
 import { TimeRange } from 'src/util/chart';
+
+const Chart = lazy(() => import('react-apexcharts'));
 
 interface Props {
   entries: FinancialLogEntry[];
@@ -76,7 +77,9 @@ export function BalanceByTypePlusChart({ entries, timeRange }: Props) {
   return (
     <div>
       <h3 className="text-sm font-semibold mb-2">Plus Balance by Type</h3>
-      <Chart type="area" height={300} options={options} series={series} />
+      <Suspense fallback={<div style={{ height: 300 }} />}>
+        <Chart type="area" height={300} options={options} series={series} />
+      </Suspense>
     </div>
   );
 }
@@ -93,7 +96,9 @@ export function BalanceByTypeMinusChart({ entries, timeRange }: Props) {
   return (
     <div>
       <h3 className="text-sm font-semibold mb-2">Minus Balance by Type</h3>
-      <Chart type="area" height={300} options={options} series={series} />
+      <Suspense fallback={<div style={{ height: 300 }} />}>
+        <Chart type="area" height={300} options={options} series={series} />
+      </Suspense>
     </div>
   );
 }
@@ -114,7 +119,9 @@ export function BalanceByTypeTotalChart({ entries, timeRange }: Props) {
   return (
     <div>
       <h3 className="text-sm font-semibold mb-2">Net Balance by Type</h3>
-      <Chart type="area" height={300} options={options} series={series} />
+      <Suspense fallback={<div style={{ height: 300 }} />}>
+        <Chart type="area" height={300} options={options} series={series} />
+      </Suspense>
     </div>
   );
 }

--- a/src/components/dashboard/financial-changes-chart.tsx
+++ b/src/components/dashboard/financial-changes-chart.tsx
@@ -1,8 +1,9 @@
 import { ApexOptions } from 'apexcharts';
-import { useMemo } from 'react';
-import Chart from 'react-apexcharts';
+import { lazy, Suspense, useMemo } from 'react';
 import { FinancialChangesEntry } from 'src/dto/dashboard.dto';
 import { TimeRange } from 'src/util/chart';
+
+const Chart = lazy(() => import('react-apexcharts'));
 
 interface FinancialChangesChartProps {
   entries: FinancialChangesEntry[];
@@ -54,7 +55,9 @@ export function FinancialChangesTotalChart({ entries, timeRange }: FinancialChan
   return (
     <div>
       <h3 className="text-sm font-semibold mb-2">Net Total (cumulative)</h3>
-      <Chart type="area" height={250} options={options} series={series} />
+      <Suspense fallback={<div style={{ height: 250 }} />}>
+        <Chart type="area" height={250} options={options} series={series} />
+      </Suspense>
     </div>
   );
 }
@@ -72,7 +75,9 @@ export function FinancialChangesPlusChart({ entries, timeRange }: FinancialChang
   return (
     <div>
       <h3 className="text-sm font-semibold mb-2">Income / Plus (cumulative)</h3>
-      <Chart type="area" height={250} options={options} series={series} />
+      <Suspense fallback={<div style={{ height: 250 }} />}>
+        <Chart type="area" height={250} options={options} series={series} />
+      </Suspense>
     </div>
   );
 }
@@ -102,7 +107,9 @@ export function FinancialChangesMinusChart({ entries, timeRange, onDetails }: Fi
           </button>
         )}
       </div>
-      <Chart type="area" height={250} options={options} series={series} />
+      <Suspense fallback={<div style={{ height: 250 }} />}>
+        <Chart type="area" height={250} options={options} series={series} />
+      </Suspense>
     </div>
   );
 }

--- a/src/components/dashboard/latest-balance-bar-chart.tsx
+++ b/src/components/dashboard/latest-balance-bar-chart.tsx
@@ -1,7 +1,8 @@
 import { ApexOptions } from 'apexcharts';
-import { useMemo } from 'react';
-import Chart from 'react-apexcharts';
+import { lazy, Suspense, useMemo } from 'react';
 import { BalanceByGroup } from 'src/dto/dashboard.dto';
+
+const Chart = lazy(() => import('react-apexcharts'));
 
 interface BalanceBarChartProps {
   title: string;
@@ -75,7 +76,9 @@ function SimpleBarChart({ title, data, dark }: { title: string; data: BalanceByG
   return (
     <div>
       <h3 className="text-sm font-semibold mb-2">{title}</h3>
-      <Chart type="bar" height={300} options={options} series={series} />
+      <Suspense fallback={<div style={{ height: 300 }} />}>
+        <Chart type="bar" height={300} options={options} series={series} />
+      </Suspense>
     </div>
   );
 }
@@ -125,7 +128,9 @@ function StackedBarChart({ title, data, dark }: { title: string; data: BalanceBy
   return (
     <div>
       <h3 className="text-sm font-semibold mb-2">{title}</h3>
-      <Chart type="bar" height={400} options={options} series={series} />
+      <Suspense fallback={<div style={{ height: 400 }} />}>
+        <Chart type="bar" height={400} options={options} series={series} />
+      </Suspense>
     </div>
   );
 }

--- a/src/components/dashboard/latest-balance-bar-chart.tsx
+++ b/src/components/dashboard/latest-balance-bar-chart.tsx
@@ -45,9 +45,14 @@ export function BalanceBarChart({ title, data, dark }: BalanceBarChartProps) {
 }
 
 function SimpleBarChart({ title, data, dark }: { title: string; data: BalanceByGroup[]; dark?: boolean }) {
-  const categories = data.map((i) => i.name);
-  const values = data.map((i) => Math.round(i.netBalanceChf));
-  const colors = data.map((i) => (i.netBalanceChf >= 0 ? '#22c55e' : '#ef4444'));
+  const { categories, values, colors } = useMemo(
+    () => ({
+      categories: data.map((i) => i.name),
+      values: data.map((i) => Math.round(i.netBalanceChf)),
+      colors: data.map((i) => (i.netBalanceChf >= 0 ? '#22c55e' : '#ef4444')),
+    }),
+    [data],
+  );
 
   const options = useMemo((): ApexOptions => ({
     chart: { type: 'bar', toolbar: { show: false }, background: '0' },

--- a/src/components/dashboard/total-balance-long-chart.tsx
+++ b/src/components/dashboard/total-balance-long-chart.tsx
@@ -1,8 +1,9 @@
 import { ApexOptions } from 'apexcharts';
-import { useMemo } from 'react';
-import Chart from 'react-apexcharts';
+import { lazy, Suspense, useMemo } from 'react';
 import { FinancialLogEntry } from 'src/dto/dashboard.dto';
 import { TimeRange } from 'src/util/chart';
+
+const Chart = lazy(() => import('react-apexcharts'));
 
 interface TotalBalanceLongChartProps {
   entries: FinancialLogEntry[];
@@ -68,7 +69,9 @@ export function TotalBalanceLongChart({ entries, timeRange, dark }: TotalBalance
   return (
     <div>
       <h3 className="text-sm font-semibold mb-2">Total Balance vs BTC Price</h3>
-      <Chart type="line" height={300} options={chartOptions} series={chartSeries} />
+      <Suspense fallback={<div style={{ height: 300 }} />}>
+        <Chart type="line" height={300} options={chartOptions} series={chartSeries} />
+      </Suspense>
     </div>
   );
 }

--- a/src/components/dashboard/total-balance-short-chart.tsx
+++ b/src/components/dashboard/total-balance-short-chart.tsx
@@ -1,8 +1,9 @@
 import { ApexOptions } from 'apexcharts';
-import { useMemo } from 'react';
-import Chart from 'react-apexcharts';
+import { lazy, Suspense, useMemo } from 'react';
 import { FinancialLogEntry } from 'src/dto/dashboard.dto';
 import { TimeRange } from 'src/util/chart';
+
+const Chart = lazy(() => import('react-apexcharts'));
 
 interface Props {
   entries: FinancialLogEntry[];
@@ -48,7 +49,9 @@ export function ShortTermPlusChart({ entries, timeRange }: Props) {
   return (
     <div>
       <h3 className="text-sm font-semibold mb-2">Plus Balance</h3>
-      <Chart type="line" height={250} options={options} series={series} />
+      <Suspense fallback={<div style={{ height: 250 }} />}>
+        <Chart type="line" height={250} options={options} series={series} />
+      </Suspense>
     </div>
   );
 }
@@ -62,7 +65,9 @@ export function ShortTermMinusChart({ entries, timeRange }: Props) {
   return (
     <div>
       <h3 className="text-sm font-semibold mb-2">Minus Balance</h3>
-      <Chart type="line" height={250} options={options} series={series} />
+      <Suspense fallback={<div style={{ height: 250 }} />}>
+        <Chart type="line" height={250} options={options} series={series} />
+      </Suspense>
     </div>
   );
 }
@@ -76,7 +81,9 @@ export function ShortTermTotalChart({ entries, timeRange }: Props) {
   return (
     <div>
       <h3 className="text-sm font-semibold mb-2">Total Balance</h3>
-      <Chart type="line" height={250} options={options} series={series} />
+      <Suspense fallback={<div style={{ height: 250 }} />}>
+        <Chart type="line" height={250} options={options} series={series} />
+      </Suspense>
     </div>
   );
 }

--- a/src/hooks/dashboard.hook.ts
+++ b/src/hooks/dashboard.hook.ts
@@ -11,54 +11,53 @@ import {
 export function useDashboard() {
   const { call } = useApi();
 
-  async function getFinancialLog(from?: string, dailySample?: boolean): Promise<FinancialLogResponse> {
-    const params = new URLSearchParams();
-    if (from) params.set('from', from);
-    if (dailySample !== undefined) params.set('dailySample', String(dailySample));
-    const query = params.toString();
+  return useMemo(() => {
+    async function getFinancialLog(from?: string, dailySample?: boolean): Promise<FinancialLogResponse> {
+      const params = new URLSearchParams();
+      if (from) params.set('from', from);
+      if (dailySample !== undefined) params.set('dailySample', String(dailySample));
+      const query = params.toString();
 
-    return call<FinancialLogResponse>({
-      url: `dashboard/financial/log${query ? `?${query}` : ''}`,
-      method: 'GET',
-    });
-  }
+      return call<FinancialLogResponse>({
+        url: `dashboard/financial/log${query ? `?${query}` : ''}`,
+        method: 'GET',
+      });
+    }
 
-  async function getFinancialChanges(from?: string, dailySample?: boolean): Promise<FinancialChangesResponse> {
-    const params = new URLSearchParams();
-    if (from) params.set('from', from);
-    if (dailySample !== undefined) params.set('dailySample', String(dailySample));
-    const query = params.toString();
+    async function getFinancialChanges(from?: string, dailySample?: boolean): Promise<FinancialChangesResponse> {
+      const params = new URLSearchParams();
+      if (from) params.set('from', from);
+      if (dailySample !== undefined) params.set('dailySample', String(dailySample));
+      const query = params.toString();
 
-    return call<FinancialChangesResponse>({
-      url: `dashboard/financial/changes${query ? `?${query}` : ''}`,
-      method: 'GET',
-    });
-  }
+      return call<FinancialChangesResponse>({
+        url: `dashboard/financial/changes${query ? `?${query}` : ''}`,
+        method: 'GET',
+      });
+    }
 
-  async function getLatestBalance(): Promise<LatestBalanceResponse> {
-    return call<LatestBalanceResponse>({
-      url: 'dashboard/financial/latest',
-      method: 'GET',
-    });
-  }
+    async function getLatestBalance(): Promise<LatestBalanceResponse> {
+      return call<LatestBalanceResponse>({
+        url: 'dashboard/financial/latest',
+        method: 'GET',
+      });
+    }
 
-  async function getLatestChanges(): Promise<FinancialChangesEntry> {
-    return call<FinancialChangesEntry>({
-      url: 'dashboard/financial/changes/latest',
-      method: 'GET',
-    });
-  }
+    async function getLatestChanges(): Promise<FinancialChangesEntry> {
+      return call<FinancialChangesEntry>({
+        url: 'dashboard/financial/changes/latest',
+        method: 'GET',
+      });
+    }
 
-  async function getRefRecipients(from?: string): Promise<RefRewardRecipient[]> {
-    const query = from ? `?from=${from}` : '';
-    return call<RefRewardRecipient[]>({
-      url: `dashboard/financial/ref-recipients${query}`,
-      method: 'GET',
-    });
-  }
+    async function getRefRecipients(from?: string): Promise<RefRewardRecipient[]> {
+      const query = from ? `?from=${from}` : '';
+      return call<RefRewardRecipient[]>({
+        url: `dashboard/financial/ref-recipients${query}`,
+        method: 'GET',
+      });
+    }
 
-  return useMemo(
-    () => ({ getFinancialLog, getFinancialChanges, getLatestBalance, getLatestChanges, getRefRecipients }),
-    [call],
-  );
+    return { getFinancialLog, getFinancialChanges, getLatestBalance, getLatestChanges, getRefRecipients };
+  }, [call]);
 }

--- a/src/screens/dashboard-financial-liquidity.screen.tsx
+++ b/src/screens/dashboard-financial-liquidity.screen.tsx
@@ -35,6 +35,9 @@ export default function DashboardFinancialLiquidityScreen(): JSX.Element {
     return net;
   }, [latestBalance]);
 
+  // Memoize the array so BalanceBarChart's internal useMemo cache stays stable across renders.
+  const byBlockchain = useMemo(() => latestBalance?.byBlockchain ?? [], [latestBalance]);
+
   if (isLoading) {
     return (
       <div className="flex justify-center items-center w-full h-96">
@@ -50,7 +53,7 @@ export default function DashboardFinancialLiquidityScreen(): JSX.Element {
       </div>
 
       <div className="bg-white rounded-lg shadow p-4">
-        <BalanceBarChart title="Liquidity by Provider" data={latestBalance?.byBlockchain ?? []} />
+        <BalanceBarChart title="Liquidity by Provider" data={byBlockchain} />
       </div>
     </div>
   );

--- a/src/screens/dashboard-financial-live.screen.tsx
+++ b/src/screens/dashboard-financial-live.screen.tsx
@@ -39,6 +39,9 @@ export default function DashboardFinancialLiveScreen(): JSX.Element {
     return { totalPlus: plus, totalMinus: minus, totalBalance: plus - minus };
   }, [latestBalance]);
 
+  // Memoize the array so BalanceBarChart's internal useMemo cache stays stable across renders.
+  const byType = useMemo(() => latestBalance?.byType ?? [], [latestBalance]);
+
   if (isLoading) {
     return (
       <div className="flex justify-center items-center w-full h-96">
@@ -60,7 +63,7 @@ export default function DashboardFinancialLiveScreen(): JSX.Element {
       </div>
 
       <div className="bg-white rounded-lg shadow p-4">
-        <BalanceBarChart title="Balance by Type" data={latestBalance?.byType ?? []} />
+        <BalanceBarChart title="Balance by Type" data={byType} />
       </div>
     </div>
   );

--- a/src/screens/dashboard-financial-overview.screen.tsx
+++ b/src/screens/dashboard-financial-overview.screen.tsx
@@ -24,6 +24,21 @@ const TIMEFRAME_OPTIONS = [
 
 const REFRESH_INTERVAL_MS = 60_000;
 
+export function sameLatestBalance(a: LatestBalanceResponse | undefined, b: LatestBalanceResponse | undefined): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.timestamp !== b.timestamp) return false;
+  if (a.byType?.length !== b.byType?.length) return false;
+  return true;
+}
+
+export function sameLogEntries(a: FinancialLogEntry[], b: FinancialLogEntry[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  if (a.length === 0) return true;
+  return a[a.length - 1]?.timestamp === b[b.length - 1]?.timestamp;
+}
+
 export default function DashboardFinancialOverviewScreen(): JSX.Element {
   useAdminGuard();
   useLayoutOptions({ title: 'Financial Overview', noMaxWidth: true });
@@ -46,10 +61,10 @@ export default function DashboardFinancialOverviewScreen(): JSX.Element {
     function load(initial: boolean) {
       if (initial) setIsLoading(true);
       getLatestBalance()
-        .then(setLatestBalance)
+        .then((data) => setLatestBalance((prev) => (sameLatestBalance(prev, data) ? prev : data)))
         .catch(() => undefined);
       getFinancialLog(from, dailySample)
-        .then((logData) => setLogEntries(logData.entries))
+        .then((logData) => setLogEntries((prev) => (sameLogEntries(prev, logData.entries) ? prev : logData.entries)))
         .catch(() => undefined)
         .finally(() => {
           if (initial) setIsLoading(false);

--- a/src/screens/dashboard-financial-overview.screen.tsx
+++ b/src/screens/dashboard-financial-overview.screen.tsx
@@ -51,6 +51,12 @@ export default function DashboardFinancialOverviewScreen(): JSX.Element {
   const [logEntries, setLogEntries] = useState<FinancialLogEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
+  // Prefetch the lazy ApexCharts chunk while the page is mounting so the
+  // first chart paint does not wait on a separate network round-trip.
+  useEffect(() => {
+    import('react-apexcharts');
+  }, []);
+
   useEffect(() => {
     if (!isLoggedIn) return;
 

--- a/src/screens/dashboard-financial-overview.screen.tsx
+++ b/src/screens/dashboard-financial-overview.screen.tsx
@@ -105,6 +105,9 @@ export default function DashboardFinancialOverviewScreen(): JSX.Element {
     return { totalPlus: plus, totalMinus: minus, totalBalance: plus - minus };
   }, [latestBalance]);
 
+  // Memoize the array so BalanceBarChart's internal useMemo cache stays stable across renders.
+  const byBlockchain = useMemo(() => latestBalance?.byBlockchain ?? [], [latestBalance]);
+
   return (
     <div className="space-y-4 p-4 w-full self-stretch bg-dfxBlue-800 min-h-screen" style={{ color: '#ffffff' }}>
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
@@ -141,7 +144,7 @@ export default function DashboardFinancialOverviewScreen(): JSX.Element {
           </div>
 
           <div className="bg-dfxBlue-700 rounded-lg shadow p-4">
-            <BalanceBarChart title="Liquidity by Provider" data={latestBalance?.byBlockchain ?? []} dark />
+            <BalanceBarChart title="Liquidity by Provider" data={byBlockchain} dark />
           </div>
         </>
       )}

--- a/src/screens/dashboard-financial-overview.screen.tsx
+++ b/src/screens/dashboard-financial-overview.screen.tsx
@@ -54,7 +54,7 @@ export default function DashboardFinancialOverviewScreen(): JSX.Element {
   // Prefetch the lazy ApexCharts chunk while the page is mounting so the
   // first chart paint does not wait on a separate network round-trip.
   useEffect(() => {
-    import('react-apexcharts');
+    import('react-apexcharts').catch(() => undefined);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Skip state updates in the financial overview when the 60s auto-refresh returns identical payloads (timestamp / append-only log tail), so ApexCharts no longer redoes SVG repaints for no-op polls.
- Stabilize the references returned by `useDashboard` and the derived inputs of `SimpleBarChart` so existing `useMemo`s actually short-circuit instead of invalidating every render.
- Move `react-apexcharts` (~500 KB) behind `React.lazy` in all five dashboard chart components, with layout-stable Suspense fallbacks. Prefetch the chunk on overview mount so the first chart paint does not wait on a separate round-trip.

Pairs with the backend optimization in https://github.com/DFXswiss/api/pull/3725 (financial log query latency 5-15s -> <500ms).

## Changes
**Fix A - skip no-op state updates (`src/screens/dashboard-financial-overview.screen.tsx`)**
- Add pure helpers `sameLatestBalance(a, b)` and `sameLogEntries(a, b)` exported alongside the screen for testability.
- Switch both setters in the 60s refresh effect to the functional form so the previous reference is kept when nothing changed.

**Fix C - stabilize identities**
- `src/hooks/dashboard.hook.ts`: move the five async functions (`getFinancialLog`, `getFinancialChanges`, `getLatestBalance`, `getLatestChanges`, `getRefRecipients`) inside the existing `useMemo([call])` body so consumers actually get stable references across renders.
- `src/components/dashboard/latest-balance-bar-chart.tsx`: collapse `categories`, `values` and `colors` (previously recomputed on every render and used as `useMemo` deps) into a single `useMemo([data])`.

**Fix B - lazy-load ApexCharts**
- `src/components/dashboard/total-balance-long-chart.tsx`, `latest-balance-bar-chart.tsx`, `balance-by-type-area-chart.tsx`, `financial-changes-chart.tsx`, `total-balance-short-chart.tsx`: replace `import Chart from 'react-apexcharts'` with `lazy(() => import('react-apexcharts'))` and wrap every `<Chart />` in a `<Suspense fallback={<div style={{ height: N }} />}>` matching the chart height (250 / 300 / 400 px) so the layout does not jump.
- `dashboard-financial-overview.screen.tsx`: fire a best-effort `import('react-apexcharts').catch(...)` on mount so the chunk is warmed up in parallel with the first data fetch.

**Tests**
- `src/__tests__/dashboard-financial-overview.helpers.test.ts`: 12 cases covering reference, undefined, empty, length, last-timestamp, and append-tail edge cases for the two new equality helpers.

## Verification

**Build (npm run build:dev):**

| | Main bundle | `apexcharts` chunk | Loading strategy |
|---|---|---|---|
| Before | 3 410 970 B | 587 651 B (separate chunk `2019.*.chunk.js`) | static import - chunk fetched as soon as the dashboard module is parsed |
| After  | 3 410 870 B | 587 651 B (same chunk) | `lazy()` - chunk fetched only when a `<Suspense>` boundary actually renders |

Total JS bytes across all chunks change by < 0.1 % (587 KB vs 587 KB for the chart vendor chunk, same content). The win is on the critical path, not raw bytes: screens that do not render a chart no longer pull in the apex bundle, and the overview prefetches it in parallel with `getLatestBalance` / `getFinancialLog` instead of blocking on a serial import.

**Local CI gates (all green):**
- `npm run lint`
- `npm run test` -> 295 tests, 27 suites, all passing (12 new)
- `npm run build:dev`

## Test plan
- [ ] Open `/dashboard/financial/overview`, watch the network tab: the `2019.*.chunk.js` (apex) request fires shortly after first paint, layout does not jump when the chart resolves.
- [ ] Sit on the overview for >60s, watch React DevTools Profiler: the auto-refresh interval should produce no chart re-render when payload timestamps are unchanged (compare commit counts on the chart subtree before vs after).
- [ ] Switch timeframes (1D / 1W / 1M etc.); both charts re-render correctly with the new data.
- [ ] Navigate to `/dashboard/financial/history` after the overview - the apex chunk should already be in the browser cache (no extra request).
- [ ] Reviewer: use the React DevTools Profiler to spot-check re-render counts for `TotalBalanceLongChart` / `BalanceBarChart` over a 5-minute window with no backend changes. Expectation: zero renders triggered by the polling refresh.