### PR TITLE
docs: set clipboard-write permission on the Iframe example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ DFX services can be integrated using a browser redirect to [app.dfx.swiss](https
 
 #### Iframe
 
-DFX services can be integrated by opening [app.dfx.swiss](https://app.dfx.swiss/) with the desired parameters (see [below](#query-parameters)) in an Iframe. See the [code example](#iframe-example) below. The `allow="clipboard-write"` attribute should be set on the Iframe, as copy buttons cannot use the browser clipboard from within a cross-origin Iframe without it.
+DFX services can be integrated by opening [app.dfx.swiss](https://app.dfx.swiss/) with the desired parameters (see [below](#query-parameters)) in an Iframe. See the [code example](#iframe-example) below. The `allow="clipboard-write"` attribute should be set on the Iframe, as Chromium-based browsers do not grant the asynchronous Clipboard API (`navigator.clipboard`) to cross-origin Iframes without it.
 
 On cancel or completion, a message will be sent on the window object of the browser. See [below](#close-message) for details on the message format. If a redirect URI is specified, the user will be redirected to this URI (see [redirect](#redirect)).
 
@@ -253,7 +253,7 @@ Documentation on `BuyPaymentInfoDto`, `SellPaymentInfoDto` and `SwapPaymentInfoD
   }
 </script>
 
-<iframe src="https://app.dfx.swiss" height="600" width="450" frameborder="0" allow="clipboard-write" />
+<iframe src="https://app.dfx.swiss" height="600" width="450" frameborder="0" allow="clipboard-write"></iframe>
 ```
 
 #### Web Component Example

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ DFX services can be integrated using a browser redirect to [app.dfx.swiss](https
 
 #### Iframe
 
-DFX services can be integrated by opening [app.dfx.swiss](https://app.dfx.swiss/) with the desired parameters (see [below](#query-parameters)) in an Iframe. See the [code example](#iframe-example) below.
+DFX services can be integrated by opening [app.dfx.swiss](https://app.dfx.swiss/) with the desired parameters (see [below](#query-parameters)) in an Iframe. See the [code example](#iframe-example) below. The `allow="clipboard-write"` attribute should be set on the Iframe, as copy buttons cannot use the browser clipboard from within a cross-origin Iframe without it.
 
 On cancel or completion, a message will be sent on the window object of the browser. See [below](#close-message) for details on the message format. If a redirect URI is specified, the user will be redirected to this URI (see [redirect](#redirect)).
 
@@ -253,7 +253,7 @@ Documentation on `BuyPaymentInfoDto`, `SellPaymentInfoDto` and `SwapPaymentInfoD
   }
 </script>
 
-<iframe src="https://app.dfx.swiss" height="600" width="450" frameborder="0" />
+<iframe src="https://app.dfx.swiss" height="600" width="450" frameborder="0" allow="clipboard-write" />
 ```
 
 #### Web Component Example


### PR DESCRIPTION
## Summary

`clipboard-write` is a Permissions-Policy-gated feature whose default allowlist is `self`. In a cross-origin Iframe — which is what the documented Iframe integration of app.dfx.swiss is — `navigator.clipboard.writeText` therefore rejects unless the embedding page grants the permission via `allow="clipboard-write"` on the Iframe element.

With #1287 the app copies via `navigator.clipboard.writeText` and only falls back to the legacy DOM-based mechanism when the Clipboard API is unavailable or the write rejects. Without this attribute, an Iframe integrator's users take the fallback on every copy in Chromium; with it, they get the native path. The attribute is an upgrade, not a prerequisite — copy buttons keep working without it (the fallback is not policy-gated), which is why the docs sentence recommends rather than requires it, and why it is phrased around browser behavior so it is accurate both before and after #1287 lands. Enforcement of `clipboard-write` delegation is Chromium-specific; Firefox and Safari gate the Clipboard API on user activation instead, so the attribute is a no-op there.

This PR adds the attribute to the Iframe code example and states the recommendation in the Iframe section. It also closes the `<iframe>` tag in the example — `iframe` is not a void element, so the previous self-closing form was invalid HTML that would swallow any markup an integrator pasted after it.

The Web Component and React Component integrations load into the host page's own document and need no attribute.

## Test plan

- [x] `npx prettier --check README.md` — clean (Markdown is prettier-checked in CI since #1294)
- [x] Rendered Markdown reviewed
