### PR TITLE
feat(compliance): show phone call times column in call queue list

### DIFF
--- a/src/screens/compliance-call-queue.screen.tsx
+++ b/src/screens/compliance-call-queue.screen.tsx
@@ -32,8 +32,10 @@ export default function ComplianceCallQueueScreen(): JSX.Element {
   const showIp = queue === CallQueue.MANUAL_CHECK_IP_PHONE || queue === CallQueue.MANUAL_CHECK_IP_COUNTRY_PHONE;
   const showCountry = queue === CallQueue.MANUAL_CHECK_IP_COUNTRY_PHONE || queue === CallQueue.UNAVAILABLE_SUSPICIOUS;
   const showStatus = queue === CallQueue.UNAVAILABLE_SUSPICIOUS;
+  const showPhoneCallTimes =
+    queue === CallQueue.MANUAL_CHECK_PHONE || queue === CallQueue.MANUAL_CHECK_IP_COUNTRY_PHONE;
 
-  const columnCount = 5 + [isTxQueue, showIp, showCountry, showStatus].filter(Boolean).length;
+  const columnCount = 5 + [isTxQueue, showIp, showCountry, showStatus, showPhoneCallTimes].filter(Boolean).length;
 
   useEffect(() => {
     if (!isLoggedIn || !queue) return;
@@ -99,6 +101,11 @@ export default function ComplianceCallQueueScreen(): JSX.Element {
               <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">
                 {translate('screens/compliance', 'Date')}
               </th>
+              {showPhoneCallTimes && (
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">
+                  {translate('screens/compliance', 'Phone Call Times')}
+                </th>
+              )}
             </tr>
           </thead>
           <tbody>
@@ -134,6 +141,9 @@ export default function ComplianceCallQueueScreen(): JSX.Element {
                   <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">
                     {new Date(item.date).toLocaleDateString('de-CH')}
                   </td>
+                  {showPhoneCallTimes && (
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{item.phoneCallTimes || '-'}</td>
+                  )}
                 </tr>
               ))
             ) : (


### PR DESCRIPTION
## Was
Neue Spalte **„Phone Call Times"** in der Call-Queue-Übersicht (`compliance-call-queue.screen.tsx`), ganz am Schluss nach „Date". Zeigt die vom Kunden gewählte bevorzugte Anrufzeit (`item.phoneCallTimes`, roh).

## Warum
Zur besseren Übersicht soll die gewählte Anrufzeit schon in der Liste sichtbar sein (bisher nur in der Detailansicht beim Klick auf den User).

## Scope
- Spalte nur in den Queues **`ManualCheckPhone`** und **`ManualCheckIpCountryPhone`** (Flag `showPhoneCallTimes`), via gleichem Muster wie `showIp`/`showCountry`/`showStatus`
- Header „Phone Call Times" angeglichen an die Detailansicht (`call-queue-user-info.tsx`)
- Leerwert (null/undefined/leerer String) → `-` (`|| '-'`), damit auch ein leeres Array sauber dargestellt wird
- Keine neuen i18n-Keys nötig (`screens/compliance` ist in keiner Sprachdatei → Fallback auf EN-Key wie bei allen anderen Spalten)

## Abhängigkeit ⚠️
Braucht das Feld `phoneCallTimes` aus `@dfx.swiss/core` (CallQueueItem). Vor „Ready for review":
1. `@dfx.swiss/core`/`react`-PR mergen → CI published neue Beta
2. hier `@dfx.swiss/react` auf die neue Beta ziehen (`npm install`, Lockfile-Update)

Gekoppelter API-PR: DFXswiss/api#3924