### PR TITLE
fix(compliance): pick latest KYC step by id, not sequenceNumber

### DIFF
--- a/src/components/compliance/compliance-review-header.tsx
+++ b/src/components/compliance/compliance-review-header.tsx
@@ -1,5 +1,12 @@
 import { KycStepInfo, UserDataDetail } from 'src/hooks/compliance.hook';
-import { buildAddress, display, extractLegalEntity, formatBirthday, refName } from 'src/util/compliance-helpers';
+import {
+  buildAddress,
+  display,
+  extractLegalEntity,
+  findLatestStep,
+  formatBirthday,
+  refName,
+} from 'src/util/compliance-helpers';
 
 interface ComplianceReviewHeaderProps {
   userData: UserDataDetail;
@@ -14,7 +21,7 @@ interface HeaderField {
 }
 
 function extractStepCreatedDate(kycSteps: KycStepInfo[]): string {
-  const step = kycSteps.filter((s) => s.name === 'LegalEntity').sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
+  const step = findLatestStep(kycSteps, 'LegalEntity');
 
   if (!step) return '-';
   return new Date(step.created).toLocaleDateString('de-CH');

--- a/src/components/compliance/freigabe-panel.tsx
+++ b/src/components/compliance/freigabe-panel.tsx
@@ -4,6 +4,7 @@ import { KycFile, KycStepInfo, UserDataDetail } from 'src/hooks/compliance.hook'
 import {
   buildAddress,
   display,
+  findLatestStep,
   formatBirthday,
   formatDate,
   formatDateTime,
@@ -50,10 +51,6 @@ interface SavedComment {
   amlAccountType?: string;
   processedBy?: string;
   finalDecision?: string;
-}
-
-function findStep(steps: KycStepInfo[], name: string): KycStepInfo | undefined {
-  return steps.filter((s) => s.name === name).sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
 }
 
 function parseResult(step: KycStepInfo | undefined): Record<string, unknown> | undefined {
@@ -280,9 +277,9 @@ export function ComplianceReviewFreigabePanel({
   isSaving,
 }: OnboardingComplianceReviewFreigabePanelProps): JSX.Element {
   // Derived from predecessor step status (read-only, like in GS)
-  const ownerDirectoryStep = findStep(kycSteps, 'OwnerDirectory');
-  const legalEntityStepForDecision = findStep(kycSteps, 'LegalEntity');
-  const authorityStepForDecision = findStep(kycSteps, 'Authority');
+  const ownerDirectoryStep = findLatestStep(kycSteps, 'OwnerDirectory');
+  const legalEntityStepForDecision = findLatestStep(kycSteps, 'LegalEntity');
+  const authorityStepForDecision = findLatestStep(kycSteps, 'Authority');
 
   function stepToDecision(s: KycStepInfo | undefined): DecisionValue {
     if (!s) return '';
@@ -343,16 +340,16 @@ export function ComplianceReviewFreigabePanel({
 
   const accountType = display(userData.accountType);
   const isOrganization = accountType === 'Organization';
-  const legalEntityStep = findStep(kycSteps, 'LegalEntity');
+  const legalEntityStep = findLatestStep(kycSteps, 'LegalEntity');
   const legalEntityResult = parseResult(legalEntityStep);
   const legalEntity = legalEntityResult?.legalEntity ? String(legalEntityResult.legalEntity) : '';
   const isGmbH = legalEntity === 'GmbH';
 
   const kycHash = display(userData.kycHash);
-  const financialDataStep = findStep(kycSteps, 'FinancialData');
-  const beneficialOwnerStep = findStep(kycSteps, 'BeneficialOwner');
-  const signatoryPowerStep = findStep(kycSteps, 'SignatoryPower');
-  const operationalActivityStep = findStep(kycSteps, 'OperationalActivity');
+  const financialDataStep = findLatestStep(kycSteps, 'FinancialData');
+  const beneficialOwnerStep = findLatestStep(kycSteps, 'BeneficialOwner');
+  const signatoryPowerStep = findLatestStep(kycSteps, 'SignatoryPower');
+  const operationalActivityStep = findLatestStep(kycSteps, 'OperationalActivity');
   const operationalActivityResult = parseResult(operationalActivityStep);
 
   async function handleSave(): Promise<void> {

--- a/src/components/compliance/ident-panel.tsx
+++ b/src/components/compliance/ident-panel.tsx
@@ -1,6 +1,13 @@
 import { useState } from 'react';
 import { ComplianceUserData, KycFile, KycStepInfo, IpLogInfo } from 'src/hooks/compliance.hook';
-import { display, formatBirthday, refName, statusBadge, todayAsString } from 'src/util/compliance-helpers';
+import {
+  display,
+  findLatestStep,
+  formatBirthday,
+  refName,
+  statusBadge,
+  todayAsString,
+} from 'src/util/compliance-helpers';
 import { renderResultTable } from './compliance-review-panel';
 
 interface IdentPanelProps {
@@ -31,10 +38,6 @@ interface IdentResult {
   ipCountry?: string;
   country?: string;
   type?: string;
-}
-
-function findLatestStep(kycSteps: KycStepInfo[], stepName: string): KycStepInfo | undefined {
-  return kycSteps.filter((s) => s.name === stepName).sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
 }
 
 function parseIdentResult(step: KycStepInfo): IdentResult | undefined {

--- a/src/components/compliance/stammdaten-panel.tsx
+++ b/src/components/compliance/stammdaten-panel.tsx
@@ -2,7 +2,7 @@ import { Country } from '@dfx.swiss/react';
 import { useEffect, useState } from 'react';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { ComplianceUserData, KycFile, KycStepInfo, UserDataDetail } from 'src/hooks/compliance.hook';
-import { statusBadge, formatDateTime } from 'src/util/compliance-helpers';
+import { findLatestStep, statusBadge, formatDateTime } from 'src/util/compliance-helpers';
 
 interface StammdatenPanelProps {
   data: ComplianceUserData;
@@ -72,10 +72,6 @@ const changeSections: ChangeSection[] = [
   { label: 'Namensänderung', stepName: 'NameChange', fileType: 'NameChange' },
   { label: 'Adressänderung', stepName: 'AddressChange', fileType: 'AddressChange' },
 ];
-
-function findLatestStep(kycSteps: KycStepInfo[], stepName: string): KycStepInfo | undefined {
-  return kycSteps.filter((s) => s.name === stepName).sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
-}
 
 function safeString(value: unknown): string {
   if (value == null) return '-';

--- a/src/screens/compliance-review.screen.tsx
+++ b/src/screens/compliance-review.screen.tsx
@@ -20,11 +20,7 @@ import { ComplianceUserData, KycFile, KycStepInfo, TransactionInfo, useComplianc
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useSplitPane } from 'src/hooks/split-pane.hook';
-import { buildKycLogMessage, KycLogResult } from 'src/util/compliance-helpers';
-
-function findLatestStep(kycSteps: KycStepInfo[], stepName: string): KycStepInfo | undefined {
-  return kycSteps.filter((s) => s.name === stepName).sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
-}
+import { buildKycLogMessage, findLatestStep, KycLogResult } from 'src/util/compliance-helpers';
 
 function findFiles(kycFiles: KycFile[], fileTypes: string[]): KycFile[] {
   return kycFiles.filter((f) => fileTypes.includes(f.type));

--- a/src/util/compliance-helpers.tsx
+++ b/src/util/compliance-helpers.tsx
@@ -208,14 +208,21 @@ export function refName(ref?: { name?: string; symbol?: string }): string {
   return ref?.name ?? ref?.symbol ?? '-';
 }
 
+// Returns the most recent KYC step of the given name. "Most recent" is the highest id
+// (auto-increment, so chronologically latest) — NOT the highest sequenceNumber. A newer step
+// can have a lower sequenceNumber than an older one (e.g. a fresh SumsubVideo ident in
+// ManualReview vs. a previously completed SumsubAuto ident), and sorting by sequenceNumber
+// would surface the stale completed step and hide the one that still needs review.
+export function findLatestStep(kycSteps: KycStepInfo[], stepName: string): KycStepInfo | undefined {
+  return kycSteps.filter((s) => s.name === stepName).sort((a, b) => b.id - a.id)[0];
+}
+
 // Resolve the legal entity for a user from the latest LegalEntity KYC step result.
 // Sole proprietorships are treated as Einzelunternehmen without a step lookup.
 export function extractLegalEntity(kycSteps: KycStepInfo[], accountType?: string): string {
   if (accountType === 'SoleProprietorship') return 'Einzelunternehmen';
 
-  const legalEntityStep = kycSteps
-    .filter((s) => s.name === 'LegalEntity')
-    .sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
+  const legalEntityStep = findLatestStep(kycSteps, 'LegalEntity');
 
   if (legalEntityStep?.result) {
     try {


### PR DESCRIPTION
## Problem

In the compliance KYC review, `findLatestStep(kycSteps, name)` picked the step with the **highest `sequenceNumber`**, not the most recent one. A newer step can have a *lower* sequenceNumber than an older one of the same name.

Concrete case: a user with a completed `SumsubAuto` ident (`sequenceNumber 1`, April) and a newer `SumsubVideo` ident still in **`ManualReview`** (`sequenceNumber 0`, June). The lookup returned the stale **completed** auto-ident, so:

- the **Ident tab showed green** ("done"), masking the open review, and
- the **accept/reject buttons never appeared** in the Ident panel — they only render when the displayed step's status is `ManualReview`. Since the shown step was `Completed`, only the grey hint text appeared and the open video ident **could not be approved from the per-user KYC review** at all.

In our case the video ident was approved by Sumsub but sat unactioned in `ManualReview` for two weeks (blocking the customer's buy with `amlReason=VideoIdentNeeded`), partly because the UI made it look already handled.

## Fix

- Sort by **`id`** (auto-increment ⇒ chronological) instead of `sequenceNumber`, so the genuinely latest step wins and an open review is no longer hidden by an older completed one.
- Consolidate the **six** duplicated/inlined copies of this lookup into a single exported `findLatestStep` in `compliance-helpers` (also covered `extractLegalEntity`, the header's `extractStepCreatedDate`, and freigabe-panel's `findStep`), so the same bug can't reappear in one place.

## Affected
- `util/compliance-helpers.tsx` (new shared `findLatestStep`)
- `screens/compliance-review.screen.tsx`, `components/compliance/ident-panel.tsx`, `stammdaten-panel.tsx`, `compliance-review-header.tsx`, `freigabe-panel.tsx`

## Notes
- No behaviour change for users with a single step of a given name.
- eslint + prettier clean on all touched files.