### PR TITLE
c49d5c1c - Surface an empty or failed clerk list on the call-queue outcome form

### DIFF
--- a/src/__tests__/call-queue-clerks.hook.test.ts
+++ b/src/__tests__/call-queue-clerks.hook.test.ts
@@ -48,6 +48,19 @@ describe('useCallQueueClerks', () => {
     expect(result.current.error).toBe('Unknown error');
   });
 
+  it('uses the fallback message when the Error carries an empty message', async () => {
+    mockGetCallQueueClerks.mockRejectedValue(new Error(''));
+
+    const { result } = renderHook(() => useCallQueueClerks());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // an empty message would be falsy in the form and mislabel the failure as "not configured"
+    expect(result.current.error).toBe('Unknown error');
+  });
+
+  // Coverage of the cancelled path: React 18 gives no observable signal for a skipped
+  // post-unmount state update, so this documents the guard rather than proving it.
   it('ignores a resolved request after unmounting', async () => {
     let resolveRequest!: (clerks: string[]) => void;
     const request = new Promise<string[]>((resolve) => {
@@ -66,6 +79,7 @@ describe('useCallQueueClerks', () => {
     });
   });
 
+  // Same coverage-only caveat as above.
   it('ignores a rejected request after unmounting', async () => {
     let rejectRequest!: (reason: unknown) => void;
     const request = new Promise<string[]>((_, reject) => {

--- a/src/__tests__/call-queue-clerks.hook.test.ts
+++ b/src/__tests__/call-queue-clerks.hook.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useCallQueueClerks } from 'src/hooks/call-queue-clerks.hook';
+
+const mockGetCallQueueClerks = jest.fn();
+
+jest.mock('src/hooks/compliance.hook', () => ({
+  useCompliance: () => ({ getCallQueueClerks: mockGetCallQueueClerks }),
+}));
+
+describe('useCallQueueClerks', () => {
+  beforeEach(() => {
+    mockGetCallQueueClerks.mockReset();
+  });
+
+  it('loads the configured clerks', async () => {
+    mockGetCallQueueClerks.mockResolvedValue(['JR', 'AB']);
+
+    const { result } = renderHook(() => useCallQueueClerks());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.clerks).toEqual([]);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.clerks).toEqual(['JR', 'AB']);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('exposes the message when loading fails with an Error', async () => {
+    mockGetCallQueueClerks.mockRejectedValue(new Error('Network down'));
+
+    const { result } = renderHook(() => useCallQueueClerks());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.clerks).toEqual([]);
+    expect(result.current.error).toBe('Network down');
+  });
+
+  it('uses a fallback message when loading fails with a non-Error value', async () => {
+    mockGetCallQueueClerks.mockRejectedValue('boom');
+
+    const { result } = renderHook(() => useCallQueueClerks());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.clerks).toEqual([]);
+    expect(result.current.error).toBe('Unknown error');
+  });
+
+  it('ignores a resolved request after unmounting', async () => {
+    let resolveRequest!: (clerks: string[]) => void;
+    const request = new Promise<string[]>((resolve) => {
+      resolveRequest = resolve;
+    });
+    mockGetCallQueueClerks.mockReturnValue(request);
+    const { unmount } = renderHook(() => useCallQueueClerks());
+
+    unmount();
+
+    // React 18 has no observable state-update warning after unmount; resolving
+    // without error still exercises the cancelled === true guard branch.
+    await act(async () => {
+      resolveRequest(['JR']);
+      await Promise.resolve();
+    });
+  });
+
+  it('ignores a rejected request after unmounting', async () => {
+    let rejectRequest!: (reason: unknown) => void;
+    const request = new Promise<string[]>((_, reject) => {
+      rejectRequest = reject;
+    });
+    mockGetCallQueueClerks.mockReturnValue(request);
+    const { unmount } = renderHook(() => useCallQueueClerks());
+
+    unmount();
+
+    // React 18 has no observable state-update warning after unmount; rejecting
+    // without error still exercises the cancelled === true guard branch.
+    await act(async () => {
+      rejectRequest(new Error('Network down'));
+      await Promise.resolve();
+    });
+  });
+});

--- a/src/__tests__/call-queue-outcome-form.test.tsx
+++ b/src/__tests__/call-queue-outcome-form.test.tsx
@@ -16,7 +16,9 @@ jest.mock('@dfx.swiss/react-components', () => ({
   ),
   StyledButtonWidth: { FULL: 'full' },
 }));
-jest.mock('src/components/error-hint', () => ({ ErrorHint: () => null }));
+jest.mock('src/components/error-hint', () => ({
+  ErrorHint: ({ message }: { message: string }) => <div data-testid="error-hint">{message}</div>,
+}));
 jest.mock('src/contexts/settings.context', () => ({
   useSettingsContext: () => ({ translate: (_ns: string, key: string) => key }),
 }));
@@ -64,12 +66,18 @@ const PLAIN_PHONE_TX_CONTEXT = { ...TX_CONTEXT, queue: 'ManualCheckPhone' };
 const INELIGIBLE_TX_CONTEXT = { ...TX_CONTEXT, buyCryptoResetEligible: false };
 const USER_CONTEXT = { queue: 'UnavailableSuspicious', userDataId: 1 } as any;
 
-function renderForm(context: any) {
+let testClerks = ['JR'];
+let testClerksError: string | undefined;
+let testClerksLoading: boolean | undefined;
+
+function renderForm(context: any = TX_CONTEXT) {
   return render(
     <CallQueueOutcomeForm
       context={context}
       availableOutcomes={OUTCOMES}
-      clerks={['JR']}
+      clerks={testClerks}
+      clerksError={testClerksError}
+      clerksLoading={testClerksLoading}
       onSaved={jest.fn()}
       title="Save Outcome"
     />,
@@ -89,6 +97,104 @@ function submittedAmlAction(): string | undefined {
 }
 
 describe('CallQueueOutcomeForm AmlCheck action', () => {
+  beforeEach(() => {
+    testClerks = ['JR'];
+    testClerksError = undefined;
+    testClerksLoading = undefined;
+  });
+
+  it('shows a configuration hint when no clerks are configured', () => {
+    testClerks = [];
+
+    renderForm();
+
+    expect(screen.getByTestId('error-hint')).toHaveTextContent(
+      'No clerks are configured, so no signature can be selected and saving stays disabled. An admin has to fill the "complianceClerks" setting.',
+    );
+  });
+
+  it('shows the loading error when the clerk list could not be loaded', () => {
+    testClerks = [];
+    testClerksError = 'Network down';
+
+    renderForm();
+
+    expect(screen.getByTestId('error-hint')).toHaveTextContent(
+      'Could not load the clerk list: Network down. Saving is disabled until it loads.',
+    );
+  });
+
+  it('does not show a clerk hint while the clerk list is loading', () => {
+    testClerks = [];
+    testClerksError = 'Network down';
+    testClerksLoading = true;
+
+    renderForm();
+
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
+  });
+
+  it('saves the explicitly selected signature', async () => {
+    testClerks = ['JR', 'AB'];
+    renderForm();
+    const selects = screen.getAllByRole('combobox');
+    const outcomeSelect = selects[1] as HTMLSelectElement;
+    const outcome = Array.from(outcomeSelect.options).find((option) => option.value)?.value;
+
+    expect(outcome).toBeDefined();
+    fireEvent.change(selects[0], { target: { value: 'AB' } });
+    fireEvent.change(outcomeSelect, { target: { value: outcome } });
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Completed call' } });
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() =>
+      expect(mockSaveCallOutcome).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ signature: 'AB' }),
+      ),
+    );
+  });
+
+  it('renders fallback details for a failed save without completed steps', async () => {
+    mockSaveCallOutcome.mockResolvedValue({ success: false, completedSteps: [] });
+    renderForm();
+    const outcomeSelect = screen.getAllByRole('combobox')[1] as HTMLSelectElement;
+    const outcome = Array.from(outcomeSelect.options).find((option) => option.value)?.value;
+
+    expect(outcome).toBeDefined();
+    fireEvent.change(outcomeSelect, { target: { value: outcome } });
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Completed call' } });
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('error-hint').textContent).toBe("Failed at step 'unknown': Unknown error"),
+    );
+  });
+
+  it('renders completed steps and explicit details for a failed save', async () => {
+    mockSaveCallOutcome.mockResolvedValue({
+      success: false,
+      failedStep: 'transaction',
+      message: 'DB write failed',
+      completedSteps: ['userData'],
+    });
+    renderForm();
+    const outcomeSelect = screen.getAllByRole('combobox')[1] as HTMLSelectElement;
+    const outcome = Array.from(outcomeSelect.options).find((option) => option.value)?.value;
+
+    expect(outcome).toBeDefined();
+    fireEvent.change(outcomeSelect, { target: { value: outcome } });
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Completed call' } });
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('error-hint').textContent).toBe(
+        "Failed at step 'transaction': DB write failed. Previously completed: userData. Please verify state manually before retry.",
+      ),
+    );
+  });
+
   beforeEach(() => {
     mockAuth.session = { role: 'Compliance' };
     jest.clearAllMocks();

--- a/src/__tests__/compliance-call-queue-detail.screen.test.tsx
+++ b/src/__tests__/compliance-call-queue-detail.screen.test.tsx
@@ -12,6 +12,7 @@ let mockClerksResult: { clerks: string[]; isLoading: boolean; error?: string } =
 
 const mockGetUserData = jest.fn();
 const mockNavigate = jest.fn();
+let capturedLayoutOptions: { onBack?: () => void } | undefined;
 const mockUseComplianceGuard = jest.fn();
 const mockCanReset = jest.fn((..._args: unknown[]) => true);
 
@@ -65,7 +66,9 @@ jest.mock('src/hooks/guard.hook', () => ({
 }));
 
 jest.mock('src/hooks/layout-config.hook', () => ({
-  useLayoutOptions: () => undefined,
+  useLayoutOptions: (options: { onBack?: () => void }) => {
+    capturedLayoutOptions = options;
+  },
 }));
 
 jest.mock('src/hooks/navigation.hook', () => ({
@@ -315,6 +318,15 @@ describe('ComplianceCallQueueDetailScreen', () => {
       { pathname: '/compliance/call-queues/ManualCheckPhone' },
       { replace: true, clearParams: ['txId'] },
     );
+  });
+
+  it('navigates back through the layout onBack callback', async () => {
+    await renderLoaded();
+
+    expect(capturedLayoutOptions?.onBack).toBeDefined();
+    capturedLayoutOptions?.onBack?.();
+
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
   });
 
   it('renders address information for the IP-country queue', async () => {

--- a/src/__tests__/compliance-call-queue-detail.screen.test.tsx
+++ b/src/__tests__/compliance-call-queue-detail.screen.test.tsx
@@ -1,0 +1,423 @@
+let mockIsLoggedIn = true;
+let mockParams: { queue?: string; userDataId?: string } = {
+  queue: 'ManualCheckPhone',
+  userDataId: '2001',
+};
+let mockSearch = '';
+let mockClerksResult: { clerks: string[]; isLoading: boolean; error?: string } = {
+  clerks: ['JR'],
+  isLoading: false,
+  error: undefined,
+};
+
+const mockGetUserData = jest.fn();
+const mockNavigate = jest.fn();
+const mockUseComplianceGuard = jest.fn();
+const mockCanReset = jest.fn((..._args: unknown[]) => true);
+
+jest.mock('@dfx.swiss/react', () => ({
+  useSessionContext: () => ({ isLoggedIn: mockIsLoggedIn }),
+  CallQueue: {
+    MANUAL_CHECK_PHONE: 'ManualCheckPhone',
+    MANUAL_CHECK_IP_PHONE: 'ManualCheckIpPhone',
+    MANUAL_CHECK_IP_COUNTRY_PHONE: 'ManualCheckIpCountryPhone',
+    MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE: 'ManualCheckExternalAccountPhone',
+    UNAVAILABLE_SUSPICIOUS: 'UnavailableSuspicious',
+  },
+}));
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  SpinnerSize: { LG: 'lg' },
+  StyledLoadingSpinner: ({ size }: any) => <div data-testid="loading-spinner" data-size={size} />,
+  StyledVerticalStack: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => mockParams,
+  useLocation: () => ({ search: mockSearch }),
+}));
+
+jest.mock('src/components/error-hint', () => ({
+  ErrorHint: ({ message }: { message: string }) => <div data-testid="error-hint">{message}</div>,
+}));
+
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({ translate: (_ns: string, key: string) => key }),
+}));
+
+jest.mock('src/hooks/call-queue-clerks.hook', () => ({
+  useCallQueueClerks: () => mockClerksResult,
+}));
+
+jest.mock('src/hooks/compliance.hook', () => ({
+  useCompliance: () => ({ getUserData: mockGetUserData }),
+  CallOutcome: {
+    COMPLETED: 'Completed',
+    UNAVAILABLE: 'Unavailable',
+    SUSPICIOUS: 'Suspicious',
+    FAILED: 'Failed',
+    REPEAT: 'Repeat',
+  },
+}));
+
+jest.mock('src/hooks/guard.hook', () => ({
+  useComplianceGuard: (...args: unknown[]) => mockUseComplianceGuard(...args),
+}));
+
+jest.mock('src/hooks/layout-config.hook', () => ({
+  useLayoutOptions: () => undefined,
+}));
+
+jest.mock('src/hooks/navigation.hook', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('src/util/buy-crypto-reset.util', () => ({
+  canResetBuyCryptoAmlForReview: (...args: unknown[]) => mockCanReset(...args),
+}));
+
+jest.mock('src/components/compliance/call-queue/call-queue-user-info', () => ({
+  CallQueueUserInfo: () => <div data-testid="user-info" />,
+}));
+
+jest.mock('src/components/compliance/call-queue/call-queue-tx-info', () => ({
+  CallQueueTxInfo: () => <div data-testid="tx-info" />,
+}));
+
+jest.mock('src/components/compliance/call-queue/call-queue-address-info', () => ({
+  CallQueueAddressInfo: () => <div data-testid="address-info" />,
+}));
+
+jest.mock('src/components/compliance/call-queue/call-queue-transactions-list', () => ({
+  CallQueueTransactionsList: () => <div data-testid="transactions-list" />,
+}));
+
+jest.mock('src/components/compliance/call-queue/call-queue-bank-tx-info', () => ({
+  CallQueueBankTxInfo: () => <div data-testid="bank-tx-info" />,
+}));
+
+jest.mock('src/components/compliance/call-queue/call-queue-ip-countries', () => ({
+  CallQueueIpCountries: () => <div data-testid="ip-countries" />,
+}));
+
+jest.mock('src/components/compliance/call-queue/call-queue-kyc-comments', () => ({
+  CallQueueKycComments: () => <div data-testid="kyc-comments" />,
+}));
+
+jest.mock('src/components/compliance/call-queue/call-queue-questions', () => ({
+  CallQueueQuestions: () => <div data-testid="questions" />,
+}));
+
+jest.mock('src/components/compliance/call-queue/call-queue-outcome-form', () => ({
+  CallQueueOutcomeForm: (props: any) => (
+    <div
+      data-testid="outcome-form"
+      data-context={JSON.stringify(props.context)}
+      data-outcomes={JSON.stringify(props.availableOutcomes)}
+      data-clerks={JSON.stringify(props.clerks)}
+      data-clerks-error={props.clerksError ?? ''}
+      data-clerks-loading={String(!!props.clerksLoading)}
+    >
+      <button onClick={props.onSaved}>save</button>
+    </div>
+  ),
+}));
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ComplianceCallQueueDetailScreen from 'src/screens/compliance-call-queue-detail.screen';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: Error) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  const controls = {
+    resolve: (_value: T) => {
+      throw new Error('deferred not initialized');
+    },
+    reject: (_reason: Error) => {
+      throw new Error('deferred not initialized');
+    },
+  };
+  const promise = new Promise<T>((resolve, reject) => {
+    controls.resolve = resolve;
+    controls.reject = reject;
+  });
+  return { promise, resolve: controls.resolve, reject: controls.reject };
+}
+
+function baseData(overrides: Partial<any> = {}): any {
+  return {
+    userData: { id: 2001 },
+    kycSteps: [],
+    transactions: [],
+    bankTxs: [],
+    cryptoInputs: [],
+    users: [],
+    bankDatas: [],
+    buyRoutes: [],
+    sellRoutes: [],
+    swapRoutes: [],
+    virtualIbans: [],
+    refRewards: [],
+    notifications: [],
+    notes: [],
+    permissions: {},
+    ...overrides,
+  };
+}
+
+function transaction(overrides: Partial<any> = {}): any {
+  return {
+    id: 101,
+    uid: 'tx-101',
+    sourceType: 'BuyCrypto',
+    ...overrides,
+  };
+}
+
+function bankData(overrides: Partial<any> = {}): any {
+  return {
+    id: 1,
+    iban: 'CH9300762011623852957',
+    name: 'Fixture User',
+    approved: false,
+    active: false,
+    created: '2026-08-01T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+async function renderLoaded(data: any = baseData()): Promise<HTMLElement> {
+  mockGetUserData.mockResolvedValue(data);
+  render(<ComplianceCallQueueDetailScreen />);
+  return screen.findByTestId('outcome-form');
+}
+
+function outcomeContext(): Record<string, unknown> {
+  return JSON.parse(screen.getByTestId('outcome-form').getAttribute('data-context') ?? '{}');
+}
+
+const OUTCOMES = ['Completed', 'Unavailable', 'Suspicious', 'Failed', 'Repeat'];
+const INVALID_QUEUES: Array<[string | undefined, string]> = [
+  ['NotARealQueue', 'Unknown call queue: NotARealQueue'],
+  [undefined, 'Unknown call queue: undefined'],
+];
+
+describe('ComplianceCallQueueDetailScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsLoggedIn = true;
+    mockParams = { queue: 'ManualCheckPhone', userDataId: '2001' };
+    mockSearch = '';
+    mockClerksResult = { clerks: ['JR'], isLoading: false, error: undefined };
+    mockGetUserData.mockResolvedValue(baseData());
+    mockCanReset.mockReturnValue(true);
+  });
+
+  it('calls the compliance guard without arguments', () => {
+    render(<ComplianceCallQueueDetailScreen />);
+
+    expect(mockUseComplianceGuard).toHaveBeenCalledWith();
+  });
+
+  it.each(INVALID_QUEUES)('shows an error before fetching for queue %s', (queue, message) => {
+    mockParams = { queue, userDataId: '2001' };
+
+    render(<ComplianceCallQueueDetailScreen />);
+
+    expect(screen.getByTestId('error-hint')).toHaveTextContent(message);
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+    expect(mockGetUserData).not.toHaveBeenCalled();
+  });
+
+  it('keeps the loading state and does not fetch without a userDataId', () => {
+    mockParams = { queue: 'ManualCheckPhone' };
+
+    render(<ComplianceCallQueueDetailScreen />);
+
+    expect(mockGetUserData).not.toHaveBeenCalled();
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+  });
+
+  it('keeps the loading state and does not fetch while logged out', () => {
+    mockIsLoggedIn = false;
+
+    render(<ComplianceCallQueueDetailScreen />);
+
+    expect(mockGetUserData).not.toHaveBeenCalled();
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+  });
+
+  it('shows the spinner while loading and then renders the content', async () => {
+    const deferred = createDeferred<any>();
+    mockGetUserData.mockReturnValue(deferred.promise);
+
+    render(<ComplianceCallQueueDetailScreen />);
+
+    expect(screen.getByTestId('loading-spinner')).toHaveAttribute('data-size', 'lg');
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('outcome-form')).not.toBeInTheDocument();
+
+    deferred.resolve(baseData());
+    await waitFor(() => {
+      expect(screen.getByTestId('outcome-form')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+  });
+
+  it('shows the fetch error after loading finishes', async () => {
+    mockGetUserData.mockRejectedValue(new Error('Network down'));
+
+    render(<ComplianceCallQueueDetailScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-hint')).toHaveTextContent('Network down');
+    });
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+  });
+
+  it('shows No data when a successful fetch resolves without data', async () => {
+    mockGetUserData.mockResolvedValue(undefined as any);
+
+    render(<ComplianceCallQueueDetailScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-hint')).toHaveTextContent('No data');
+    });
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+  });
+
+  it('renders the base queue, forwards a clerk error, and navigates after save', async () => {
+    mockClerksResult = { clerks: [], isLoading: false, error: 'Network down' };
+
+    const form = await renderLoaded();
+
+    expect(mockGetUserData).toHaveBeenCalledWith(2001);
+    expect(screen.getByTestId('user-info')).toBeInTheDocument();
+    expect(screen.getByTestId('transactions-list')).toBeInTheDocument();
+    expect(screen.getByTestId('ip-countries')).toBeInTheDocument();
+    expect(screen.getByTestId('kyc-comments')).toBeInTheDocument();
+    expect(screen.getByTestId('questions')).toBeInTheDocument();
+    expect(form).toHaveAttribute('data-clerks', '[]');
+    expect(form).toHaveAttribute('data-clerks-error', 'Network down');
+    expect(form).toHaveAttribute('data-clerks-loading', 'false');
+    expect(screen.queryByTestId('tx-info')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('address-info')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bank-tx-info')).not.toBeInTheDocument();
+    // With no txId there is no transaction, so the bankData memo returns before inspecting bankDatas.
+    expect(mockCanReset).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('save'));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      { pathname: '/compliance/call-queues/ManualCheckPhone' },
+      { replace: true, clearParams: ['txId'] },
+    );
+  });
+
+  it('renders address information for the IP-country queue', async () => {
+    mockParams.queue = 'ManualCheckIpCountryPhone';
+
+    await renderLoaded(baseData({ ipLogs: [], kycLogs: [] }));
+
+    expect(screen.getByTestId('address-info')).toBeInTheDocument();
+    expect(screen.queryByTestId('bank-tx-info')).not.toBeInTheDocument();
+  });
+
+  it('renders bank transactions for the external-account queue', async () => {
+    mockParams.queue = 'ManualCheckExternalAccountPhone';
+
+    await renderLoaded();
+
+    expect(screen.getByTestId('bank-tx-info')).toBeInTheDocument();
+    expect(screen.queryByTestId('address-info')).not.toBeInTheDocument();
+  });
+
+  it('uses the user outcomes and forwards the clerk loading state', async () => {
+    mockParams.queue = 'UnavailableSuspicious';
+    mockClerksResult = { clerks: [], isLoading: true, error: undefined };
+
+    const form = await renderLoaded();
+
+    expect(JSON.parse(form.getAttribute('data-outcomes') ?? '[]')).toEqual(OUTCOMES);
+    expect(form).toHaveAttribute('data-clerks', '[]');
+    expect(form).toHaveAttribute('data-clerks-error', '');
+    expect(form).toHaveAttribute('data-clerks-loading', 'true');
+  });
+
+  it('builds a BuyCrypto context with reset eligibility and no bank data', async () => {
+    mockSearch = '?txId=101';
+    const tx = transaction({
+      buyCryptoId: 7001,
+      amlCheck: 'Review',
+      amlReason: 'Manual review',
+    });
+
+    await renderLoaded(baseData({ transactions: [tx], bankDatas: [] }));
+
+    expect(screen.getByTestId('tx-info')).toBeInTheDocument();
+    expect(mockCanReset).toHaveBeenCalledWith(tx);
+    expect(outcomeContext()).toEqual({
+      queue: 'ManualCheckPhone',
+      userDataId: 2001,
+      txId: 7001,
+      sourceType: 'BuyCrypto',
+      amlCheck: 'Review',
+      amlReason: 'Manual review',
+      buyCryptoResetEligible: true,
+    });
+  });
+
+  it('forwards false BuyCrypto reset eligibility and selects approved active bank data', async () => {
+    mockSearch = '?txId=101';
+    mockCanReset.mockReturnValue(false);
+    const tx = transaction({ buyCryptoId: 7002 });
+
+    await renderLoaded(
+      baseData({
+        transactions: [tx],
+        bankDatas: [bankData({ approved: true, active: true })],
+      }),
+    );
+
+    expect(screen.getByTestId('tx-info')).toBeInTheDocument();
+    expect(outcomeContext()).toMatchObject({
+      txId: 7002,
+      sourceType: 'BuyCrypto',
+      buyCryptoResetEligible: false,
+    });
+  });
+
+  it('builds a BuyFiat context and falls back to the first bank data entry', async () => {
+    mockParams.queue = 'ManualCheckExternalAccountPhone';
+    mockSearch = '?txId=102';
+    const tx = transaction({ id: 102, buyFiatId: 8001, sourceType: 'BuyFiat' });
+
+    await renderLoaded(
+      baseData({
+        transactions: [transaction({ id: 99 }), tx],
+        bankDatas: [
+          bankData({ id: 1, approved: false, active: true }),
+          bankData({ id: 2, approved: true, active: false }),
+        ],
+      }),
+    );
+
+    expect(screen.getByTestId('tx-info')).toBeInTheDocument();
+    expect(screen.getByTestId('bank-tx-info')).toBeInTheDocument();
+    expect(outcomeContext()).toMatchObject({ txId: 8001, sourceType: 'BuyFiat' });
+  });
+
+  it('omits transaction context fields when the matched transaction has no source id', async () => {
+    mockSearch = '?txId=103';
+    const tx = transaction({ id: 103, sourceType: 'BankTx' });
+
+    await renderLoaded(baseData({ transactions: [tx] }));
+
+    expect(screen.getByTestId('tx-info')).toBeInTheDocument();
+    expect(mockCanReset).toHaveBeenCalledWith(tx);
+    expect(outcomeContext()).toEqual({ queue: 'ManualCheckPhone', userDataId: 2001 });
+  });
+});

--- a/src/__tests__/compliance-call-queue-detail.screen.test.tsx
+++ b/src/__tests__/compliance-call-queue-detail.screen.test.tsx
@@ -212,6 +212,7 @@ const INVALID_QUEUES: Array<[string | undefined, string]> = [
 describe('ComplianceCallQueueDetailScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedLayoutOptions = undefined;
     mockIsLoggedIn = true;
     mockParams = { queue: 'ManualCheckPhone', userDataId: '2001' };
     mockSearch = '';

--- a/src/components/compliance/call-queue/call-queue-outcome-form.tsx
+++ b/src/components/compliance/call-queue/call-queue-outcome-form.tsx
@@ -82,10 +82,10 @@ export function CallQueueOutcomeForm({
   }
 
   async function handleSubmit() {
-    if (!outcome || !signature || !comment.trim()) return;
     setIsSaving(true);
     setResult(undefined);
-    const res = await saveCallOutcome(context, outcome, {
+    // the cast is carried by the disabled-button gate: canSubmit requires a non-empty outcome
+    const res = await saveCallOutcome(context, outcome as CallOutcome, {
       signature,
       comment,
       amlAction: hasTx ? (outcomeImpliesAmlAction ? impliedAmlAction() : amlAction || undefined) : undefined,

--- a/src/components/compliance/call-queue/call-queue-outcome-form.tsx
+++ b/src/components/compliance/call-queue/call-queue-outcome-form.tsx
@@ -22,11 +22,21 @@ interface Props {
   context: CallOutcomeContext;
   availableOutcomes: CallOutcome[];
   clerks: string[];
+  clerksError?: string;
+  clerksLoading?: boolean;
   onSaved: () => void;
   title: string;
 }
 
-export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSaved, title }: Props): JSX.Element {
+export function CallQueueOutcomeForm({
+  context,
+  availableOutcomes,
+  clerks,
+  clerksError,
+  clerksLoading,
+  onSaved,
+  title,
+}: Props): JSX.Element {
   const { translate } = useSettingsContext();
   const { saveCallOutcome } = useCompliance();
   const { session } = useAuthContext();
@@ -88,6 +98,17 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
   return (
     <div className="w-full bg-white rounded-lg shadow-sm p-4">
       <h3 className="text-base font-semibold text-dfxBlue-800 mb-3">{title}</h3>
+      {!clerks.length && !clerksLoading && (
+        <div className="mb-4">
+          <ErrorHint
+            message={
+              clerksError
+                ? `Could not load the clerk list: ${clerksError}. Saving is disabled until it loads.`
+                : 'No clerks are configured, so no signature can be selected and saving stays disabled. An admin has to fill the "complianceClerks" setting.'
+            }
+          />
+        </div>
+      )}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <label className="block text-sm font-medium text-dfxBlue-800 mb-1">Signature</label>

--- a/src/hooks/call-queue-clerks.hook.ts
+++ b/src/hooks/call-queue-clerks.hook.ts
@@ -1,19 +1,26 @@
 import { useEffect, useState } from 'react';
 import { useCompliance } from './compliance.hook';
 
-export function useCallQueueClerks(): { clerks: string[]; isLoading: boolean } {
+export function useCallQueueClerks(): { clerks: string[]; isLoading: boolean; error?: string } {
   const { getCallQueueClerks } = useCompliance();
   const [clerks, setClerks] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string>();
 
   useEffect(() => {
     let cancelled = false;
     getCallQueueClerks()
       .then((list) => {
-        if (!cancelled) setClerks(list);
+        if (!cancelled) {
+          setClerks(list);
+          setError(undefined);
+        }
       })
-      .catch(() => {
-        if (!cancelled) setClerks([]);
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setClerks([]);
+          setError(e instanceof Error ? e.message : 'Unknown error');
+        }
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false);
@@ -23,5 +30,5 @@ export function useCallQueueClerks(): { clerks: string[]; isLoading: boolean } {
     };
   }, []);
 
-  return { clerks, isLoading };
+  return { clerks, isLoading, error };
 }

--- a/src/hooks/call-queue-clerks.hook.ts
+++ b/src/hooks/call-queue-clerks.hook.ts
@@ -19,7 +19,7 @@ export function useCallQueueClerks(): { clerks: string[]; isLoading: boolean; er
       .catch((e: unknown) => {
         if (!cancelled) {
           setClerks([]);
-          setError(e instanceof Error ? e.message : 'Unknown error');
+          setError(e instanceof Error && e.message ? e.message : 'Unknown error');
         }
       })
       .finally(() => {

--- a/src/screens/compliance-call-queue-detail.screen.tsx
+++ b/src/screens/compliance-call-queue-detail.screen.tsx
@@ -89,7 +89,7 @@ export default function ComplianceCallQueueDetailScreen(): JSX.Element {
   const { isLoggedIn } = useSessionContext();
   const { queue: queueParam, userDataId } = useParams<{ queue: string; userDataId: string }>();
   const { search } = useLocation();
-  const { clerks } = useCallQueueClerks();
+  const { clerks, error: clerksError, isLoading: clerksLoading } = useCallQueueClerks();
 
   const query = new URLSearchParams(search);
   const txIdParam = query.get('txId');
@@ -189,6 +189,8 @@ export default function ComplianceCallQueueDetailScreen(): JSX.Element {
         context={context}
         availableOutcomes={config.outcomes}
         clerks={clerks}
+        clerksError={clerksError}
+        clerksLoading={clerksLoading}
         onSaved={() =>
           navigate({ pathname: `/compliance/call-queues/${queue}` }, { replace: true, clearParams: ['txId'] })
         }


### PR DESCRIPTION
## What

The compliance call-queue outcome form is gated by the Signature dropdown: with an empty clerk list, `canSubmit` stays false and the "Save Outcome" button is permanently disabled — with no explanation whatsoever. When the clerk list fails to load, the error is swallowed silently as well.

This PR makes both states visible:

- `useCallQueueClerks` now reports a load `error` instead of swallowing it.
- `CallQueueOutcomeForm` renders an `ErrorHint` above the form when the clerk list is empty: either "could not load: <error>" or "no clerks configured — an admin has to fill the `complianceClerks` setting".
- The hint is suppressed while the list is still loading (no flash on mount).

## Why now

The change was originally built on 2026-07-31 in a session that a machine crash ended before the push; it was recovered from a local backup. The companion migration seeding `complianceClerks` was **dropped** during recovery: a check against the production DB showed the setting has existed since 2026-04-28 (`["CT","VR","YO","JR"]`) — only the silent-failure UX remained worth shipping.

## Coverage of touched files

| file | stmts | branch | funcs | lines |
|---|---|---|---|---|
| `src/hooks/call-queue-clerks.hook.ts` | 100 | 100 | 100 | 100 |
| `src/components/compliance/call-queue/call-queue-outcome-form.tsx` | 100 | 100 | 100 | 100 |
| `src/screens/compliance-call-queue-detail.screen.tsx` | 100 | 100 | 100 | 100 |

No deviations: the initially declared screen exception fell in review — capturing the `useLayoutOptions` argument in the existing mock suffices to invoke `onBack` and assert `navigate(-1)`.

Along the way the submit guard in the outcome form was removed: at runtime it duplicated the disabled-button gate (`canSubmit` requires outcome, signature and comment), so it could never fire; its only effect was type narrowing, which a documented cast tied to `canSubmit` now provides. 42 tests across the three suites, `lint`, `build:dev` and `widget:dev` are green.
