### PR TITLE
feat(partner): add /partner dashboard for partner self-service

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,6 +88,9 @@ const RealunitTransactionDetailScreen = lazy(() => import('./screens/realunit-tr
 const RealunitUserScreen = lazy(() => import('./screens/realunit-user.screen'));
 const PersonalIbanScreen = lazy(() => import('./screens/personal-iban.screen'));
 const BuyCryptoUpdateScreen = lazy(() => import('./screens/buy-crypto-update.screen'));
+const PartnerScreen = lazy(() => import('./screens/partner.screen'));
+const PartnerOnboardingScreen = lazy(() => import('./screens/partner-onboarding.screen'));
+const PartnerHistoryScreen = lazy(() => import('./screens/partner-history.screen'));
 const DashboardScreen = lazy(() => import('./screens/dashboard.screen'));
 const DashboardFinancialScreen = lazy(() => import('./screens/dashboard-financial.screen'));
 const DashboardFinancialOverviewScreen = lazy(() => import('./screens/dashboard-financial-overview.screen'));
@@ -506,6 +509,14 @@ export const Routes = [
             path: 'user/:address',
             element: withSuspense(<RealunitUserScreen />),
           },
+        ],
+      },
+      {
+        path: 'partner',
+        children: [
+          { index: true, element: withSuspense(<PartnerScreen />) },
+          { path: 'onboarding', element: withSuspense(<PartnerOnboardingScreen />) },
+          { path: 'history', element: withSuspense(<PartnerHistoryScreen />) },
         ],
       },
       {

--- a/src/components/partner/partner-user-card.tsx
+++ b/src/components/partner/partner-user-card.tsx
@@ -1,0 +1,38 @@
+import { PartnerUserInfo } from 'src/dto/partner.dto';
+
+interface PartnerUserCardProps {
+  user: PartnerUserInfo;
+}
+
+export function PartnerUserCard({ user }: PartnerUserCardProps): JSX.Element {
+  const fullName = [user.firstname, user.surname].filter(Boolean).join(' ') || '—';
+
+  return (
+    <div className="bg-white rounded-lg shadow p-4 text-sm space-y-1" style={{ color: '#111827' }}>
+      <div className="flex justify-between">
+        <span className="text-dfxGray-700">UserData ID</span>
+        <span className="font-mono">{user.id}</span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-dfxGray-700">Name</span>
+        <span>{fullName}</span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-dfxGray-700">Email</span>
+        <span>{user.mail || '—'}</span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-dfxGray-700">Status</span>
+        <span>{user.status}</span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-dfxGray-700">usedRef</span>
+        <span className="font-mono">{user.usedRef}</span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-dfxGray-700">Current fees</span>
+        <span className="font-mono">{user.feeIds.length ? user.feeIds.join(', ') : '—'}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/dto/partner.dto.ts
+++ b/src/dto/partner.dto.ts
@@ -1,0 +1,24 @@
+import { KycStatus } from '@dfx.swiss/react';
+
+export interface PartnerUserInfo {
+  id: number;
+  status: string;
+  mail?: string;
+  firstname?: string;
+  surname?: string;
+  usedRef: string;
+  feeIds: number[];
+  canModify: boolean;
+}
+
+export interface PartnerFee {
+  id: number;
+  label: string;
+  type: string;
+  rate: number;
+  fixed: number;
+}
+
+export interface PartnerRefereeDisplay extends PartnerUserInfo {
+  kycStatus?: KycStatus;
+}

--- a/src/hooks/guard.hook.ts
+++ b/src/hooks/guard.hook.ts
@@ -23,6 +23,12 @@ export function useComplianceGuard(redirectPath = '/', isActive = true) {
   useUserRoleGuard([UserRole.ADMIN, UserRole.COMPLIANCE], redirectPath, isActive);
 }
 
+// 'Partner' is exported as UserRole.PARTNER in @dfx.swiss/react >= 1.4.0-beta.2.
+// Cast keeps this PR independent of the packages publish; switch to UserRole.PARTNER once consumed.
+export function usePartnerGuard(redirectPath = '/', isActive = true) {
+  useUserRoleGuard([UserRole.ADMIN, 'Partner' as UserRole], redirectPath, isActive);
+}
+
 export const SUPPORT_DASHBOARD_ROLES = [UserRole.ADMIN, UserRole.COMPLIANCE, UserRole.SUPPORT, UserRole.MARKETING];
 
 export function useSupportDashboardGuard(redirectPath = '/', isActive = true) {

--- a/src/hooks/partner.hook.ts
+++ b/src/hooks/partner.hook.ts
@@ -1,0 +1,50 @@
+import { useApi } from '@dfx.swiss/react';
+import { useMemo } from 'react';
+import { PartnerFee, PartnerUserInfo } from 'src/dto/partner.dto';
+
+export interface UsePartner {
+  findUserByAddress: (address: string) => Promise<PartnerUserInfo>;
+  getMyReferees: () => Promise<PartnerUserInfo[]>;
+  getAvailableFees: () => Promise<PartnerFee[]>;
+  setOnboarding: (userDataId: number, feeId: number) => Promise<void>;
+  removeFee: (userDataId: number, feeId: number) => Promise<void>;
+}
+
+export function usePartner(): UsePartner {
+  const { call } = useApi();
+
+  async function findUserByAddress(address: string): Promise<PartnerUserInfo> {
+    return call<PartnerUserInfo>({
+      url: `partner/user?address=${encodeURIComponent(address)}`,
+      method: 'GET',
+    });
+  }
+
+  async function getMyReferees(): Promise<PartnerUserInfo[]> {
+    return call<PartnerUserInfo[]>({ url: 'partner/users', method: 'GET' });
+  }
+
+  async function getAvailableFees(): Promise<PartnerFee[]> {
+    return call<PartnerFee[]>({ url: 'partner/fees', method: 'GET' });
+  }
+
+  async function setOnboarding(userDataId: number, feeId: number): Promise<void> {
+    return call<void>({
+      url: `partner/user/${userDataId}/onboarding`,
+      method: 'PUT',
+      data: { feeId },
+    });
+  }
+
+  async function removeFee(userDataId: number, feeId: number): Promise<void> {
+    return call<void>({
+      url: `partner/user/${userDataId}/fee?fee=${feeId}`,
+      method: 'DELETE',
+    });
+  }
+
+  return useMemo(
+    () => ({ findUserByAddress, getMyReferees, getAvailableFees, setOnboarding, removeFee }),
+    [call],
+  );
+}

--- a/src/screens/partner-history.screen.tsx
+++ b/src/screens/partner-history.screen.tsx
@@ -1,0 +1,72 @@
+import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
+import { useCallback, useEffect, useState } from 'react';
+import { ErrorHint } from 'src/components/error-hint';
+import { PartnerUserInfo } from 'src/dto/partner.dto';
+import { usePartnerGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
+import { usePartner } from 'src/hooks/partner.hook';
+
+export default function PartnerHistoryScreen(): JSX.Element {
+  usePartnerGuard();
+
+  const { navigate } = useNavigation();
+  const { getMyReferees } = usePartner();
+
+  const [referees, setReferees] = useState<PartnerUserInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  const onBack = useCallback(() => navigate('/partner'), [navigate]);
+  useLayoutOptions({ title: 'My Referees', backButton: true, onBack });
+
+  useEffect(() => {
+    getMyReferees()
+      .then(setReferees)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load referees'))
+      .finally(() => setLoading(false));
+  }, [getMyReferees]);
+
+  if (loading) {
+    return (
+      <div className="p-4 flex justify-center">
+        <StyledLoadingSpinner size={SpinnerSize.LG} />
+      </div>
+    );
+  }
+
+  if (error) return <ErrorHint message={error} />;
+
+  if (!referees.length) {
+    return <p className="p-4 text-center text-dfxGray-700">No referees yet.</p>;
+  }
+
+  return (
+    <div className="p-4 w-full" style={{ color: '#111827' }}>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-dfxGray-300 text-left">
+              <th className="py-2 pr-3">ID</th>
+              <th className="py-2 pr-3">Name</th>
+              <th className="py-2 pr-3">Email</th>
+              <th className="py-2 pr-3">Status</th>
+              <th className="py-2 pr-3">Fees</th>
+            </tr>
+          </thead>
+          <tbody>
+            {referees.map((r) => (
+              <tr key={r.id} className="border-b border-dfxGray-300">
+                <td className="py-2 pr-3 font-mono">{r.id}</td>
+                <td className="py-2 pr-3">{[r.firstname, r.surname].filter(Boolean).join(' ') || '—'}</td>
+                <td className="py-2 pr-3">{r.mail || '—'}</td>
+                <td className="py-2 pr-3">{r.status}</td>
+                <td className="py-2 pr-3 font-mono">{r.feeIds.length ? r.feeIds.join(', ') : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/partner-onboarding.screen.tsx
+++ b/src/screens/partner-onboarding.screen.tsx
@@ -1,0 +1,209 @@
+import { Utils, Validations } from '@dfx.swiss/react';
+import {
+  Form,
+  StyledButton,
+  StyledButtonColor,
+  StyledButtonWidth,
+  StyledDropdown,
+  StyledInput,
+  StyledVerticalStack,
+} from '@dfx.swiss/react-components';
+import { useCallback, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { ErrorHint } from 'src/components/error-hint';
+import { PartnerUserCard } from 'src/components/partner/partner-user-card';
+import { useLayoutContext } from 'src/contexts/layout.context';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { PartnerFee, PartnerUserInfo } from 'src/dto/partner.dto';
+import { usePartnerGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
+import { usePartner } from 'src/hooks/partner.hook';
+
+interface FormData {
+  address: string;
+  feeId: string;
+}
+
+export default function PartnerOnboardingScreen(): JSX.Element {
+  usePartnerGuard();
+
+  const { translate, translateError } = useSettingsContext();
+  const { rootRef } = useLayoutContext();
+  const { navigate } = useNavigation();
+  const { findUserByAddress, getAvailableFees, setOnboarding, removeFee } = usePartner();
+
+  const [lookupLoading, setLookupLoading] = useState(false);
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [fees, setFees] = useState<PartnerFee[]>();
+  const [feesError, setFeesError] = useState<string>();
+  const [target, setTarget] = useState<PartnerUserInfo>();
+  const [error, setError] = useState<string>();
+  const [success, setSuccess] = useState<string>();
+
+  const onBack = useCallback(() => navigate('/partner'), [navigate]);
+  useLayoutOptions({ title: 'Set Onboarding Fee', backButton: true, onBack });
+
+  const {
+    control,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors, isValid },
+  } = useForm<FormData>({ mode: 'onChange', defaultValues: { address: '', feeId: '' } });
+
+  const selectedFeeId = watch('feeId');
+
+  const ensureFeesLoaded = useCallback(async () => {
+    if (fees) return;
+    try {
+      const list = await getAvailableFees();
+      setFees(list);
+    } catch (e) {
+      setFeesError(e instanceof Error ? e.message : 'Failed to load fees');
+    }
+  }, [fees, getAvailableFees]);
+
+  const onLookup = useCallback(
+    async (data: FormData) => {
+      setLookupLoading(true);
+      setError(undefined);
+      setSuccess(undefined);
+      setTarget(undefined);
+      try {
+        const user = await findUserByAddress(data.address);
+        setTarget(user);
+        await ensureFeesLoaded();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Lookup failed');
+      } finally {
+        setLookupLoading(false);
+      }
+    },
+    [findUserByAddress, ensureFeesLoaded],
+  );
+
+  const onSetFee = useCallback(async () => {
+    if (!target || !selectedFeeId) return;
+    setSubmitLoading(true);
+    setError(undefined);
+    setSuccess(undefined);
+    try {
+      await setOnboarding(target.id, +selectedFeeId);
+      setSuccess('Fee assigned, user marked Active, ref updated.');
+      const refreshed = await findUserByAddress(watch('address'));
+      setTarget(refreshed);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Operation failed');
+    } finally {
+      setSubmitLoading(false);
+    }
+  }, [target, selectedFeeId, setOnboarding, findUserByAddress, watch]);
+
+  const onRemoveFee = useCallback(async () => {
+    if (!target || !selectedFeeId) return;
+    setSubmitLoading(true);
+    setError(undefined);
+    setSuccess(undefined);
+    try {
+      await removeFee(target.id, +selectedFeeId);
+      setSuccess('Fee removed.');
+      const refreshed = await findUserByAddress(watch('address'));
+      setTarget(refreshed);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Operation failed');
+    } finally {
+      setSubmitLoading(false);
+    }
+  }, [target, selectedFeeId, removeFee, findUserByAddress, watch]);
+
+  const onReset = useCallback(() => {
+    reset();
+    setTarget(undefined);
+    setError(undefined);
+    setSuccess(undefined);
+  }, [reset]);
+
+  const rules = Utils.createRules({
+    address: Validations.Required,
+  });
+
+  const selectedFee = fees?.find((f) => f.id === +selectedFeeId);
+  const isFeeAssigned = !!target && !!selectedFee && target.feeIds.includes(selectedFee.id);
+
+  return (
+    <Form control={control} rules={rules} errors={errors} translate={translateError}>
+      <StyledVerticalStack gap={4} full>
+        <StyledInput
+          name="address"
+          label={translate('screens/payment', 'Blockchain address')}
+          placeholder="0x… / bc1… / …"
+          full
+        />
+
+        <StyledButton
+          onClick={handleSubmit(onLookup)}
+          label={translate('general/actions', 'Lookup')}
+          disabled={!isValid || lookupLoading}
+          isLoading={lookupLoading}
+          width={StyledButtonWidth.FULL}
+        />
+
+        {error && <ErrorHint message={error} />}
+        {feesError && <ErrorHint message={feesError} />}
+
+        {target && (
+          <>
+            <PartnerUserCard user={target} />
+
+            {target.canModify ? (
+              <>
+                <StyledDropdown<PartnerFee>
+                  name="feeId"
+                  rootRef={rootRef}
+                  label={translate('screens/payment', 'Fee')}
+                  placeholder={translate('general/actions', 'Select') + '...'}
+                  items={fees ?? []}
+                  labelFunc={(f) => f.label}
+                  descriptionFunc={(f) => `${f.fixed} CHF fixed · ${(f.rate * 100).toFixed(2)}%`}
+                  full
+                />
+
+                <div className="flex gap-3">
+                  <StyledButton
+                    onClick={onSetFee}
+                    label={isFeeAssigned ? 'Already assigned' : 'Set Fee + Activate'}
+                    disabled={!selectedFeeId || submitLoading || isFeeAssigned}
+                    isLoading={submitLoading}
+                    width={StyledButtonWidth.FULL}
+                  />
+                  <StyledButton
+                    onClick={onRemoveFee}
+                    label="Remove Fee"
+                    color={StyledButtonColor.STURDY_WHITE}
+                    disabled={!selectedFeeId || submitLoading || !isFeeAssigned}
+                    isLoading={submitLoading}
+                    width={StyledButtonWidth.FULL}
+                  />
+                </div>
+              </>
+            ) : (
+              <p className="text-dfxRed-100 text-center text-sm">
+                This user is referred by another partner — read-only.
+              </p>
+            )}
+
+            {success && <p className="text-dfxGray-700 text-center text-sm">{success}</p>}
+
+            <StyledButton
+              onClick={onReset}
+              label={translate('general/actions', 'Reset')}
+              color={StyledButtonColor.STURDY_WHITE}
+              width={StyledButtonWidth.FULL}
+            />
+          </>
+        )}
+      </StyledVerticalStack>
+    </Form>
+  );
+}

--- a/src/screens/partner.screen.tsx
+++ b/src/screens/partner.screen.tsx
@@ -1,0 +1,33 @@
+import { usePartnerGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
+
+export default function PartnerScreen(): JSX.Element {
+  usePartnerGuard();
+  useLayoutOptions({ title: 'Partner' });
+
+  const { navigate } = useNavigation();
+
+  return (
+    <div className="space-y-4 p-4 w-full" style={{ color: '#111827' }}>
+      <div
+        className="bg-white rounded-lg shadow p-6 cursor-pointer hover:bg-gray-50"
+        onClick={() => navigate('/partner/onboarding')}
+      >
+        <div className="text-lg font-semibold">Set Onboarding Fee</div>
+        <div className="text-sm mt-1" style={{ color: '#6b7280' }}>
+          Look up a referee by address, assign or remove their individual fee
+        </div>
+      </div>
+      <div
+        className="bg-white rounded-lg shadow p-6 cursor-pointer hover:bg-gray-50"
+        onClick={() => navigate('/partner/history')}
+      >
+        <div className="text-lg font-semibold">My Referees</div>
+        <div className="text-sm mt-1" style={{ color: '#6b7280' }}>
+          List of all users currently linked to your referral code
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/partner` route family on `app.dfx.swiss`, gated by `usePartnerGuard` (`Admin` + `Partner`)
- Three lazy-loaded screens:
  - `/partner` — hub with two tiles
  - `/partner/onboarding` — lookup-by-address form, fee dropdown, **Set Fee + Activate** / **Remove Fee** buttons
  - `/partner/history` — table of all users currently linked to caller's `usedRef`
- `usePartner` hook with 5 methods against `/v1/partner/*` ([api#3787](https://github.com/DFXswiss/api/pull/3787))
- Local `PartnerUserInfo` / `PartnerFee` DTOs (admin-style, mirrors `compliance.hook` pattern)

## Why
Referral partners like Fab today rely on the internal DFX Admin Google Sheet (operated by the Compliance team) to set custom onboarding fees on their referees. This PR moves that workflow into a self-service UI on `app.dfx.swiss`, paired with backend scope enforcement.

## Dependencies
- Hard: [api#3787](https://github.com/DFXswiss/api/pull/3787) — adds `UserRole.PARTNER` + `/v1/partner/*` endpoints with server-side scope check (caller can only act on users with `usedRef ∈ { defaultRef, caller.ref }`)
- Soft: [packages#178](https://github.com/DFXswiss/packages/pull/178) — `PARTNER` enum value + `PartnerUrl` constants in `@dfx.swiss/core`. Not consumed in this PR (cast workaround in `guard.hook.ts`); a follow-up can migrate to native `UserRole.PARTNER` once packages 1.4.0-beta.2 is published.

## Operational notes
- After merge to DEV: set Fab's test-account `user.role = 'Partner'` via DB to test scope behaviour.
- After merge to PROD: same one-off `UPDATE` for the actual partner accounts.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build:lib` (tsc) clean
- [x] `npm run test` — 283 passed
- [x] `npm run build:dev` clean
- [ ] DEV: login as test partner (role=Partner, ref=158-532), navigate `/partner`
- [ ] `/partner/onboarding`: paste an unowned address → Lookup → see UserCard with `canModify=true` → pick fee → Set → success, UserCard refreshes with new fee + Active + caller's ref
- [ ] Remove Fee on a fee that's currently assigned → success
- [ ] Lookup an address with another partner's `usedRef` → `canModify=false`, dropdown disabled, message visible
- [ ] `/partner/history`: see table of own referees
- [ ] Non-partner login → redirect to `/`