### PR TITLE
refactor: use the SDK blockchain client

### DIFF
--- a/src/hooks/blockchain-balance.hook.ts
+++ b/src/hooks/blockchain-balance.hook.ts
@@ -1,40 +1,20 @@
-import { Asset, Blockchain, useApi } from '@dfx.swiss/react';
+import { Asset, Blockchain, useBlockchain } from '@dfx.swiss/react';
 import { useMemo } from 'react';
 import { AssetBalance } from 'src/contexts/balance.context';
-
-interface BalanceDto {
-  assetId: number;
-  chainId?: string;
-  balance: number;
-}
-
-interface GetBalancesResponse {
-  balances: BalanceDto[];
-}
 
 export interface BlockchainBalanceInterface {
   getAddressBalances: (assets: Asset[], address: string, blockchain: Blockchain) => Promise<AssetBalance[]>;
 }
 
 export function useBlockchainBalance(): BlockchainBalanceInterface {
-  const { call } = useApi();
+  const { getBalances } = useBlockchain();
 
   async function getAddressBalances(
     assets: Asset[],
     address: string,
     blockchain: Blockchain,
   ): Promise<AssetBalance[]> {
-    const assetIds = assets.map((a) => a.id);
-
-    const response = await call<GetBalancesResponse>({
-      url: 'blockchain/balances',
-      method: 'POST',
-      data: {
-        address,
-        blockchain,
-        assetIds,
-      },
-    });
+    const response = await getBalances({ address, blockchain, assetIds: assets.map((a) => a.id) });
 
     return response.balances
       .map((b) => {
@@ -44,5 +24,5 @@ export function useBlockchainBalance(): BlockchainBalanceInterface {
       .filter((b): b is AssetBalance => b !== undefined);
   }
 
-  return useMemo(() => ({ getAddressBalances }), [call]);
+  return useMemo(() => ({ getAddressBalances }), [getBalances]);
 }

--- a/src/hooks/blockchain-transaction.hook.ts
+++ b/src/hooks/blockchain-transaction.hook.ts
@@ -1,17 +1,6 @@
-import { Asset, Blockchain, useApi } from '@dfx.swiss/react';
+import { Asset, Blockchain, useBlockchain } from '@dfx.swiss/react';
 import * as Solana from '@solana/web3.js';
 import { useMemo } from 'react';
-
-interface UnsignedTransactionDto {
-  rawTransaction: string;
-  encoding: 'base64' | 'hex';
-  recentBlockhash?: string;
-  expiration?: number;
-}
-
-interface BroadcastResultDto {
-  txHash: string;
-}
 
 export interface BlockchainTransactionInterface {
   createSolanaTransaction: (
@@ -30,7 +19,7 @@ export interface BlockchainTransactionInterface {
 }
 
 export function useBlockchainTransaction(): BlockchainTransactionInterface {
-  const { call } = useApi();
+  const { createTransaction, broadcastTransaction: broadcast } = useBlockchain();
 
   async function createSolanaTransaction(
     fromAddress: string,
@@ -38,16 +27,12 @@ export function useBlockchainTransaction(): BlockchainTransactionInterface {
     amount: number,
     asset?: Asset,
   ): Promise<Solana.Transaction> {
-    const response = await call<UnsignedTransactionDto>({
-      url: 'blockchain/transaction',
-      method: 'POST',
-      data: {
-        blockchain: Blockchain.SOLANA,
-        fromAddress,
-        toAddress,
-        amount,
-        assetId: asset?.id,
-      },
+    const response = await createTransaction({
+      blockchain: Blockchain.SOLANA,
+      fromAddress,
+      toAddress,
+      amount,
+      assetId: asset?.id,
     });
 
     // Deserialize the transaction from base64
@@ -61,16 +46,12 @@ export function useBlockchainTransaction(): BlockchainTransactionInterface {
     amount: number,
     asset?: Asset,
   ): Promise<object> {
-    const response = await call<UnsignedTransactionDto>({
-      url: 'blockchain/transaction',
-      method: 'POST',
-      data: {
-        blockchain: Blockchain.TRON,
-        fromAddress,
-        toAddress,
-        amount,
-        assetId: asset?.id,
-      },
+    const response = await createTransaction({
+      blockchain: Blockchain.TRON,
+      fromAddress,
+      toAddress,
+      amount,
+      assetId: asset?.id,
     });
 
     // Parse the transaction JSON
@@ -78,17 +59,12 @@ export function useBlockchainTransaction(): BlockchainTransactionInterface {
   }
 
   async function broadcastTransaction(blockchain: Blockchain, signedTransaction: string): Promise<string> {
-    const response = await call<BroadcastResultDto>({
-      url: 'blockchain/broadcast',
-      method: 'POST',
-      data: {
-        blockchain,
-        signedTransaction,
-      },
-    });
-
-    return response.txHash;
+    const { txHash } = await broadcast({ blockchain, signedTransaction });
+    return txHash;
   }
 
-  return useMemo(() => ({ createSolanaTransaction, createTronTransaction, broadcastTransaction }), [call]);
+  return useMemo(
+    () => ({ createSolanaTransaction, createTronTransaction, broadcastTransaction }),
+    [createTransaction, broadcast],
+  );
 }


### PR DESCRIPTION
Consumer side of step 5 of DFXswiss/packages#198: use the blockchain client from `@dfx.swiss/react`
instead of a local `useApi()` wrapper.

Depends on DFXswiss/packages#203.

## Changes

Both local hooks stay — what changes is what they call. The HTTP layer and the request/response types
now come from the package; the chain-specific parts stay here, which is exactly the split the package
side was built for:

- `blockchain-balance.hook.ts` keeps the join against the asset list (the API answers with asset ids)
  and drops its local `BalanceDto` / `GetBalancesResponse`.
- `blockchain-transaction.hook.ts` keeps the Solana base64 deserialization and the Tron JSON parsing
  and drops its local `UnsignedTransactionDto` / `BroadcastResultDto`.

No call site of either hook changes.

## Before this can go green

The package pin in `package.json` still points at the published `@dfx.swiss/react`, which does not
export `useBlockchain` yet. **CI stays red until DFXswiss/packages#203 is merged and published and
the pin is raised here.** Verified locally against a build of that branch: `tsc` clean,
`npm run lint` clean, full suite at 673 passing with no new failures (the two suites failing on
`develop` today still fail, unchanged).
