### PR TITLE
Add synpress-e2e and visual-baselines agent skills

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,3 +51,19 @@ platform-, font- and data-dependent — needlessly blocking PRs.
   is expected — these tests are not a regression gate and do not fail the build.
 - For a clean, reviewable diff, regenerate on a realistic data set so the
   screenshot isolates your actual UI change rather than seed-data noise.
+
+## Agent skills
+
+Shared agent skills live under `skills/<name>/` and are version-controlled so the whole team gets them
+on pull. They follow the open [Agent Skills](https://agentskills.io) `SKILL.md` standard, so they are
+not tied to a single tool. Point your agent at the `skills/` directory — symlink or copy
+`skills/<name>/` into your agent's skills folder, or set the path in your agent's config; per-developer
+agent config stays local. Keep `SKILL.md` frontmatter to the portable core (`name`, `description`) and
+reference scripts by repository-relative path.
+
+Current skills:
+
+- `skills/synpress-e2e/` — run the MetaMask wallet e2e suite (pinned Chrome 126 / MetaMask 11.9.1,
+  headed, serial).
+- `skills/visual-baselines/` — regenerate Playwright visual baselines after a UI change (see "Visual
+  regression tests" above).

--- a/skills/synpress-e2e/SKILL.md
+++ b/skills/synpress-e2e/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: synpress-e2e
+description: Run the MetaMask wallet end-to-end test suite (Synpress/Playwright) in this repo. Use when running or debugging the on-chain wallet e2e tests — covers the one-time pinned-Chrome + MetaMask setup, the headed/serial run constraints, and the wallet/seed configuration.
+---
+
+# MetaMask wallet e2e (Synpress)
+
+The wallet e2e suite drives a real MetaMask extension through Playwright. It needs a pinned browser and
+extension and must run headed and serially. The required knowledge is not obvious and is not documented
+elsewhere — read this before running it.
+
+## One-time setup
+
+```
+npm run synpress:setup
+```
+
+This installs **Chrome 126.0.6478.0** (via `@puppeteer/browsers`) and downloads **MetaMask 11.9.1**
+into `.cache-synpress/metamask-chrome-11.9.1`. Both versions are pinned on purpose: Chrome 127+ drops
+Manifest V2 support and MetaMask 11.9.1 is an MV2 extension, so the suite uses the last MV2-capable
+Chrome (126) and loads the extension manually instead of relying on the framework's cache (which breaks
+on Chrome 127+). The Chrome binary path is hardcoded for macOS arm64.
+
+## Run the suite
+
+```
+npm run test:e2e:metamask
+```
+
+This runs Playwright with `playwright.synpress.config.ts`, which starts the app via `npm start` on
+`http://localhost:3001` and runs the wallet specs. Hard constraints — do not change them:
+
+- **Headed** (`headless: false`) — MV2 extensions cannot load in headless Chrome.
+- **Serial** (`workers: 1`) — the tests share one wallet state.
+- Only the specs in the config's `testMatch` run, not every file under `e2e/synpress/`.
+
+## Wallet configuration
+
+- `TEST_SEED` must be set in `.env` (the test wallet's mnemonic); the wallet password is `Tester@1234`.
+- The extension is loaded from `.cache-synpress/metamask-chrome-11.9.1` via Playwright's
+  `launchPersistentContext` with a fresh ephemeral profile; the wallet is imported on each run.
+
+See `reference.md` in this skill folder for the exact paths, the spec list, the Sepolia constants, and
+the isolated extension-loading debug config.

--- a/skills/synpress-e2e/reference.md
+++ b/skills/synpress-e2e/reference.md
@@ -1,0 +1,38 @@
+# Synpress / MetaMask e2e — reference
+
+## Why the versions are pinned
+- Chrome `126.0.6478.0` is the last build with Manifest V2 support; MetaMask `11.9.1` is an MV2
+  extension. Chrome 127+ deprecates MV2 and the framework's built-in cache breaks there, so the suite
+  loads the extension manually (`launchPersistentContext`) on Chrome 126.
+- macOS arm64 only: the Chrome binary path is hardcoded as
+  `chrome/mac_arm-126.0.6478.0/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/...`.
+
+## Setup commands (package.json)
+- `synpress:install-chrome` → `npx @puppeteer/browsers install chrome@126.0.6478.0`
+- `synpress:download-metamask` → downloads `metamask-chrome-11.9.1.zip` into
+  `.cache-synpress/metamask-chrome-11.9.1`
+- `synpress:setup` → runs both.
+
+## Run config (playwright.synpress.config.ts)
+- `testDir: ./e2e/synpress`, `headless: false`, `workers: 1`, `fullyParallel: false`,
+  `timeout: 120000`, `baseURL: http://localhost:3001`.
+- `webServer`: `npm start` on `http://localhost:3001` (reused locally, started in CI).
+- `testMatch` (the specs that actually run): `eip5792-custom.spec.ts`, `sepolia-usdt-sell.spec.ts`,
+  `sepolia-full-metamask.spec.ts`, `sepolia-real-tx.spec.ts`, `sell-complete.spec.ts`,
+  `sepolia-sell-e2e.spec.ts`.
+
+## Wallet constants (e2e/synpress/custom-fixtures.ts)
+- Password: `Tester@1234`. Seed: `TEST_SEED` from `.env` (sample mnemonic in `.env.sample`).
+- Extension loaded with `--disable-extensions-except` / `--load-extension` from
+  `.cache-synpress/metamask-chrome-11.9.1`; locale forced to `en-US`; fresh ephemeral profile per run.
+- Sepolia: USDT `0xaa8e23fb1079ea71e0a56f48a2aa51851d8433d0`, chainId `11155111`.
+
+## Isolated debug config
+- `playwright.metamask-debug.config.ts` runs only `metamask-setup-test.spec.ts` with **no** webServer.
+  Use it to verify Chrome-126 + extension loading + wallet import in isolation, without booting the app:
+  `npx playwright test --config=playwright.metamask-debug.config.ts`.
+
+## Caveat: two fixture paths
+`e2e/synpress/custom-fixtures.ts` (manual Chrome-126 load) is what `test:e2e:metamask` uses. A second,
+native-framework path (`fixtures.ts` + `test/wallet-setup/basic.setup.ts`, with a different seed) exists
+but is not referenced by the config's `testMatch`, so it does not run under `npm run test:e2e:metamask`.

--- a/skills/synpress-e2e/reference.md
+++ b/skills/synpress-e2e/reference.md
@@ -22,7 +22,7 @@
   `sepolia-sell-e2e.spec.ts`.
 
 ## Wallet constants (e2e/synpress/custom-fixtures.ts)
-- Password: `Tester@1234`. Seed: `TEST_SEED` from `.env` (sample mnemonic in `.env.sample`).
+- Password: `Tester@1234`. Seed: `TEST_SEED` from `.env` (placeholder mnemonic shown in `.env.sample`).
 - Extension loaded with `--disable-extensions-except` / `--load-extension` from
   `.cache-synpress/metamask-chrome-11.9.1`; locale forced to `en-US`; fresh ephemeral profile per run.
 - Sepolia: USDT `0xaa8e23fb1079ea71e0a56f48a2aa51851d8433d0`, chainId `11155111`.

--- a/skills/visual-baselines/SKILL.md
+++ b/skills/visual-baselines/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: visual-baselines
+description: Regenerate the Playwright visual-regression baselines in this repo after a UI change. Use when a change alters the rendered UI and the committed screenshot baselines need updating for pull-request review. Regenerate only affected screenshots, never all of them.
+---
+
+# Visual baselines (Playwright)
+
+The Playwright tests under `e2e/` compare the rendered app against committed screenshot baselines in
+`e2e/screenshots/baseline/`. They are a local pull-request-review aid and intentionally do **not** run
+in CI. When a change affects the UI, regenerate the affected baselines locally and commit them with the
+change so the reviewer sees the before→after in the PR diff. The full procedure lives in
+`CONTRIBUTING.md` ("Visual regression tests"); this is the short, runnable version.
+
+## Prerequisite
+
+Start the local stack (the API repo and this repo checked out as sibling folders; local DB + seed —
+see the API repository's README). The frontend runs on `http://localhost:3001`, the API on
+`http://localhost:3000`.
+
+## Run / regenerate
+
+Run an affected spec against the local API:
+
+```
+REACT_APP_API_URL=http://localhost:3000 npx playwright test <spec> --project=chromium
+```
+
+Regenerate only the screenshots your change affects, then commit them:
+
+```
+npx playwright test <spec> -g "<test title>" --update-snapshots
+```
+
+## Rules
+
+- Regenerate **only** the screenshots your change actually affects — never update all baselines at once.
+- Baselines are platform-specific (`*-chromium-darwin.png`); regenerate on macOS, like the existing ones.
+- Drift on screens you did not touch is expected — these tests are not a regression gate and do not fail
+  the build. Do not "fix" unrelated baselines.
+- Regenerate on a realistic seed data set so the diff isolates your actual UI change, not seed-data noise.


### PR DESCRIPTION
## What

Adds two agent skills under `skills/` and an "Agent skills" section to `CONTRIBUTING.md`:

- `skills/synpress-e2e/` — run the MetaMask wallet e2e suite (Synpress/Playwright).
- `skills/visual-baselines/` — regenerate Playwright visual baselines after a UI change.

Both follow the open [Agent Skills](https://agentskills.io) `SKILL.md` standard and are tool-neutral
(frontmatter limited to `name`/`description`, repository-relative paths only).

## Why this is needed

**`synpress-e2e`** — the wallet e2e suite carries brittle, version-pinned knowledge that is documented
nowhere (not in CONTRIBUTING or README — only scattered across config/fixture comments): it needs
Chrome 126.0.6478.0 and MetaMask 11.9.1 (because Chrome 127+ drops Manifest V2 and the framework's
cache breaks there), must run headed (extensions do not load headless) and serial (shared wallet
state), and only a specific `testMatch` set runs. A new contributor cannot run it without
re-discovering all of this painfully. Wrapping the existing `synpress:*` / `test:e2e:metamask` scripts
with this curated knowledge is exactly the skill case.

**`visual-baselines`** — regenerating baselines is a recurring per-PR action on UI changes where the
wrong move (a blanket `--update-snapshots`) is actively harmful: it overwrites unrelated, drifted
baselines. The procedure is already documented in CONTRIBUTING.md; this skill is a thin, runnable
pointer to it so an agent reliably regenerates only the affected screenshots, on macOS, and never all
of them.

## Why one PR for both

Both are services e2e/Playwright testing skills in the same repo and share the single new
"Agent skills" CONTRIBUTING section; splitting them would mean two PRs editing the same section.

## Files

- `skills/synpress-e2e/SKILL.md`, `skills/synpress-e2e/reference.md`
- `skills/visual-baselines/SKILL.md`
- `CONTRIBUTING.md` — new "Agent skills" section
