### PR TITLE
feat(auth): tag DFX Wallet on app.dfx.swiss email logins

### DIFF
--- a/src/components/home/wallet/connect-mail.tsx
+++ b/src/components/home/wallet/connect-mail.tsx
@@ -20,6 +20,11 @@ interface FormData {
   mail: string;
 }
 
+// House-brand wallet name of app.dfx.swiss, matching the backend's default wallet (Config.defaultWalletId).
+// Sent when no explicit `wallet` URL param is present, so an email login started here is positively
+// attributed to DFX in the per-login audit trail (IpLog.walletName) instead of relying on the backend default.
+const DFX_WALLET_NAME = 'DFX';
+
 export default function ConnectMail({ onCancel }: ConnectProps): JSX.Element {
   const { translate, translateError } = useSettingsContext();
   const { signInWithMail } = useAuth();
@@ -53,7 +58,7 @@ export default function ConnectMail({ onCancel }: ConnectProps): JSX.Element {
   async function submit({ mail }: FormData): Promise<void> {
     setIsLoading(true);
     setError(undefined);
-    signInWithMail(mail, redirectUri, recommendationCode, wallet)
+    signInWithMail(mail, redirectUri, recommendationCode, wallet ?? DFX_WALLET_NAME)
       .then(() => setMailSent(true))
       .catch((error: ApiError) => setError(error.message ?? 'Unknown error'))
       .finally(() => setIsLoading(false));


### PR DESCRIPTION
Implements the app.dfx.swiss frontend part of DFXswiss/api#3849.

## What
When a user starts an **email login on app.dfx.swiss without an explicit `?wallet=` URL param**, the app now sends `wallet: 'DFX Wallet'` on `POST /v1/auth/mail` instead of `undefined`.

```diff
- signInWithMail(mail, redirectUri, recommendationCode, wallet)
+ signInWithMail(mail, redirectUri, recommendationCode, wallet ?? DFX_WALLET_NAME)
```

`DFX_WALLET_NAME` is the resolvable production wallet name (`'DFX Wallet'`, backend default wallet / `Config.defaultWalletId = 1`).

## Why
The backend (api#3851, merged) persists `IpLog.walletName` per login from the **resolved** wallet. Sending a name that does not exist in the `wallet` table falls through `getByIdOrName` to `getDefault()` — same outcome as omitting `wallet` entirely.

Earlier revision of this PR sent `'DFX'`, which is **not** a wallet row (only `DFX Wallet`, `DFX Payment`, …). That made the change a functional no-op. Using `'DFX Wallet'` matches the real default wallet name so resolution succeeds by name.

Note on audit distinction: this tags app.dfx.swiss email logins with the same resolved name as the DFX Wallet app (and as the backend default). A separate backend wallet row (e.g. `DFX` for the web app only) would be needed if those sources must be distinguishable in `IpLog` — out of scope here.

## Scope
- `connect-mail.tsx`: default wallet name + call site
- `connect-mail-redirect.test.tsx`: wallet default / explicit param / error / back paths (100% file coverage)

No behavior change for logins that already carry a `wallet` param (`??`).

## Verification
- `eslint` clean on touched files (Studio)
- `npm test -- src/__tests__/connect-mail-redirect.test.tsx`: **1 suite / 10 tests** green (Studio)
- Coverage on `connect-mail.tsx`: **100% stmts/branch/funcs/lines**
- Mutation: `'DFX Wallet'` → `'DFX'` → 2 tests red; `wallet ?? DFX_WALLET_NAME` → `wallet` → default-wallet test red