### PR TITLE
feat(compliance): require a note on AML decisions and record it in the KYC log

### DIFF
--- a/src/components/compliance/aml-check-panel.tsx
+++ b/src/components/compliance/aml-check-panel.tsx
@@ -19,8 +19,8 @@ interface AmlCheckPendingPanelProps {
   data: ComplianceUserData;
   clerks: string[];
   isSaving: boolean;
-  onUpdate: (tx: TransactionInfo, update: AmlCheckUpdate, clerk: string) => Promise<void>;
-  onReset: (tx: TransactionInfo, clerk: string) => Promise<void>;
+  onUpdate: (tx: TransactionInfo, update: AmlCheckUpdate, clerk: string, note: string) => Promise<void>;
+  onReset: (tx: TransactionInfo, clerk: string, note: string) => Promise<void>;
 }
 
 const AML_CHECK_OPTIONS = [CheckStatus.PASS, CheckStatus.FAIL, CheckStatus.PENDING, 'Reset'] as const;
@@ -39,22 +39,23 @@ function TransactionEntry({
 }: {
   tx: TransactionInfo;
   clerks: string[];
-  onUpdate: (data: AmlCheckUpdate, clerk: string) => Promise<void>;
-  onReset: (clerk: string) => Promise<void>;
+  onUpdate: (data: AmlCheckUpdate, clerk: string, note: string) => Promise<void>;
+  onReset: (clerk: string, note: string) => Promise<void>;
   isSaving: boolean;
 }): JSX.Element {
   const [amlCheck, setAmlCheck] = useState(tx.amlCheck ?? '');
   const [amlReason, setAmlReason] = useState<AmlReason>((tx.amlReason as AmlReason) ?? AmlReason.NA);
   const [setPriceDate, setSetPriceDate] = useState(false);
   const [clerk, setClerk] = useState('');
+  const [note, setNote] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
 
   async function handleSave(): Promise<void> {
-    if (!amlCheck || !clerk) return;
+    if (!amlCheck || !clerk || !note.trim()) return;
     setIsProcessing(true);
     try {
       if (amlCheck === 'Reset') {
-        await onReset(clerk);
+        await onReset(clerk, note);
       } else {
         await onUpdate(
           {
@@ -63,6 +64,7 @@ function TransactionEntry({
             priceDefinitionAllowedDate: setPriceDate ? new Date().toISOString() : undefined,
           },
           clerk,
+          note,
         );
       }
     } finally {
@@ -175,6 +177,21 @@ function TransactionEntry({
         </div>
       </div>
 
+      {/* Notiz: geht ins KycLog (wie bei den Telefon-Notizen), NICHT in den Transaktions-Comment —
+          dort stehen die AML-Fehler, auf die der Release-Mechanismus matcht. */}
+      <div className="bg-white rounded-lg shadow-sm px-3 py-3">
+        <label className="block text-sm text-dfxBlue-800 font-medium mb-1">Notiz *</label>
+        <textarea
+          className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
+          rows={3}
+          maxLength={500}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Infos zum Entscheid"
+          required
+        />
+      </div>
+
       {/* Clerk */}
       <div className="bg-white rounded-lg shadow-sm px-3 py-3">
         <div className="flex items-center justify-between">
@@ -198,7 +215,7 @@ function TransactionEntry({
         <button
           className="px-4 py-2 text-sm text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded-lg transition-colors disabled:opacity-50"
           onClick={handleSave}
-          disabled={isSaving || isProcessing || !amlCheck || !clerk}
+          disabled={isSaving || isProcessing || !amlCheck || !clerk || !note.trim()}
         >
           {isProcessing ? 'Speichern...' : 'Speichern'}
         </button>
@@ -349,8 +366,8 @@ export function AmlCheckPendingPanel({
           <TransactionEntry
             tx={tx}
             clerks={clerks}
-            onUpdate={(updateData, clerk) => onUpdate(tx, updateData, clerk)}
-            onReset={(clerk) => onReset(tx, clerk)}
+            onUpdate={(updateData, clerk, note) => onUpdate(tx, updateData, clerk, note)}
+            onReset={(clerk, note) => onReset(tx, clerk, note)}
             isSaving={isSaving}
           />
         </div>

--- a/src/screens/compliance-review.screen.tsx
+++ b/src/screens/compliance-review.screen.tsx
@@ -261,7 +261,12 @@ export default function ComplianceReviewScreen(): JSX.Element {
     }
   }
 
-  async function handleAmlUpdate(tx: TransactionInfo, update: AmlCheckUpdate, clerk: string): Promise<void> {
+  async function handleAmlUpdate(
+    tx: TransactionInfo,
+    update: AmlCheckUpdate,
+    clerk: string,
+    note: string,
+  ): Promise<void> {
     setIsSaving(true);
     setError(undefined);
     try {
@@ -275,7 +280,7 @@ export default function ComplianceReviewScreen(): JSX.Element {
         if (update.amlReason) results.push({ table, column: 'amlReason', value: update.amlReason });
         if (update.priceDefinitionAllowedDate)
           results.push({ table, column: 'priceDefinitionAllowedDate', value: update.priceDefinitionAllowedDate });
-        await createKycLog(+userDataId, buildKycLogMessage({ description: 'AmlCheck', clerk, results }));
+        await createKycLog(+userDataId, buildKycLogMessage({ description: 'AmlCheck', clerk, results, comment: note }));
       }
       loadData();
     } catch (e: unknown) {
@@ -285,7 +290,7 @@ export default function ComplianceReviewScreen(): JSX.Element {
     }
   }
 
-  async function handleAmlReset(tx: TransactionInfo, clerk: string): Promise<void> {
+  async function handleAmlReset(tx: TransactionInfo, clerk: string, note: string): Promise<void> {
     setIsSaving(true);
     setError(undefined);
     try {
@@ -300,6 +305,7 @@ export default function ComplianceReviewScreen(): JSX.Element {
             description: 'AmlCheck',
             clerk,
             results: [{ table, column: 'amlCheck', value: 'Reset' }],
+            comment: note,
           }),
         );
       }


### PR DESCRIPTION
The AML decision form (compliance review, tab "AML Pending") gets a mandatory note field, analogous to the call-queue outcome form: the clerk records the reasoning for the release/rejection, and it is appended to the KYC log entry (`comment:` section of `buildKycLogMessage`), for Pass/Fail/Pending as well as Reset.

Deliberately NOT written to the transaction `comment` column: that column carries the AML error list (e.g. `ScorechainHighRisk`), which the release mechanism in the API matches on (DFXswiss/api#4654, DFXswiss/api#4402) — free text there would break it.

The save button stays disabled until decision, editor and note are filled in.