### PR TITLE
8d2cc4b3 - Follow the account merge as a ticket when it runs long

### DIFF
--- a/src/__tests__/job.hook.test.ts
+++ b/src/__tests__/job.hook.test.ts
@@ -1,0 +1,117 @@
+import { act, renderHook } from '@testing-library/react';
+import { JobStatus, JobTicket } from 'src/dto/job.dto';
+import { useJobTracker } from '../hooks/job.hook';
+
+const resultPayload = { kycHash: 'hash-1', accessToken: 'token-1' };
+
+function makeTicket(overrides: Partial<JobTicket> = {}): JobTicket {
+  return {
+    uid: 'J7f3a9c2e1b8d4a60',
+    group: 'AccountMerge',
+    status: JobStatus.Pending,
+    created: new Date().toISOString(),
+    expectedSeconds: 65,
+    ...overrides,
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('useJobTracker', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should set result on first fetch without ticket', async () => {
+    const fetchResult = jest.fn().mockResolvedValue(resultPayload);
+    const { result } = renderHook(() => useJobTracker(fetchResult));
+
+    await act(async () => {
+      result.current.start();
+      await flushMicrotasks();
+    });
+
+    expect(result.current.result).toEqual(resultPayload);
+    expect(result.current.ticket).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(fetchResult).toHaveBeenCalledTimes(1);
+  });
+
+  it('should poll until result after receiving a ticket', async () => {
+    const ticket = makeTicket();
+    const fetchResult = jest.fn().mockResolvedValueOnce(ticket).mockResolvedValueOnce(resultPayload);
+    const { result } = renderHook(() => useJobTracker(fetchResult));
+
+    await act(async () => {
+      result.current.start();
+      await flushMicrotasks();
+    });
+
+    expect(result.current.ticket).toEqual(ticket);
+    expect(result.current.result).toBeUndefined();
+    expect(fetchResult).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await flushMicrotasks();
+    });
+
+    expect(result.current.result).toEqual(resultPayload);
+    expect(fetchResult).toHaveBeenCalledTimes(2);
+  });
+
+  it('should set error on Failed ticket and stop polling', async () => {
+    const ticket = makeTicket({ status: JobStatus.Failed });
+    const fetchResult = jest.fn().mockResolvedValue(ticket);
+    const { result } = renderHook(() => useJobTracker(fetchResult));
+
+    await act(async () => {
+      result.current.start();
+      await flushMicrotasks();
+    });
+
+    expect(result.current.error).toBe('Job Failed');
+    expect(result.current.result).toBeUndefined();
+    expect(fetchResult).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(10000);
+      await flushMicrotasks();
+    });
+
+    expect(fetchResult).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry after a transient error without setting error', async () => {
+    const fetchResult = jest
+      .fn()
+      .mockRejectedValueOnce({ statusCode: 500, message: 'boom' })
+      .mockResolvedValueOnce(resultPayload);
+    const { result } = renderHook(() => useJobTracker(fetchResult));
+
+    await act(async () => {
+      result.current.start();
+      await flushMicrotasks();
+    });
+
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.result).toBeUndefined();
+    expect(fetchResult).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await flushMicrotasks();
+    });
+
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.result).toEqual(resultPayload);
+    expect(fetchResult).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/job.hook.test.ts
+++ b/src/__tests__/job.hook.test.ts
@@ -1,6 +1,52 @@
-import { act, renderHook } from '@testing-library/react';
+const mockCall = jest.fn();
+const mockSetAuthToken = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock('@dfx.swiss/react', () => ({
+  useApi: () => ({ call: mockCall }),
+  useAuthContext: () => ({ setAuthToken: mockSetAuthToken }),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => {
+  const { createElement } = require('react');
+  return {
+    StyledButton: () => null,
+    StyledVerticalStack: ({ children }: any) => createElement('div', null, children),
+  };
+});
+
+jest.mock('react-router-dom', () => {
+  const { useState } = require('react');
+  return {
+    useSearchParams: () => {
+      const [params, setParams] = useState(() => new URLSearchParams('otp=otp-secret-42'));
+      const setUrlParams = (next: URLSearchParams) => setParams(new URLSearchParams(next.toString()));
+      return [params, setUrlParams];
+    },
+  };
+});
+
+jest.mock('src/components/job/job-progress', () => ({
+  JobProgress: () => null,
+}));
+
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({ translate: (_ns: string, key: string) => key }),
+}));
+
+jest.mock('src/hooks/layout-config.hook', () => ({
+  useLayoutOptions: () => undefined,
+}));
+
+jest.mock('src/hooks/navigation.hook', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+import { act, render, renderHook } from '@testing-library/react';
+import { createElement } from 'react';
 import { JobStatus, JobTicket } from 'src/dto/job.dto';
-import { useJobTracker } from '../hooks/job.hook';
+import { JOB_TRACKER_TIMEOUT_ERROR, useJobTracker } from '../hooks/job.hook';
+import AccountMerge from '../screens/account-merge.screen';
 
 const resultPayload = { kycHash: 'hash-1', accessToken: 'token-1' };
 
@@ -113,5 +159,85 @@ describe('useJobTracker', () => {
     expect(result.current.error).toBeUndefined();
     expect(result.current.result).toEqual(resultPayload);
     expect(fetchResult).toHaveBeenCalledTimes(2);
+  });
+
+  it('should time out a hanging fetch after the tracking deadline and discard its late result', async () => {
+    let resolveFetch!: (value: typeof resultPayload) => void;
+    const fetchResult = jest.fn().mockImplementation(
+      () =>
+        new Promise<typeof resultPayload>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useJobTracker(fetchResult));
+
+    await act(async () => {
+      result.current.start();
+      await flushMicrotasks();
+    });
+
+    expect(result.current.error).toBeUndefined();
+    expect(fetchResult).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(600_000);
+      await flushMicrotasks();
+    });
+
+    expect(result.current.error).toBe(JOB_TRACKER_TIMEOUT_ERROR);
+    expect(result.current.result).toBeUndefined();
+
+    await act(async () => {
+      resolveFetch(resultPayload);
+      await flushMicrotasks();
+    });
+
+    expect(result.current.result).toBeUndefined();
+    expect(result.current.error).toBe(JOB_TRACKER_TIMEOUT_ERROR);
+  });
+});
+
+describe('AccountMerge screen - otp code stability across polls', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockCall.mockReset();
+    mockSetAuthToken.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('polls the mail-confirm endpoint with the same code after the otp is removed from the URL', async () => {
+    const ticket: JobTicket = {
+      uid: 'J7f3a9c2e1b8d4a60',
+      group: 'AccountMerge',
+      status: JobStatus.Pending,
+      created: new Date().toISOString(),
+      expectedSeconds: 65,
+    };
+    mockCall.mockResolvedValueOnce(ticket).mockResolvedValueOnce({ kycHash: 'hash-1', accessToken: 'token-1' });
+
+    await act(async () => {
+      render(createElement(AccountMerge));
+      await flushMicrotasks();
+    });
+
+    expect(mockCall).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await flushMicrotasks();
+    });
+
+    expect(mockCall).toHaveBeenCalledTimes(2);
+
+    const firstUrl = mockCall.mock.calls[0][0].url as string;
+    const secondUrl = mockCall.mock.calls[1][0].url as string;
+
+    expect(firstUrl).toBe('auth/mail/confirm?code=otp-secret-42');
+    expect(secondUrl).toBe(firstUrl);
+    expect(secondUrl).not.toContain('code=null');
   });
 });

--- a/src/__tests__/job.hook.test.ts
+++ b/src/__tests__/job.hook.test.ts
@@ -8,7 +8,7 @@ jest.mock('@dfx.swiss/react', () => ({
 }));
 
 jest.mock('@dfx.swiss/react-components', () => {
-  const { createElement } = require('react');
+  const { createElement } = jest.requireActual('react');
   return {
     StyledButton: () => null,
     StyledVerticalStack: ({ children }: any) => createElement('div', null, children),
@@ -16,7 +16,7 @@ jest.mock('@dfx.swiss/react-components', () => {
 });
 
 jest.mock('react-router-dom', () => {
-  const { useState } = require('react');
+  const { useState } = jest.requireActual('react');
   return {
     useSearchParams: () => {
       const [params, setParams] = useState(() => new URLSearchParams('otp=otp-secret-42'));

--- a/src/components/job/job-progress.tsx
+++ b/src/components/job/job-progress.tsx
@@ -1,0 +1,34 @@
+import { SpinnerSize, StyledLoadingSpinner, StyledVerticalStack } from '@dfx.swiss/react-components';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { JobTicket } from 'src/dto/job.dto';
+
+interface JobProgressProps {
+  ticket: JobTicket | undefined;
+  isOverdue: boolean;
+  message: string;
+}
+
+export function JobProgress({ ticket, isOverdue, message }: JobProgressProps): JSX.Element {
+  const { translate } = useSettingsContext();
+
+  return (
+    <StyledVerticalStack center gap={5}>
+      <StyledLoadingSpinner size={SpinnerSize.LG} />
+      <p className="text-dfxGray-700">{message}</p>
+      {ticket && (
+        // Visible so support can look up this exact job by its reference number.
+        <p className="text-xs text-dfxGray-700">
+          {translate('screens/kyc', 'Reference')}: {ticket.uid}
+        </p>
+      )}
+      {isOverdue && (
+        <p className="text-dfxGray-700">
+          {translate(
+            'screens/kyc',
+            'This is taking longer than usual. You can safely close this page — we will keep working in the background.',
+          )}
+        </p>
+      )}
+    </StyledVerticalStack>
+  );
+}

--- a/src/dto/job.dto.ts
+++ b/src/dto/job.dto.ts
@@ -1,0 +1,21 @@
+export enum JobStatus {
+  Pending = 'Pending',
+  Processing = 'Processing',
+  Complete = 'Complete',
+  Failed = 'Failed',
+  DeadLetter = 'DeadLetter',
+}
+
+export interface JobTicket {
+  uid: string;
+  group: string;
+  status: JobStatus;
+  created: string;
+  started?: string;
+  finished?: string;
+  expectedSeconds: number;
+}
+
+export function isJobTicket(value: unknown): value is JobTicket {
+  return typeof value === 'object' && value !== null && 'uid' in value && 'status' in value;
+}

--- a/src/hooks/job.hook.ts
+++ b/src/hooks/job.hook.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { isJobTicket, JobStatus, JobTicket } from 'src/dto/job.dto';
+
+export const JOB_TRACKER_TIMEOUT_ERROR = 'JOB_TRACKER_TIMEOUT';
+
+const TRACKING_TIMEOUT_MS = 600_000;
+const CLOCK_INTERVAL_MS = 1000;
+
+function backoffDelayMs(completedAttempts: number): number {
+  if (completedAttempts === 0) return 1000;
+  if (completedAttempts === 1) return 2000;
+  return 5000;
+}
+
+function isTerminalApiError(err: unknown): err is { statusCode: number; message: string } {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'statusCode' in err &&
+    'message' in err &&
+    ((err as { statusCode: number }).statusCode === 400 ||
+      (err as { statusCode: number }).statusCode === 409)
+  );
+}
+
+export function useJobTracker<T>(fetchResult: () => Promise<T | JobTicket>): {
+  result: T | undefined;
+  ticket: JobTicket | undefined;
+  isOverdue: boolean;
+  error: string | undefined;
+  start: () => void;
+} {
+  const [result, setResult] = useState<T | undefined>();
+  const [ticket, setTicket] = useState<JobTicket | undefined>();
+  const [error, setError] = useState<string | undefined>();
+  const [now, setNow] = useState(() => Date.now());
+
+  const fetchResultRef = useRef(fetchResult);
+  fetchResultRef.current = fetchResult;
+
+  const mountedRef = useRef(true);
+  const trackingRef = useRef(false);
+  const startTimeRef = useRef(0);
+  const attemptCountRef = useRef(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const clockRef = useRef<ReturnType<typeof setInterval>>();
+
+  const clearTimers = useCallback(() => {
+    if (timeoutRef.current !== undefined) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = undefined;
+    }
+    if (clockRef.current !== undefined) {
+      clearInterval(clockRef.current);
+      clockRef.current = undefined;
+    }
+  }, []);
+
+  const stopTracking = useCallback(() => {
+    trackingRef.current = false;
+    clearTimers();
+  }, [clearTimers]);
+
+  const runFetchRef = useRef<() => Promise<void>>(async () => undefined);
+
+  const scheduleNext = useCallback(() => {
+    if (!trackingRef.current || !mountedRef.current) return;
+
+    if (Date.now() - startTimeRef.current >= TRACKING_TIMEOUT_MS) {
+      setError(JOB_TRACKER_TIMEOUT_ERROR);
+      stopTracking();
+      return;
+    }
+
+    const delay = backoffDelayMs(attemptCountRef.current);
+    attemptCountRef.current += 1;
+
+    timeoutRef.current = setTimeout(() => {
+      void runFetchRef.current();
+    }, delay);
+  }, [stopTracking]);
+
+  const runFetch = useCallback(async () => {
+    if (!trackingRef.current || !mountedRef.current) return;
+
+    if (Date.now() - startTimeRef.current >= TRACKING_TIMEOUT_MS) {
+      if (mountedRef.current) setError(JOB_TRACKER_TIMEOUT_ERROR);
+      stopTracking();
+      return;
+    }
+
+    try {
+      const value = await fetchResultRef.current();
+      if (!mountedRef.current || !trackingRef.current) return;
+
+      if (isJobTicket(value)) {
+        setTicket(value);
+        if (value.status === JobStatus.Failed || value.status === JobStatus.DeadLetter) {
+          setError(`Job ${value.status}`);
+          stopTracking();
+          return;
+        }
+        scheduleNext();
+      } else {
+        setResult(value);
+        stopTracking();
+      }
+    } catch (err) {
+      if (!mountedRef.current || !trackingRef.current) return;
+
+      if (isTerminalApiError(err)) {
+        setError(err.message);
+        stopTracking();
+        return;
+      }
+
+      scheduleNext();
+    }
+  }, [scheduleNext, stopTracking]);
+
+  runFetchRef.current = runFetch;
+
+  const start = useCallback(() => {
+    clearTimers();
+    trackingRef.current = true;
+    startTimeRef.current = Date.now();
+    attemptCountRef.current = 0;
+
+    if (mountedRef.current) {
+      setResult(undefined);
+      setTicket(undefined);
+      setError(undefined);
+      setNow(Date.now());
+    }
+
+    clockRef.current = setInterval(() => {
+      if (mountedRef.current) {
+        setNow(Date.now());
+      }
+    }, CLOCK_INTERVAL_MS);
+
+    void runFetch();
+  }, [clearTimers, runFetch]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      trackingRef.current = false;
+      clearTimers();
+    };
+  }, [clearTimers]);
+
+  // expectedSeconds may be omitted at runtime despite the type — do not invent a default threshold.
+  const isOverdue =
+    ticket !== undefined &&
+    result === undefined &&
+    error === undefined &&
+    typeof ticket.expectedSeconds === 'number' &&
+    (now - new Date(ticket.created).getTime()) / 1000 > ticket.expectedSeconds;
+
+  return { result, ticket, isOverdue, error, start };
+}

--- a/src/hooks/job.hook.ts
+++ b/src/hooks/job.hook.ts
@@ -44,6 +44,7 @@ export function useJobTracker<T>(fetchResult: () => Promise<T | JobTicket>): {
   const attemptCountRef = useRef(0);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const clockRef = useRef<ReturnType<typeof setInterval>>();
+  const deadlineTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
   const clearTimers = useCallback(() => {
     if (timeoutRef.current !== undefined) {
@@ -53,6 +54,10 @@ export function useJobTracker<T>(fetchResult: () => Promise<T | JobTicket>): {
     if (clockRef.current !== undefined) {
       clearInterval(clockRef.current);
       clockRef.current = undefined;
+    }
+    if (deadlineTimeoutRef.current !== undefined) {
+      clearTimeout(deadlineTimeoutRef.current);
+      deadlineTimeoutRef.current = undefined;
     }
   }, []);
 
@@ -139,8 +144,14 @@ export function useJobTracker<T>(fetchResult: () => Promise<T | JobTicket>): {
       }
     }, CLOCK_INTERVAL_MS);
 
+    deadlineTimeoutRef.current = setTimeout(() => {
+      if (!trackingRef.current || !mountedRef.current) return;
+      setError(JOB_TRACKER_TIMEOUT_ERROR);
+      stopTracking();
+    }, TRACKING_TIMEOUT_MS);
+
     void runFetch();
-  }, [clearTimers, runFetch]);
+  }, [clearTimers, runFetch, stopTracking]);
 
   useEffect(() => {
     mountedRef.current = true;

--- a/src/screens/account-merge.screen.tsx
+++ b/src/screens/account-merge.screen.tsx
@@ -1,8 +1,10 @@
 import { ApiError, useApi, useAuthContext } from '@dfx.swiss/react';
-import { SpinnerSize, StyledButton, StyledLoadingSpinner, StyledVerticalStack } from '@dfx.swiss/react-components';
+import { StyledButton, StyledVerticalStack } from '@dfx.swiss/react-components';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { JobProgress } from 'src/components/job/job-progress';
 import { useSettingsContext } from 'src/contexts/settings.context';
+import { JOB_TRACKER_TIMEOUT_ERROR, useJobTracker } from 'src/hooks/job.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
 
@@ -22,33 +24,49 @@ export default function AccountMerge() {
 
   const otp = urlParams.get('otp');
 
+  const { result, ticket, isOverdue, error, start } = useJobTracker<MergeRedirect>(() =>
+    call<MergeRedirect>({ url: `auth/mail/confirm?code=${otp}`, method: 'GET' }).catch((e: ApiError) => {
+      // Pre-translate the two known, non-retryable outcomes so the job hook (which stays
+      // translation-agnostic) can just forward `message` verbatim as the terminal error.
+      if (e.statusCode === 400) e.message = translate('screens/error', 'Invalid link');
+      else if (e.statusCode === 409) e.message = translate('screens/error', 'Merge is already completed');
+      throw e;
+    }),
+  );
+
   useEffect(() => {
     if (otp) {
       urlParams.delete('otp');
       setUrlParams(urlParams);
-
-      call<MergeRedirect>({
-        url: `auth/mail/confirm?code=${otp}`,
-        method: 'GET',
-      })
-        .then(({ kycHash, accessToken }: MergeRedirect) => {
-          setAuthToken(accessToken);
-          setKycHash(kycHash);
-        })
-        .catch((error: ApiError) => {
-          const errorMessage =
-            error.statusCode === 400
-              ? translate('screens/error', 'Invalid link')
-              : error.statusCode === 409
-              ? translate('screens/error', 'Merge is already completed')
-              : error.message;
-
-          navigate({ pathname: '/error', search: `msg=${errorMessage}` });
-        });
+      start();
     } else {
       navigate('/kyc');
     }
   }, []);
+
+  useEffect(() => {
+    if (result) {
+      setAuthToken(result.accessToken);
+      setKycHash(result.kycHash);
+    }
+  }, [result]);
+
+  useEffect(() => {
+    if (!error) return;
+
+    const errorMessage =
+      error === JOB_TRACKER_TIMEOUT_ERROR
+        ? ticket
+          ? translate(
+              'screens/kyc',
+              'This is taking longer than expected. Please contact support and reference {{reference}}.',
+              { reference: ticket.uid },
+            )
+          : error
+        : error;
+
+    navigate({ pathname: '/error', search: `msg=${errorMessage}` });
+  }, [error]);
 
   useLayoutOptions({});
 
@@ -67,10 +85,11 @@ export default function AccountMerge() {
           />
         </>
       ) : (
-        <>
-          <StyledLoadingSpinner size={SpinnerSize.LG} />
-          <p className="text-dfxGray-700">{translate('screens/kyc', 'Merging your accounts...')} </p>
-        </>
+        <JobProgress
+          ticket={ticket}
+          isOverdue={isOverdue}
+          message={translate('screens/kyc', 'Merging your accounts...')}
+        />
       )}
     </StyledVerticalStack>
   );

--- a/src/screens/account-merge.screen.tsx
+++ b/src/screens/account-merge.screen.tsx
@@ -1,6 +1,6 @@
 import { ApiError, useApi, useAuthContext } from '@dfx.swiss/react';
 import { StyledButton, StyledVerticalStack } from '@dfx.swiss/react-components';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { JobProgress } from 'src/components/job/job-progress';
 import { useSettingsContext } from 'src/contexts/settings.context';
@@ -23,9 +23,12 @@ export default function AccountMerge() {
   const [kycHash, setKycHash] = useState<string>();
 
   const otp = urlParams.get('otp');
+  // Capture once: deleting otp from the URL below re-renders and would rebuild the
+  // fetch closure with code=null, so every subsequent poll would send a null code.
+  const otpRef = useRef(otp);
 
   const { result, ticket, isOverdue, error, start } = useJobTracker<MergeRedirect>(() =>
-    call<MergeRedirect>({ url: `auth/mail/confirm?code=${otp}`, method: 'GET' }).catch((e: ApiError) => {
+    call<MergeRedirect>({ url: `auth/mail/confirm?code=${otpRef.current}`, method: 'GET' }).catch((e: ApiError) => {
       // Pre-translate the two known, non-retryable outcomes so the job hook (which stays
       // translation-agnostic) can just forward `message` verbatim as the terminal error.
       if (e.statusCode === 400) e.message = translate('screens/error', 'Invalid link');

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -256,6 +256,9 @@
     "Account merged successfully!": "Konto erfolgreich zusammengeführt!",
     "You can now access your account.": "Du kannst jetzt auf Dein Konto zugreifen.",
     "My account": "Mein Konto",
+    "Reference": "Referenz",
+    "This is taking longer than usual. You can safely close this page — we will keep working in the background.": "Dies dauert länger als üblich. Du kannst diese Seite bedenkenlos schliessen — wir arbeiten im Hintergrund weiter.",
+    "This is taking longer than expected. Please contact support and reference {{reference}}.": "Dies dauert länger als erwartet. Bitte kontaktiere den Support und gib die Referenz {{reference}} an.",
 
     "Upload your SEPA file here": "Lade Deine SEPA-Datei hier hoch",
     "Uploaded": "Hochgeladen",

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -256,6 +256,9 @@
     "Account merged successfully!": "Compte fusionné avec succès!",
     "You can now access your account.": "Vous pouvez maintenant accéder à votre compte.",
     "My account": "Mon compte",
+    "Reference": "Référence",
+    "This is taking longer than usual. You can safely close this page — we will keep working in the background.": "Cela prend plus de temps que d'habitude. Vous pouvez fermer cette page en toute sécurité — nous continuons à travailler en arrière-plan.",
+    "This is taking longer than expected. Please contact support and reference {{reference}}.": "Cela prend plus de temps que prévu. Veuillez contacter le support et mentionner la référence {{reference}}.",
 
     "Upload your SEPA file here": "Téléchargez votre fichier SEPA ici",
     "Uploaded": "Téléchargé",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -256,6 +256,9 @@
     "Account merged successfully!": "Account unito con successo!",
     "You can now access your account.": "Ora puoi accedere al tuo account.",
     "My account": "Il mio account",
+    "Reference": "Riferimento",
+    "This is taking longer than usual. You can safely close this page — we will keep working in the background.": "Questo richiede più tempo del solito. Puoi chiudere questa pagina in tutta sicurezza — continueremo a lavorare in background.",
+    "This is taking longer than expected. Please contact support and reference {{reference}}.": "Questo richiede più tempo del previsto. Contatta l'assistenza e indica il riferimento {{reference}}.",
 
     "Upload your SEPA file here": "Carica il tuo file SEPA qui",
     "Uploaded": "Caricato",


### PR DESCRIPTION
## Why

`GET auth/mail/confirm` — the account merge — takes 16.4 s at the 95th percentile in production. That is far past the point where holding a request open is the right shape, so the endpoint now answers with a ticket once the work does not finish inside the request. This is the client side of that.

## What

- `hooks/job.hook.ts` — `useJobTracker` follows a ticket to its result by re-calling the same endpoint, with a 1 s / 2 s / 5 s backoff and a ten-minute cap.
- `components/job/job-progress.tsx` — reusable progress view: spinner, message, and the ticket number.
- `screens/account-merge.screen.tsx` — uses the tracker instead of a single call and a bare spinner.
- Three translation keys added to every language file.

## What does not change

The immediate-result path behaves exactly as before, including `setAuthToken` and the `kycHash` view, and so do the 400 (`Invalid link`) and 409 (`Merge is already completed`) cases. A client talking to an API that still answers synchronously sees no difference.

## Design decisions worth reviewing

**The ticket number is on screen.** It is the key support needs to find one specific merge instead of searching a time window, and it is also what the timeout message carries.

**A transient failure keeps the tracking alive**; only 400 and 409 are treated as final, since those are statements about the link rather than about the network.

**No new dependency and no new package version** — the existing `useApi().call` already treats a 202 as a success, so the tracker rides on what is there.

**`isOverdue` comes from the server's `expectedSeconds`**, not from a threshold hardcoded in the frontend, so the "taking longer than usual" hint follows the configured limit instead of drifting away from it.
