### PR TITLE
fix(referral): stop forcing a trailing slash onto the copied referral link

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -38,6 +38,7 @@ import {
   formatLocationAddress,
   apiUrl,
   relativeUrl,
+  url,
 } from '../util/utils';
 
 describe('utils', () => {
@@ -129,6 +130,27 @@ describe('utils', () => {
     it('should return false for relative URLs', () => {
       expect(isAbsoluteUrl('/path/to/page')).toBe(false);
       expect(isAbsoluteUrl('path/to/page')).toBe(false);
+    });
+  });
+
+  describe('url', () => {
+    it('should keep the base without a trailing slash when there is no path (referral link)', () => {
+      expect(url({ base: 'https://dfx.swiss/app/services', params: new URLSearchParams({ code: '185-151' }) })).toBe(
+        'https://dfx.swiss/app/services?code=185-151',
+      );
+    });
+
+    it('should keep a trailing slash that is part of the base when there is no path', () => {
+      expect(url({ base: 'https://dfx.swiss/app/services/' })).toBe('https://dfx.swiss/app/services/');
+    });
+
+    it('should join base and path with a single slash', () => {
+      expect(url({ base: 'https://dfx.swiss/app', path: 'services' })).toBe('https://dfx.swiss/app/services');
+      expect(url({ base: 'https://dfx.swiss/app/', path: '/services' })).toBe('https://dfx.swiss/app/services');
+    });
+
+    it('should use an absolute path as base', () => {
+      expect(url({ base: 'https://dfx.swiss', path: 'https://app.dfx.swiss' })).toBe('https://app.dfx.swiss/');
     });
   });
 

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -55,7 +55,7 @@ export function url({
   // Join via the slash-terminated base only when there is a path to append. With an empty path the base is
   // used exactly as provided: forcing a trailing slash onto it breaks targets that treat the two forms
   // differently (e.g. the referral link, where only the slash-less dfx.swiss URL redirects to the API).
-  const absoluteUrl = normalizedPath ? new URL(normalizedPath, normalizedBase) : new URL(base);
+  const absoluteUrl = normalizedPath ? new URL(normalizedPath, normalizedBase) : new URL(base ?? normalizedBase);
   if (params) absoluteUrl.search = params.toString();
   return absoluteUrl.href;
 }

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -52,7 +52,10 @@ export function url({
 
   const normalizedBase = base?.replace(/\/+$/, '') + '/'; // end with a single slash
   const normalizedPath = path.replace(/^\/+/, ''); // remove leading slashes
-  const absoluteUrl = new URL(normalizedPath, normalizedBase);
+  // Join via the slash-terminated base only when there is a path to append. With an empty path the base is
+  // used exactly as provided: forcing a trailing slash onto it breaks targets that treat the two forms
+  // differently (e.g. the referral link, where only the slash-less dfx.swiss URL redirects to the API).
+  const absoluteUrl = normalizedPath ? new URL(normalizedPath, normalizedBase) : new URL(base);
   if (params) absoluteUrl.search = params.toString();
   return absoluteUrl.href;
 }


### PR DESCRIPTION
## Problem

Since the URL-construction refactor in #587 (May 2025), the account screen's referral copy button produces `https://dfx.swiss/app/services/?code=XXX-XXX` — with a trailing slash before the `?`. The `url()` helper normalizes the base to end with a slash for path joining, and with an empty path the slash leaks into the result.

dfx.swiss only 301-redirects the slash-less form to `api.dfx.swiss/v1/app/services?code=…` (where the ref is stored per IP); the slash form returns the static marketing page (HTTP 200) and the code is lost — no meta refresh, no script forwards it, and the app itself only reads `refcode`/`special-code`/`recommendation-code`. Every freshly copied referral link therefore silently loses its attribution.

## Fix

With no path to join, `url()` now uses the base exactly as provided (`new URL(base)`); path joining is unchanged. Covered by new `url()` unit tests (base kept verbatim with/without slash, joining, absolute-path-as-base).

## Notes

- Ops side: a redirect rule for the slash variant on dfx.swiss would additionally heal all already-shared links (this PR only fixes newly copied ones).
- Backend counterpart for the related mail-invitation ref gap: DFXswiss/api#4211 (independent bug, no pairing required).
- Full test suite green (33 suites / 384 tests).