### PR TITLE
Keep polling the payment wait endpoint when it times out

### DIFF
--- a/src/__tests__/payment-link-pos-wait-retry.test.tsx
+++ b/src/__tests__/payment-link-pos-wait-retry.test.tsx
@@ -1,0 +1,82 @@
+const mockCall = jest.fn();
+const mockFetchJson = jest.fn();
+
+jest.mock('@dfx.swiss/react', () => ({
+  useApi: () => ({ call: mockCall }),
+  PaymentLinkPaymentStatus: {
+    PENDING: 'Pending',
+    COMPLETED: 'Completed',
+    CANCELLED: 'Cancelled',
+    EXPIRED: 'Expired',
+  },
+}));
+
+jest.mock('react-router-dom', () => ({
+  useSearchParams: () => [new URLSearchParams({ lightning: 'LNURL1TEST', key: 'test-key' })],
+}));
+
+jest.mock('src/util/lnurl', () => ({
+  Lnurl: { decode: () => 'https://api.example.com/v1/paymentLink/payment?route=test' },
+}));
+
+jest.mock('src/util/utils', () => ({
+  fetchJson: (...args: any[]) => mockFetchJson(...args),
+  url: () => 'https://app.example.com/pl/pos',
+}));
+
+import { act, render, waitFor } from '@testing-library/react';
+import PaymentLinkPosContext from '../contexts/payment-link-pos.context';
+
+const waitCalls = () => mockCall.mock.calls.filter(([request]) => request.url.startsWith('paymentLink/payment/wait'));
+
+async function advance(ms: number) {
+  await act(async () => {
+    jest.advanceTimersByTime(ms);
+    // let the retry chain (checkIsPendingPayment, then the wait call) settle
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+  });
+}
+
+function respondToWaitWith(error: { statusCode: number }) {
+  mockCall.mockImplementation(async ({ url }: { url: string }) => {
+    if (url.startsWith('paymentLink/payment/wait')) throw error;
+
+    // history, used both for authentication and for the pending-payment check
+    return [{ payments: [{ status: 'Pending' }] }];
+  });
+}
+
+describe('PaymentLinkPosContext wait retry', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockCall.mockReset();
+    mockFetchJson.mockReset();
+    mockFetchJson.mockResolvedValue({ externalId: 'ext-1' });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should ask again after a timeout', async () => {
+    respondToWaitWith({ statusCode: 408 });
+
+    render(<PaymentLinkPosContext>{null}</PaymentLinkPosContext>);
+    await waitFor(() => expect(waitCalls()).toHaveLength(1));
+
+    await advance(2 * 1000);
+
+    expect(waitCalls().length).toBeGreaterThan(1);
+  });
+
+  it('should stop asking once the session is gone', async () => {
+    respondToWaitWith({ statusCode: 401 });
+
+    render(<PaymentLinkPosContext>{null}</PaymentLinkPosContext>);
+    await waitFor(() => expect(waitCalls()).toHaveLength(1));
+
+    await advance(30 * 1000);
+
+    expect(waitCalls()).toHaveLength(1);
+  });
+});

--- a/src/__tests__/polling.test.ts
+++ b/src/__tests__/polling.test.ts
@@ -138,6 +138,29 @@ describe('usePolling', () => {
     expect(mockFetchJson).toHaveBeenCalledTimes(1);
   });
 
+  it('should poll again for the same URL after being stopped', async () => {
+    // a wait poll keeps the same URL for as long as the payment is pending, so a restart
+    // after stop() has to work — otherwise the payment is never picked up again
+    const { result } = renderHook(() => usePolling());
+    const callback = jest.fn();
+
+    await act(async () => {
+      result.current.init('https://api.example.com', callback);
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.stop();
+    });
+
+    await act(async () => {
+      result.current.init('https://api.example.com', callback);
+      await Promise.resolve();
+    });
+
+    expect(mockFetchJson).toHaveBeenCalledTimes(2);
+  });
+
   it('should clean up interval on unmount', async () => {
     const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
     

--- a/src/contexts/payment-link-pos.context.tsx
+++ b/src/contexts/payment-link-pos.context.tsx
@@ -1,5 +1,5 @@
 import { ApiError, PaymentLink, PaymentLinkPaymentStatus, useApi } from '@dfx.swiss/react';
-import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   ExtendedPaymentLinkStatus,
@@ -43,6 +43,14 @@ export default function PaymentLinkPosContext({ children }: { children: React.Re
 
   const lightning = urlParams.get('lightning') ?? undefined;
   const key = urlParams.get('key') ?? '';
+
+  const waitRetryTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => {
+      if (waitRetryTimer.current) clearTimeout(waitRetryTimer.current);
+    };
+  }, []);
 
   const fetchPayRequest = async (url: string) => {
     const api = new URL(url);
@@ -94,10 +102,13 @@ export default function PaymentLinkPosContext({ children }: { children: React.Re
       .then(({ payment }) => setPaymentStatus(payment.status))
       .catch(unauthorizedResponse)
       // The wait call answers 408 once its window closes, which lands here like any other
-      // error. Wait a moment before asking again, so an error that comes back immediately
-      // cannot turn this retry into a tight loop.
-      .catch(() => {
-        setTimeout(fetchWait, 2 * 1000);
+      // error. Ask again after a moment, so an error that comes back immediately cannot turn
+      // this retry into a tight loop — but stop once the session is gone, since re-asking
+      // without a valid key only repeats the same 401.
+      .catch((e: ApiError) => {
+        if (e.statusCode === 401) return;
+
+        waitRetryTimer.current = setTimeout(fetchWait, 2 * 1000);
       });
   };
 

--- a/src/contexts/payment-link-pos.context.tsx
+++ b/src/contexts/payment-link-pos.context.tsx
@@ -44,11 +44,16 @@ export default function PaymentLinkPosContext({ children }: { children: React.Re
   const lightning = urlParams.get('lightning') ?? undefined;
   const key = urlParams.get('key') ?? '';
 
-  const waitRetryTimer = useRef<ReturnType<typeof setTimeout>>();
+  // a set, not a single id: creating a payment starts a wait of its own, so more than one
+  // retry can be pending at a time and a single slot would lose the older one
+  const waitRetryTimers = useRef(new Set<ReturnType<typeof setTimeout>>());
 
   useEffect(() => {
+    const timers = waitRetryTimers.current;
+
     return () => {
-      if (waitRetryTimer.current) clearTimeout(waitRetryTimer.current);
+      timers.forEach(clearTimeout);
+      timers.clear();
     };
   }, []);
 
@@ -108,7 +113,12 @@ export default function PaymentLinkPosContext({ children }: { children: React.Re
       .catch((e: ApiError) => {
         if (e.statusCode === 401) return;
 
-        waitRetryTimer.current = setTimeout(fetchWait, 2 * 1000);
+        const timer = setTimeout(() => {
+          waitRetryTimers.current.delete(timer);
+          void fetchWait();
+        }, 2 * 1000);
+
+        waitRetryTimers.current.add(timer);
       });
   };
 

--- a/src/contexts/payment-link-pos.context.tsx
+++ b/src/contexts/payment-link-pos.context.tsx
@@ -93,7 +93,12 @@ export default function PaymentLinkPosContext({ children }: { children: React.Re
     })
       .then(({ payment }) => setPaymentStatus(payment.status))
       .catch(unauthorizedResponse)
-      .catch(fetchWait);
+      // The wait call answers 408 once its window closes, which lands here like any other
+      // error. Wait a moment before asking again, so an error that comes back immediately
+      // cannot turn this retry into a tight loop.
+      .catch(() => {
+        setTimeout(fetchWait, 2 * 1000);
+      });
   };
 
   const createPayment = useCallback(

--- a/src/contexts/payment-link.context.tsx
+++ b/src/contexts/payment-link.context.tsx
@@ -317,6 +317,11 @@ export function PaymentLinkProvider(props: PropsWithChildren): JSX.Element {
     });
 
     initWaitPolling(lnurlpUrl, (response) => {
+      // The wait endpoint caps how long it blocks and answers 408 while the payment is
+      // still pending. That is not a result — keep the poll running, otherwise the
+      // payment would never be picked up (init() ignores a repeat call for the same URL).
+      if (response.statusCode === 408) return;
+
       stopWaitPolling();
 
       if (response.status === PaymentLinkPaymentStatus.COMPLETED && redirectUri) {

--- a/src/hooks/polling.ts
+++ b/src/hooks/polling.ts
@@ -41,6 +41,9 @@ export function usePolling({ timeInterval = 3 * 1000 }: { timeInterval?: number 
 
   const stop = () => {
     if (internalId.current) clearInterval(internalId.current);
+    // release the URL as well: init() skips a call for the URL it is already polling, so
+    // keeping it would make a later restart on the same URL a silent no-op
+    url.current = undefined;
     setIsPolling(false);
   };
 


### PR DESCRIPTION
## Why

The API is about to cap how long `GET /v1/lnurlp/wait/{id}` blocks and answer **HTTP 408** while the payment is still pending (DFXswiss/api#4502, implemented in DFXswiss/api#4533). Today that request is instead cut off by the CDN after 125 s with a gateway error page.

That difference matters here. `fetchJson` (`src/util/utils.ts`) returns the parsed body regardless of status, so today's non-JSON error page makes the promise reject and the poll interval keeps running — the widget recovers by accident. A JSON 408 would instead arrive in the **success** callback, which calls `stopWaitPolling()`. And `usePolling.init()` returned early when called again with the same URL, which is exactly what happens for a wait poll (the URL is derived from the payment and does not change while it is pending). The poll would stop for good and the completed payment would never be picked up.

## What

**`payment-link.context.tsx`** — a 408 in the wait callback is treated as "nothing decided yet" and the poll continues.

**`polling.ts`** — `stop()` now also releases `url.current`. It previously kept it, so a restart on the same URL was silently ignored: every stop on a still-pending payment was final. That was the trap the 408 guard had to work around; it is now gone, and a test covers the restart.

**`payment-link-pos.context.tsx`** — the POS terminal reaches the same endpoint through `call()`, which throws on any non-2xx, so its `.catch` chain already re-issued the wait. Three things were wrong with that retry once 408 becomes a regular occurrence:

- it retried immediately, so an error returning at once would spin;
- it retried a 401 as well, so a terminal whose session had gone re-asked every two seconds for as long as it stayed open;
- the retry timers were untracked, so a pending retry fired for a terminal nobody was using anymore.

The retry now waits, skips the unauthorized case, and every pending timer is cleared on unmount. Because creating a payment starts a wait of its own, the timers are held in a set rather than a single slot — otherwise the older one is lost and fires unattended.

## Tests

`polling.test.ts` covers the restart after stop; `payment-link-pos-wait-retry.test.tsx` covers both retry rules (ask again after a timeout, stop once the session is gone).

## Deployment order

This has to go out **before** the API-side cap.