### PR TITLE
refactor: use the SDK payment link pay flow contract

### DIFF
--- a/src/__tests__/payment-link-wallet.test.ts
+++ b/src/__tests__/payment-link-wallet.test.ts
@@ -2,7 +2,8 @@
 jest.mock('src/dto/payment-link.dto', () => ({}));
 
 import { Wallet } from '../util/payment-link-wallet';
-import { TransferInfo, WalletInfo } from 'src/dto/payment-link.dto';
+import { TransferAmount } from '@dfx.swiss/react';
+import { WalletInfo } from 'src/dto/payment-link.dto';
 
 describe('Wallet', () => {
   // Test data
@@ -11,11 +12,11 @@ describe('Wallet', () => {
     supportedAssets: assets,
   } as WalletInfo);
 
-  const createTransferInfo = (method: string, assets: string[], available = true): TransferInfo => ({
+  const createTransferInfo = (method: string, assets: string[], available = true): TransferAmount => ({
     method,
     assets: assets.map(name => ({ asset: name })),
     available,
-  } as TransferInfo);
+  } as TransferAmount);
 
   describe('filterTransferInfoByWallet', () => {
     it('should return empty array if no methods match', () => {

--- a/src/contexts/payment-link-pos.context.tsx
+++ b/src/contexts/payment-link-pos.context.tsx
@@ -1,12 +1,8 @@
 import { ApiError, PaymentLink, PaymentLinkPaymentStatus, useApi } from '@dfx.swiss/react';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import {
-  ExtendedPaymentLinkStatus,
-  NoPaymentLinkPaymentStatus,
-  PaymentLinkHistory,
-  PaymentLinkPayRequest,
-} from 'src/dto/payment-link.dto';
+import { PaymentLinkHistory, PaymentLinkPayRequest } from '@dfx.swiss/react';
+import { ExtendedPaymentLinkStatus, NoPaymentLinkPaymentStatus } from 'src/dto/payment-link.dto';
 import { Lnurl } from 'src/util/lnurl';
 import { fetchJson, url } from 'src/util/utils';
 

--- a/src/contexts/payment-link.context.tsx
+++ b/src/contexts/payment-link.context.tsx
@@ -23,14 +23,14 @@ import { Api } from 'src/config/api';
 import { CloseType, useAppHandlingContext } from 'src/contexts/app-handling.context';
 import { AssetBalance } from 'src/contexts/balance.context';
 import {
-  Amount,
-  ExtendedPaymentLinkStatus,
-  MetaMaskInfo,
-  NoPaymentLinkPaymentStatus,
+  PaymentAmount,
   PaymentLinkPayRequest,
+  PaymentLinkPayResponse,
   PaymentLinkPayTerminal,
   PaymentStandard,
-} from 'src/dto/payment-link.dto';
+  hasPaymentQuote as hasQuoteField,
+} from '@dfx.swiss/react';
+import { ExtendedPaymentLinkStatus, MetaMaskInfo, NoPaymentLinkPaymentStatus } from 'src/dto/payment-link.dto';
 import { usePolling } from 'src/hooks/polling';
 import { useSessionStore } from 'src/hooks/session-store.hook';
 import { Evm } from 'src/util/evm';
@@ -237,14 +237,14 @@ export function PaymentLinkProvider(props: PropsWithChildren): JSX.Element {
     try {
       const urlObj = new URL(url);
       urlObj.searchParams.set('timeout', '0');
-      const payRequest = await fetchJson<PaymentLinkPayRequest>(urlObj);
+      const payRequest = await fetchJson<PaymentLinkPayResponse>(urlObj);
 
       if (merchantMode) {
         setPayRequest(payRequest);
         return;
       }
 
-      if (payRequest.statusCode === 400 && payRequest.message?.includes('not assigned')) {
+      if (!hasQuoteField(payRequest) && payRequest.statusCode === 400 && payRequest.message.includes('not assigned')) {
         setPayRequest(payRequest);
         navigate('/pl/assign');
         return;
@@ -255,7 +255,8 @@ export function PaymentLinkProvider(props: PropsWithChildren): JSX.Element {
       setPayRequest(payRequest);
       setPaymentStatus(status);
 
-      if (status === PaymentLinkPaymentStatus.PENDING) {
+      // A pending status is only ever derived from a quoted response, but the type cannot know that.
+      if (status === PaymentLinkPaymentStatus.PENDING && hasQuoteField(payRequest)) {
         return waitPayment(payRequest);
       }
 
@@ -470,7 +471,7 @@ export function PaymentLinkProvider(props: PropsWithChildren): JSX.Element {
   async function findAssetWithBalance(
     address: string,
     blockchain: Blockchain,
-    transferAmounts: Amount[],
+    transferAmounts: PaymentAmount[],
   ): Promise<AssetBalance | undefined> {
     transferAmounts.sort((a, b) => (a.asset === 'dEURO' ? -1 : b.asset === 'dEURO' ? 1 : 0));
 

--- a/src/dto/payment-link.dto.ts
+++ b/src/dto/payment-link.dto.ts
@@ -1,90 +1,4 @@
-import { Asset, Blockchain, PaymentLinkMode, PaymentLinkPaymentStatus, PaymentStandardType } from '@dfx.swiss/react';
-
-export interface PaymentStandard {
-  id: PaymentStandardType;
-  label: string;
-  description: string;
-  paymentIdentifierLabel?: string;
-  blockchain?: Blockchain;
-}
-
-export interface Quote {
-  id: string;
-  expiration: Date;
-  payment: string;
-}
-
-export interface Amount {
-  asset: string;
-  amount?: number;
-}
-
-export enum C2BPaymentMethod {
-  BINANCE_PAY = 'BinancePay',
-  KUCOINPAY = 'KucoinPay',
-}
-
-export type TransferMethod = Blockchain | C2BPaymentMethod;
-
-export interface TransferInfo {
-  method: TransferMethod;
-  minFee: number;
-  assets: Amount[];
-  available?: boolean;
-}
-
-export interface RecipientInfo {
-  address?: {
-    city: string;
-    country: string;
-    houseNumber: string;
-    street: string;
-    zip: string;
-  };
-  name?: string;
-  mail?: string;
-  phone?: string;
-  website?: string;
-}
-
-export interface PaymentLinkPayTerminal {
-  id: string;
-  externalId?: string;
-  tag: string;
-  displayName: string;
-  standard: PaymentStandardType;
-  possibleStandards: PaymentStandardType[];
-  displayQr: boolean;
-  mode: PaymentLinkMode;
-  route: string;
-  currency: string;
-  recipient: RecipientInfo;
-  transferAmounts: TransferInfo[];
-
-  // error fields
-  statusCode?: number;
-  message?: string;
-  error?: string;
-}
-
-export enum NoPaymentLinkPaymentStatus {
-  NO_PAYMENT = 'NoPayment',
-}
-
-export type ExtendedPaymentLinkStatus = PaymentLinkPaymentStatus | NoPaymentLinkPaymentStatus;
-
-export interface PaymentStatus {
-  status: PaymentLinkPaymentStatus;
-}
-
-export interface PaymentLinkPayRequest extends PaymentLinkPayTerminal {
-  quote: Quote;
-  callback: string;
-  metadata: string;
-  minSendable: number;
-  maxSendable: number;
-  requestedAmount: Amount;
-}
+import { Asset, PaymentLinkPaymentStatus, TransferMethod } from '@dfx.swiss/react';
 
 export interface WalletInfo {
   id: number;
@@ -109,16 +23,14 @@ export interface MetaMaskInfo {
   minFee: number;
 }
 
-export interface PaymentLinkHistory extends PaymentLinkPayRequest {
-  payments: PaymentLinkHistoryPayment[];
-  totalCompletedAmount: number;
+/** Screen state for a terminal with no active payment. Not a status the API ever sends. */
+export enum NoPaymentLinkPaymentStatus {
+  NO_PAYMENT = 'NoPayment',
 }
 
-export interface PaymentLinkHistoryPayment {
-  id: string;
+export type ExtendedPaymentLinkStatus = PaymentLinkPaymentStatus | NoPaymentLinkPaymentStatus;
+
+/** Shape of the LNURL wait response, which reports the status on its own. */
+export interface PaymentStatus {
   status: PaymentLinkPaymentStatus;
-  amount: number;
-  currency: string;
-  date: Date;
-  externalId: string;
 }

--- a/src/hooks/payment-link-wallets.hook.ts
+++ b/src/hooks/payment-link-wallets.hook.ts
@@ -1,8 +1,8 @@
-import { Blockchain, PaymentLinkMode } from '@dfx.swiss/react';
+import { Blockchain, C2BPaymentMethod, PaymentLinkMode, TransferMethod } from '@dfx.swiss/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Api } from 'src/config/api';
 import { usePaymentLinkContext } from 'src/contexts/payment-link.context';
-import { C2BPaymentMethod, TransferMethod, WalletInfo } from 'src/dto/payment-link.dto';
+import { WalletInfo } from 'src/dto/payment-link.dto';
 import { Wallet } from 'src/util/payment-link-wallet';
 import { fetchJson, url } from 'src/util/utils';
 
@@ -118,7 +118,7 @@ export const usePaymentLinkWallets = (): PaymentLinkWalletsProps => {
 
       case 'KuCoin Pay':
         const { uri: kucoinUri } =
-          (await fetchCallbackUrlForTransferMethod<{ uri: string }>(C2BPaymentMethod.KUCOINPAY)) ?? {};
+          (await fetchCallbackUrlForTransferMethod<{ uri: string }>(C2BPaymentMethod.KUCOIN_PAY)) ?? {};
         return kucoinUri;
 
       default:

--- a/src/screens/payment-link-assign.screen.tsx
+++ b/src/screens/payment-link-assign.screen.tsx
@@ -1,4 +1,4 @@
-import { ApiError, Utils, Validations } from '@dfx.swiss/react';
+import { ApiError, Utils, Validations, hasPaymentQuote } from '@dfx.swiss/react';
 import { Form, StyledButton, StyledButtonWidth, StyledInput, StyledVerticalStack } from '@dfx.swiss/react-components';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -25,7 +25,7 @@ export default function PaymentLinkAssignScreen(): JSX.Element {
   useEffect(() => {
     if (!payRequest) {
       navigate('/');
-    } else if (payRequest.statusCode !== 400) {
+    } else if (hasPaymentQuote(payRequest) || payRequest.statusCode !== 400) {
       navigate('/pl');
     }
   }, [payRequest]);

--- a/src/screens/payment-link-pos.screen.tsx
+++ b/src/screens/payment-link-pos.screen.tsx
@@ -21,7 +21,7 @@ import { Modal } from 'src/components/modal';
 import { QrBasic } from 'src/components/payment/qr-code';
 import { usePaymentPosContext } from 'src/contexts/payment-link-pos.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
-import { PaymentLinkHistory } from 'src/dto/payment-link.dto';
+import { PaymentLinkHistory } from '@dfx.swiss/react';
 import { useClipboard } from 'src/hooks/clipboard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';

--- a/src/screens/payment-link.screen.tsx
+++ b/src/screens/payment-link.screen.tsx
@@ -53,12 +53,12 @@ import { usePaymentLinkContext } from 'src/contexts/payment-link.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useWindowContext } from 'src/contexts/window.context';
 import {
-  NoPaymentLinkPaymentStatus,
   PaymentLinkPayRequest,
-  PaymentLinkPayTerminal,
+  PaymentLinkPayResponse,
   PaymentStandard,
-  WalletInfo,
-} from 'src/dto/payment-link.dto';
+  hasPaymentQuote,
+} from '@dfx.swiss/react';
+import { NoPaymentLinkPaymentStatus, WalletInfo } from 'src/dto/payment-link.dto';
 import { useNavigation } from 'src/hooks/navigation.hook';
 import { usePaymentLinkWallets } from 'src/hooks/payment-link-wallets.hook';
 import { useWeb3 } from 'src/hooks/web3.hook';
@@ -364,10 +364,14 @@ export default function PaymentLinkScreen(): JSX.Element {
                                 label: translate('screens/home', 'Mode'),
                                 text: payRequest.mode,
                               },
-                              {
-                                label: translate('screens/payment', 'Tag'),
-                                text: payRequest.tag,
-                              },
+                              ...(hasPaymentQuote(payRequest)
+                                ? [
+                                    {
+                                      label: translate('screens/payment', 'Tag'),
+                                      text: payRequest.tag,
+                                    },
+                                  ]
+                                : []),
                               {
                                 label: translate('screens/payment', 'Route'),
                                 text: payRequest.route,
@@ -878,7 +882,7 @@ function WalletLogo({ wallet, size }: { wallet: WalletInfo; size: number }): JSX
   );
 }
 
-function CreatePublicPaymentForm({ paymentRequest }: { paymentRequest: PaymentLinkPayTerminal }): JSX.Element {
+function CreatePublicPaymentForm({ paymentRequest }: { paymentRequest: PaymentLinkPayResponse }): JSX.Element {
   const { call } = useApi();
   const { translate, translateError } = useSettingsContext();
   const [isActivating, setIsActivating] = useState(false);
@@ -900,7 +904,7 @@ function CreatePublicPaymentForm({ paymentRequest }: { paymentRequest: PaymentLi
     setIsActivating(true);
     const params = new URLSearchParams({
       externalLinkId: paymentRequest.externalId as string,
-      route: paymentRequest.route,
+      ...(paymentRequest.route ? { route: paymentRequest.route } : {}),
     });
 
     return call<PaymentLink>({
@@ -931,7 +935,7 @@ function CreatePublicPaymentForm({ paymentRequest }: { paymentRequest: PaymentLi
           </p>
           <StyledInput
             label={translate('screens/payment', 'Amount in {{currencyName}}', {
-              currencyName: paymentRequest.currency,
+              currencyName: paymentRequest.currency ?? '',
             })}
             name="amount"
             control={control}
@@ -955,7 +959,7 @@ function CreatePublicPaymentForm({ paymentRequest }: { paymentRequest: PaymentLi
   );
 }
 
-function EditPublicPaymentForm({ paymentRequest }: { paymentRequest: PaymentLinkPayTerminal }): JSX.Element {
+function EditPublicPaymentForm({ paymentRequest }: { paymentRequest: PaymentLinkPayResponse }): JSX.Element {
   const { call } = useApi();
   const { translate, translateError } = useSettingsContext();
   const [isEditing, setIsEditing] = useState(false);
@@ -969,7 +973,7 @@ function EditPublicPaymentForm({ paymentRequest }: { paymentRequest: PaymentLink
     setIsEditing(true);
     const params = new URLSearchParams({
       externalLinkId: paymentRequest.externalId as string,
-      route: paymentRequest.route,
+      ...(paymentRequest.route ? { route: paymentRequest.route } : {}),
     });
 
     return call<PaymentLink>({

--- a/src/util/payment-link-wallet.ts
+++ b/src/util/payment-link-wallet.ts
@@ -1,19 +1,20 @@
-import { TransferInfo, WalletInfo } from 'src/dto/payment-link.dto';
+import { TransferAmount } from '@dfx.swiss/react';
+import { WalletInfo } from 'src/dto/payment-link.dto';
 
 export class Wallet {
-  static filterTransferInfoByWallet(wallet: WalletInfo, transferInfoList: TransferInfo[]): TransferInfo[] {
-    return transferInfoList.map((ta) => this.filterCompatible(wallet, ta)).filter(Boolean) as TransferInfo[];
+  static filterTransferInfoByWallet(wallet: WalletInfo, transferInfoList: TransferAmount[]): TransferAmount[] {
+    return transferInfoList.map((ta) => this.filterCompatible(wallet, ta)).filter(Boolean) as TransferAmount[];
   }
 
-  static qualifiesForPayment(wallet: WalletInfo, transferInfoList: TransferInfo[]): boolean {
+  static qualifiesForPayment(wallet: WalletInfo, transferInfoList: TransferAmount[]): boolean {
     return transferInfoList.some((ta) => this.filterCompatible(wallet, ta));
   }
 
   private static filterCompatible(
     wallet: WalletInfo,
-    transferInfo: TransferInfo,
+    transferInfo: TransferAmount,
     isAvailable = true,
-  ): TransferInfo | undefined {
+  ): TransferAmount | undefined {
     const { method, assets, available } = transferInfo;
     if (isAvailable && available === false) return undefined;
 


### PR DESCRIPTION
Consumer side of step 3 of DFXswiss/packages#198: use the payment link pay-flow contract from
`@dfx.swiss/react` and drop the local copies.

Depends on DFXswiss/packages#201.

## Changes

`src/dto/payment-link.dto.ts` keeps only what is genuinely local — `WalletInfo`, `MetaMaskInfo`, the
UI-only `NoPaymentLinkPaymentStatus` / `ExtendedPaymentLinkStatus`, and the LNURL wait shape. Everything
that describes the wire now comes from the package, under the package's names:

| here, before | package |
|---|---|
| `TransferInfo` | `TransferAmount` |
| `Amount` | `PaymentAmount` |
| `RecipientInfo` | `PaymentLinkRecipient` |
| `Quote` | `PaymentQuote` |

## What the corrected types surfaced

The local copy had `PaymentLinkPayRequest extends PaymentLinkPayTerminal`, so error fields and quote
fields lived on one type and every access typechecked. The package models them as the two shapes the
API actually returns, which made four real assumptions visible:

- `fetchPayRequest` declared its response as a pay request and then read `statusCode` / `message` off
  it — the error case it was handling could not occur under its own type. It now reads
  `PaymentLinkPayResponse` and narrows with `hasPaymentQuote`.
- The assign screen and the "not assigned" branch read `statusCode` without narrowing; same fix.
- `route` and `currency` are optional on a pay request. The public-payment form passed `route` into
  `URLSearchParams` as a string and interpolated `currency` into a label — both assumed a value the
  API does not promise. `route` is now only sent when present.
- The `Tag` detail row read `payRequest.tag`, which only exists on a quoted response.

`C2BPaymentMethod.KUCOINPAY` is `KUCOIN_PAY` in the package.

## Before this can go green

The package pin in `package.json` still points at the published `@dfx.swiss/react`. **CI stays red
until DFXswiss/packages#201 is merged and published and the pin is raised here.** Verified locally
against a build of that branch: `tsc` clean, `npm run lint` clean, full suite at 673 passing with no
new failures (the two suites failing on `develop` today still fail, unchanged).

## Overlap

#1223 touches the same two contexts (wait-endpoint polling). The textual conflict is routine, but
worth a look when the second of the two lands: any code it adds that reads `statusCode`, `message`,
`tag`, `route` or `currency` off a pay request needs the same narrowing this PR introduces —
the compiler will say so, but only once both are in.
