### PR TITLE
Pin the buy e2e locale so the collection-IBAN test stops depending on account data

### DIFF
--- a/e2e/buy-process.spec.ts
+++ b/e2e/buy-process.spec.ts
@@ -207,8 +207,11 @@ test.describe('Buy Process - UI Flow', () => {
 
     // asset-out is pinned: without it the screen picks the first listed asset, which has
     // no price rule in the local seed and the quote never reaches the payment details.
+    // lang=en pins the UI locale: the selectors and the baselines below are English, and without
+    // the parameter the language comes from the test account's stored user.language, which anyone
+    // can change on the server and which makes this test fail with "element(s) not found".
     await page.goto(
-      `/buy?session=${token}&blockchain=Ethereum&asset-in=EUR&asset-out=ETH&amount-in=100&personal-iban=frick`,
+      `/buy?session=${token}&blockchain=Ethereum&asset-in=EUR&asset-out=ETH&amount-in=100&personal-iban=frick&lang=en`,
     );
 
     const paymentDetails = page


### PR DESCRIPTION
## What

`e2e/buy-process.spec.ts` → the `should toggle between the personal and the collection IBAN` test now opens the buy screen with `&lang=en`.

## Why

The test asserts English labels (`Payment Information`, `Show collection IBAN`), but without a `lang` parameter the UI locale is resolved as

```
lang (URL) ?? user.language ?? storedLanguage ?? browserLanguage
```

(`src/contexts/settings.context.tsx`). With no parameter the locale therefore comes from the **test account's stored `user.language`** — server-side data anyone can change. It is currently German, so the app renders `Zahlungsinformation`, the English selectors match nothing and the test fails with `element(s) not found`.

## Evidence

Run against an unmodified checkout of the current `develop` (51ce782), repo-pinned Playwright 1.57.0:

| | Result |
|---|---|
| without `lang=en` | **1 failed** — `element(s) not found` |
| with `lang=en` | **1 passed** |

The baseline screenshots are unchanged by this PR — the parameter changes the locale, not the rendering that the baselines capture.

## Scope

Test-only, four lines (three of them the comment explaining the failure mode). No production code, no other test touched.

## Necessity

**Symptom (verbatim):** `Error: expect(locator).toBeVisible() failed` — `Locator: getByRole('heading', { name: 'Payment Information' }).locator('..').getByRole('button', { name: 'Show collection IBAN' })` — `Error: element(s) not found`. Reproduced on an unmodified checkout of develop 51ce782, so it is not caused by any code change.

**Scale:** this test is the only visual guard for the collection-IBAN UI, and it fails for every developer whose test account language is not English. The account language changed after the test was written on 2026-08-04, and two people hit it on that same day. It also blocks validating the two regenerated baselines in #1270.

**Smaller fix considered:** setting the test account language back to English on the dev API, zero lines of code — insufficient because that is mutable server-side state which the next person can change back, which is exactly how the test broke in the first place.
