### PR TITLE
019ff5a5 - Clarify compliance refund UX for pending chargebacks

### DIFF
--- a/e2e/compliance-bank-tx-return.spec.ts
+++ b/e2e/compliance-bank-tx-return.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect, APIRequestContext, Page, Route } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createTestCredentials } from './test-wallet';
+
+/**
+ * E2E Visual Regression: Compliance bank-tx return / refund approval page
+ *
+ * Route: /compliance/bank-tx/:transactionId/return
+ *
+ * Auth is real; GET support/transaction/:id/refund is mocked with synthetic data so
+ * baselines stay deterministic and free of production PII.
+ *
+ * Name-mismatch nav-state is covered by unit tests (history.state is awkward across page.goto).
+ */
+
+const API_URL = process.env.REACT_APP_API_URL! + '/v1';
+const REFUND_RE = /\/v1\/support\/transaction\/\d+\/refund(?:\?|$)/;
+
+function getAdminSeed(): string {
+  const apiEnvPath = path.join(__dirname, '../../api/.env');
+  if (!fs.existsSync(apiEnvPath)) {
+    throw new Error(`API .env file not found at ${apiEnvPath}. Run 'npm run setup' in the API directory first.`);
+  }
+  const content = fs.readFileSync(apiEnvPath, 'utf8');
+  const match = content.match(/^ADMIN_SEED=(.*)$/m);
+  if (!match || !match[1]) {
+    throw new Error('ADMIN_SEED not found in API .env file. Run "npm run setup" in the API directory first.');
+  }
+  return match[1];
+}
+
+async function getAdminAuth(request: APIRequestContext): Promise<string> {
+  const adminSeed = getAdminSeed();
+  const credentials = await createTestCredentials(adminSeed);
+
+  const response = await request.post(`${API_URL}/auth`, {
+    data: credentials,
+  });
+
+  if (!response.ok()) {
+    const body = await response.text().catch(() => 'unknown');
+    throw new Error(`Admin auth failed: ${response.status()} - ${body}`);
+  }
+
+  const data = await response.json();
+  return data.accessToken;
+}
+
+const REFUND_FIXTURE = {
+  expiryDate: '2020-01-02T01:00:00.000Z',
+  fee: { dfx: 3, network: 0, bank: 2 },
+  refundAmount: 95,
+  refundAsset: { id: 1, name: 'EUR' },
+  inputAmount: 100,
+  inputAsset: { id: 1, name: 'EUR' },
+  refundTarget: 'DE89370400440532013000',
+  bankDetails: {
+    name: 'Erika Muster',
+    address: 'Main Street',
+    houseNumber: '1',
+    zip: '10115',
+    city: 'Berlin',
+    country: 'DE',
+    iban: 'DE89370400440532013000',
+  },
+};
+
+async function installRefundRoute(
+  page: Page,
+  options: { body?: unknown; status?: number; errorMessage?: string } = {},
+): Promise<void> {
+  await page.route('**/v1/**', async (route: Route) => {
+    const url = route.request().url();
+    if (REFUND_RE.test(url) && route.request().method() === 'GET') {
+      if (options.errorMessage) {
+        await route.fulfill({
+          status: options.status ?? 400,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: options.errorMessage }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: options.status ?? 200,
+        contentType: 'application/json',
+        body: JSON.stringify(options.body ?? REFUND_FIXTURE),
+      });
+      return;
+    }
+    await route.continue();
+  });
+}
+
+test.describe('Compliance bank-tx return - Visual Regression Tests', () => {
+  let token: string;
+
+  test.beforeAll(async ({ request }) => {
+    token = await getAdminAuth(request);
+  });
+
+  test('1. pending user refund form with prefilled creditor and approval banner', async ({ page }) => {
+    await installRefundRoute(page);
+
+    await page.goto(`/compliance/bank-tx/9002/return?session=${token}`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('pending-refund-banner')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Waiting for manual approval')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Confirm refund', exact: true })).toBeVisible();
+
+    await expect(page).toHaveScreenshot('bank-tx-return-01-pending-prefill.png', {
+      fullPage: true,
+      maxDiffPixels: 5000,
+    });
+  });
+
+  test('2. already charged back error is plain language', async ({ page }) => {
+    await installRefundRoute(page, { errorMessage: 'Transaction already charged back', status: 400 });
+
+    await page.goto(`/compliance/bank-tx/9002/return?session=${token}`);
+    await page.waitForLoadState('networkidle');
+
+    await expect(
+      page.getByText('This refund has already been approved or paid out and cannot be submitted again.'),
+    ).toBeVisible({ timeout: 15000 });
+
+    await expect(page).toHaveScreenshot('bank-tx-return-02-already-done.png', {
+      fullPage: true,
+      maxDiffPixels: 5000,
+    });
+  });
+});

--- a/scripts/handbook/metadata.json
+++ b/scripts/handbook/metadata.json
@@ -67,6 +67,10 @@
     "title": "Compliance: Offene Chargebacks",
     "description": "Liste offener Chargebacks mit Blockgründen, Namensvergleich und Leerzustand."
   },
+  "compliance-bank-tx-return": {
+    "title": "Compliance: Bank-Tx-Rückzahlung freigeben",
+    "description": "Rückzahlungsformular mit Banner für manuelle Freigabe und klarer Meldung wenn die Rückzahlung bereits freigegeben/ausgezahlt ist."
+  },
   "compliance-review-kyc-status": {
     "title": "Compliance KYC-Status",
     "description": "KYC-Status und AML-Reset in der Compliance-Review."

--- a/src/__tests__/compliance-bank-tx-return.screen.test.tsx
+++ b/src/__tests__/compliance-bank-tx-return.screen.test.tsx
@@ -1,0 +1,180 @@
+// Unit tests for ComplianceBankTxReturnScreen: error mapping and pending-approval banner.
+
+const mockGetTransactionRefundData = jest.fn();
+const mockChargebackTransaction = jest.fn();
+const mockGoBack = jest.fn();
+const mockUseComplianceGuard = jest.fn();
+const mockTranslate = jest.fn((ns: string, key: string) => key);
+
+let mockLocationState: unknown = undefined;
+
+jest.mock('@dfx.swiss/react', () => ({
+  Country: {},
+  Utils: { createRules: (r: unknown) => r },
+  Validations: { Required: { required: true } },
+}));
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  Form: ({ children }: { children: React.ReactNode }) => <form>{children}</form>,
+  SpinnerSize: { LG: 'lg' },
+  StyledButton: ({ label, onClick }: { label: string; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {label}
+    </button>
+  ),
+  StyledButtonColor: { WHITE: 'white' },
+  StyledButtonWidth: { FULL: 'full', MD: 'md' },
+  StyledLoadingSpinner: () => <div data-testid="loading-spinner" />,
+  StyledVerticalStack: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('react-hook-form', () => ({
+  useForm: () => ({
+    control: {},
+    handleSubmit: (fn: (data: unknown) => void) => () =>
+      fn({
+        iban: 'DE89370400440532013000',
+        creditorName: 'Erika Muster',
+        creditorStreet: 'Main',
+        creditorHouseNumber: '1',
+        creditorZip: '10115',
+        creditorCity: 'Berlin',
+        creditorCountry: { symbol: 'DE' },
+      }),
+    formState: { isValid: true, errors: {} },
+    setValue: jest.fn(),
+  }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ id: '9002' }),
+  useLocation: () => ({ state: mockLocationState }),
+}));
+
+jest.mock('src/components/error-hint', () => ({
+  ErrorHint: ({ message }: { message: string }) => <div data-testid="error-hint">{message}</div>,
+}));
+
+jest.mock('src/components/refund/refund-creditor-fields', () => ({
+  RefundCreditorFields: () => <div data-testid="creditor-fields" />,
+}));
+
+jest.mock('src/components/refund/refund-data-table', () => ({
+  RefundDataTable: () => <div data-testid="refund-data-table" />,
+}));
+
+jest.mock('src/contexts/layout.context', () => ({
+  useLayoutContext: () => ({ rootRef: { current: null } }),
+}));
+
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({
+    translate: mockTranslate,
+    translateError: (k: string) => k,
+    allowedCountries: [{ symbol: 'DE', name: 'Germany' }],
+  }),
+}));
+
+jest.mock('src/hooks/compliance.hook', () => ({
+  useCompliance: () => ({
+    getTransactionRefundData: mockGetTransactionRefundData,
+    chargebackTransaction: mockChargebackTransaction,
+  }),
+}));
+
+jest.mock('src/hooks/guard.hook', () => ({
+  useComplianceGuard: (...args: unknown[]) => mockUseComplianceGuard(...args),
+}));
+
+jest.mock('src/hooks/layout-config.hook', () => ({
+  useLayoutOptions: () => undefined,
+}));
+
+jest.mock('src/hooks/navigation.hook', () => ({
+  useNavigation: () => ({ goBack: mockGoBack }),
+}));
+
+jest.mock('src/util/validation-rules', () => ({
+  ZipValidation: { required: true },
+}));
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { ChargebackBlockReason } from 'src/dto/chargeback.dto';
+import ComplianceBankTxReturnScreen from 'src/screens/compliance-bank-tx-return.screen';
+
+const refundPayload = {
+  expiryDate: '2020-01-02T01:00:00.000Z',
+  fee: { dfx: 3, network: 0, bank: 2 },
+  refundAmount: 95,
+  refundAsset: { id: 1, name: 'EUR' },
+  inputAmount: 100,
+  inputAsset: { id: 1, name: 'EUR' },
+  refundTarget: 'DE89370400440532013000',
+  bankDetails: {
+    name: 'Erika Muster',
+    address: 'Main',
+    zip: '10115',
+    city: 'Berlin',
+    country: 'DE',
+    iban: 'DE89370400440532013000',
+  },
+};
+
+describe('ComplianceBankTxReturnScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocationState = undefined;
+    mockTranslate.mockImplementation((_ns: string, key: string) => key);
+    mockGetTransactionRefundData.mockResolvedValue(refundPayload);
+    mockChargebackTransaction.mockResolvedValue(undefined);
+  });
+
+  it('shows the pending-approval banner when bank details are prefilled from a user request', async () => {
+    render(<ComplianceBankTxReturnScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pending-refund-banner')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Waiting for manual approval')).toBeInTheDocument();
+    expect(screen.getByTestId('refund-data-table')).toBeInTheDocument();
+  });
+
+  it('highlights name mismatch when opened from the pending list with that block reason', async () => {
+    mockLocationState = {
+      pendingChargeback: {
+        blockReasons: [ChargebackBlockReason.NAME_MISMATCH],
+        verifiedName: 'Justus Fixture',
+        completeName: 'Justus Fixture',
+        creditorName: 'Erika Muster',
+        chargebackAmount: 95,
+        chargebackAsset: 'EUR',
+      },
+    };
+
+    render(<ComplianceBankTxReturnScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pending-refund-banner')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        'Name mismatch: the creditor name differs from the KYC name. Confirm the recipient before approving.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('Justus Fixture').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('maps already-charged-back API errors to plain language', async () => {
+    mockGetTransactionRefundData.mockRejectedValue(new Error('Transaction already charged back'));
+
+    render(<ComplianceBankTxReturnScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-hint')).toBeInTheDocument();
+    });
+    expect(mockTranslate).toHaveBeenCalledWith(
+      'screens/compliance',
+      'This refund has already been approved or paid out and cannot be submitted again.',
+    );
+  });
+});

--- a/src/__tests__/compliance-chargeback-list.screen.test.tsx
+++ b/src/__tests__/compliance-chargeback-list.screen.test.tsx
@@ -13,9 +13,7 @@ jest.mock('@dfx.swiss/react', () => ({
 
 jest.mock('@dfx.swiss/react-components', () => ({
   SpinnerSize: { SM: 'sm', LG: 'lg' },
-  StyledLoadingSpinner: ({ size }: { size?: string }) => (
-    <div data-testid="loading-spinner" data-size={size} />
-  ),
+  StyledLoadingSpinner: ({ size }: { size?: string }) => <div data-testid="loading-spinner" data-size={size} />,
   StyledVerticalStack: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
@@ -426,6 +424,17 @@ describe('ComplianceChargebackListScreen', () => {
       fireEvent.click(row);
     }
 
-    expect(mockNavigate).toHaveBeenCalledWith('compliance/bank-tx/9301/return');
+    expect(mockNavigate).toHaveBeenCalledWith('compliance/bank-tx/9301/return', {
+      state: {
+        pendingChargeback: {
+          blockReasons: entry.blockReasons,
+          verifiedName: entry.verifiedName,
+          completeName: entry.completeName,
+          creditorName: entry.creditorName,
+          chargebackAmount: entry.chargebackAmount,
+          chargebackAsset: entry.chargebackAsset,
+        },
+      },
+    });
   });
 });

--- a/src/components/compliance/chargeback-modal.tsx
+++ b/src/components/compliance/chargeback-modal.tsx
@@ -19,6 +19,7 @@ import { RefundDataTable } from 'src/components/refund/refund-data-table';
 import { useLayoutContext } from 'src/contexts/layout.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { TransactionRefundData, useCompliance } from 'src/hooks/compliance.hook';
+import { mapRefundApiError } from 'src/util/refund-error';
 import { ZipValidation } from 'src/util/validation-rules';
 
 interface ChargebackModalProps {
@@ -114,7 +115,9 @@ export function ChargebackModal({
         if (data.refundTarget) setValue('refundAddress', data.refundTarget);
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load refund data');
+      const raw = e instanceof Error ? e.message : 'Failed to load refund data';
+      const mapped = mapRefundApiError(raw);
+      setError(mapped !== raw.trim() ? translate('screens/compliance', mapped) : raw);
     } finally {
       setIsLoading(false);
     }
@@ -147,7 +150,9 @@ export function ChargebackModal({
       });
       onSuccess();
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Chargeback failed');
+      const raw = e instanceof Error ? e.message : 'Chargeback failed';
+      const mapped = mapRefundApiError(raw);
+      setError(mapped !== raw.trim() ? translate('screens/compliance', mapped) : raw);
     } finally {
       setIsSubmitting(false);
     }

--- a/src/screens/compliance-bank-tx-return.screen.tsx
+++ b/src/screens/compliance-bank-tx-return.screen.tsx
@@ -8,18 +8,20 @@ import {
   StyledLoadingSpinner,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { ErrorHint } from 'src/components/error-hint';
 import { RefundCreditorFields } from 'src/components/refund/refund-creditor-fields';
 import { RefundDataTable } from 'src/components/refund/refund-data-table';
 import { useLayoutContext } from 'src/contexts/layout.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
+import { ChargebackBlockReason } from 'src/dto/chargeback.dto';
 import { TransactionRefundData, useCompliance } from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
+import { isPendingChargebackNavState, mapRefundApiError, PendingChargebackNavState } from 'src/util/refund-error';
 import { ZipValidation } from 'src/util/validation-rules';
 
 interface FormData {
@@ -32,14 +34,33 @@ interface FormData {
   creditorCountry: Country;
 }
 
+function formatError(e: unknown, translate: (ns: string, key: string) => string): string {
+  const raw = e instanceof Error ? e.message : 'Unknown error';
+  const mapped = mapRefundApiError(raw);
+  // Prefer translated compliance copy when we rewrote the message; fall back to raw API text.
+  if (mapped !== raw.trim()) {
+    return translate('screens/compliance', mapped);
+  }
+  return raw;
+}
+
 export default function ComplianceBankTxReturnScreen(): JSX.Element {
   useComplianceGuard();
 
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
   const { translate, translateError, allowedCountries } = useSettingsContext();
   const { getTransactionRefundData, chargebackTransaction } = useCompliance();
   const { goBack } = useNavigation();
   const { rootRef } = useLayoutContext();
+
+  const pendingContext = useMemo((): PendingChargebackNavState | undefined => {
+    const state = location.state as { pendingChargeback?: unknown } | null;
+    if (state?.pendingChargeback && isPendingChargebackNavState(state.pendingChargeback)) {
+      return state.pendingChargeback;
+    }
+    return undefined;
+  }, [location.state]);
 
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -81,7 +102,7 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
         }
       }
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Unknown error');
+      setError(formatError(e, translate));
     } finally {
       setIsLoading(false);
     }
@@ -107,7 +128,7 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
       });
       setSuccess(true);
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Unknown error');
+      setError(formatError(e, translate));
     } finally {
       setIsSubmitting(false);
     }
@@ -123,6 +144,12 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
   });
 
   useLayoutOptions({ title: translate('screens/compliance', 'Bank Transaction Return') });
+
+  const hasNameMismatch = pendingContext?.blockReasons.includes(ChargebackBlockReason.NAME_MISMATCH);
+  // Prefill already happened from API bankDetails; show context when we came from the pending list
+  // or when the API returned creditor-style bank details after a user refund request.
+  const showPendingBanner =
+    pendingContext != null || (refundData?.bankDetails?.name != null && refundData.bankDetails.name.trim() !== '');
 
   if (success) {
     return (
@@ -155,6 +182,65 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
 
   return (
     <StyledVerticalStack gap={6} full>
+      {showPendingBanner && (
+        <div
+          className={`rounded-lg border p-4 text-sm ${
+            hasNameMismatch
+              ? 'border-dfxYellow-500 bg-dfxYellow-500/10 text-dfxBlue-800'
+              : 'border-dfxGray-400 bg-dfxGray-300/40 text-dfxBlue-800'
+          }`}
+          data-testid="pending-refund-banner"
+        >
+          <p className="font-semibold mb-1">{translate('screens/compliance', 'Waiting for manual approval')}</p>
+          <p className="mb-2">
+            {translate(
+              'screens/compliance',
+              'Customer refund request — review the details and approve to release the payout.',
+            )}
+          </p>
+          {hasNameMismatch && (
+            <p className="mb-2 text-primary-red font-medium">
+              {translate(
+                'screens/compliance',
+                'Name mismatch: the creditor name differs from the KYC name. Confirm the recipient before approving.',
+              )}
+            </p>
+          )}
+          {(pendingContext?.verifiedName ||
+            pendingContext?.completeName ||
+            pendingContext?.creditorName ||
+            refundData.bankDetails?.name) && (
+            <div className="flex flex-col gap-1 text-xs mt-2">
+              {pendingContext?.verifiedName != null && (
+                <span>
+                  <span className="text-dfxGray-700">{translate('screens/compliance', 'KYC verified name')}: </span>
+                  {pendingContext.verifiedName}
+                </span>
+              )}
+              {pendingContext?.completeName != null && (
+                <span>
+                  <span className="text-dfxGray-700">{translate('screens/compliance', 'Complete name')}: </span>
+                  {pendingContext.completeName}
+                </span>
+              )}
+              <span>
+                <span className="text-dfxGray-700">{translate('screens/compliance', 'Creditor name')}: </span>
+                {pendingContext?.creditorName ?? refundData.bankDetails?.name ?? '-'}
+              </span>
+              {(pendingContext?.chargebackAmount != null || refundData.refundAmount != null) && (
+                <span>
+                  <span className="text-dfxGray-700">
+                    {translate('screens/compliance', 'Requested chargeback amount')}:{' '}
+                  </span>
+                  {pendingContext?.chargebackAmount ?? refundData.refundAmount}{' '}
+                  {pendingContext?.chargebackAsset ?? refundData.refundAsset?.name ?? ''}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
       <RefundDataTable refundData={refundData} />
 
       <Form

--- a/src/screens/compliance-chargeback-list.screen.tsx
+++ b/src/screens/compliance-chargeback-list.screen.tsx
@@ -66,9 +66,7 @@ export default function ComplianceChargebackListScreen(): JSX.Element {
 
   function blockReasonBadge(reason: ChargebackBlockReason): JSX.Element {
     const isUserNotReleased = reason === ChargebackBlockReason.USER_NOT_RELEASED;
-    const classes = isUserNotReleased
-      ? 'bg-dfxGray-300 text-primary-red'
-      : 'bg-dfxGray-300 text-dfxBlue-800';
+    const classes = isUserNotReleased ? 'bg-dfxGray-300 text-primary-red' : 'bg-dfxGray-300 text-dfxBlue-800';
     return (
       <span key={reason} className={`px-2 py-1 rounded text-xs font-semibold ${classes}`}>
         {reason}
@@ -104,7 +102,20 @@ export default function ComplianceChargebackListScreen(): JSX.Element {
                     <tr
                       key={`${entry.sourceType}-${entry.entityId}-${entry.txId}`}
                       className={rowClassName(entry)}
-                      onClick={() => navigate(`compliance/bank-tx/${entry.txId}/return`)}
+                      onClick={() =>
+                        navigate(`compliance/bank-tx/${entry.txId}/return`, {
+                          state: {
+                            pendingChargeback: {
+                              blockReasons: entry.blockReasons,
+                              verifiedName: entry.verifiedName,
+                              completeName: entry.completeName,
+                              creditorName: entry.creditorName,
+                              chargebackAmount: entry.chargebackAmount,
+                              chargebackAsset: entry.chargebackAsset,
+                            },
+                          },
+                        })
+                      }
                     >
                       <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">
                         {formatDate(entry.requestedDate)}

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -71,9 +71,7 @@
     "Allowed formats: PDF, JPG, JPEG, PNG": "Erlaubte Formate: PDF, JPG, JPEG, PNG",
     "Invalid date format": "Ungültiges Datumsformat",
     "Maximum allowed characters: 4000": "Maximal erlaubte Zeichen: 4000",
-
     "No entries yet": "Noch keine Einträge vorhanden",
-
     "Something went wrong. Please try again. If the issue persists please reach out to our support.": "Irgendwas hat nicht funktioniert, bitte versuche es noch einmal. Wenn das Problem weiterhin besteht, wende Dich bitte an unseren Support.",
     "invoice": "DFX kennt keinen Empfänger mit dem Namen <strong>{{recipient}}</strong>. Dieser Service kann nur für Empfänger verwendet werden, die ein aktives Konto bei DFX haben und für den Rechnungsservice aktiviert sind. Solltest Du Dich als Empfänger bei DFX registrieren wollen, dann melde Dich beim Support unter <link>{{supportLink}}</link>.",
     "iban": "Dies ist eine Multi-Account-IBAN und kann nicht als persönliches Konto hinzugefügt werden. Bitte öffne ein Support-Ticket auf <1></1> und füge die Bestätigung der Banktransaktion als PDF bei."
@@ -92,15 +90,12 @@
     "KYC progress": "KYC-Fortschritt",
     "This step has already been finished.": "Dieser Schritt ist bereits abgeschlossen.",
     "This step has failed.": "Dieser Schritt ist fehlgeschlagen.",
-
     "per 24h": "pro 24h",
     "per 30 days": "pro 30 Tage",
     "per year": "pro Jahr",
-
     "Terminated": "Beendet",
     "Rejected": "Abgelehnt",
     "Level {{level}}": "Level {{level}}",
-
     "Contact data": "Kontaktdaten",
     "Personal data": "Persönliche Daten",
     "Identification": "Identifikation",
@@ -120,7 +115,6 @@
     "Residence permit": "Aufenthaltsbewilligung",
     "Association statutes": "Vereinsstatuten",
     "DFX approval": "DFX-Genehmigung",
-
     "Stock corporation (AG, Ltd, SA)": "Aktiengesellschaft (AG)",
     "Limited liability company under Swiss/German/Austrian law (GmbH, LLC, Sàrl)": "Gesellschaft mit beschränkter Haftung (GmbH)",
     "Entrepreneurial company (UG)": "Unternehmergesellschaft (UG)",
@@ -143,25 +137,19 @@
     "Simple and flexible form of cooperation between two or more people who join forces for a common purpose": "Einfache und flexible Form der Zusammenarbeit zwischen zwei oder mehr Personen, die sich für einen gemeinsamen Zweck zusammenschließen",
     "An internet excerpt is sufficient. No notarization is required. The extract must not be older than 2 months.": "Ein Internetauszug ist ausreichend. Eine notarielle Beglaubigung ist nicht erforderlich. Der Auszug darf nicht älter als 2 Monate sein.",
     "Document template": "Dokument-Vorlage",
-
     "Female": "Weiblich",
     "Male": "Männlich",
-
     "Birthday": "Geburtstag",
     "YYYY-MM-DD": "JJJJ-MM-TT",
-
     "Passport": "Pass",
     "ID card": "ID-Karte",
     "Driver's license": "Führerschein",
-
     "Authorized to sign individually": "Einzelunterschriftberechtigt",
     "Authorized to sign jointly": "Unterschriftsberechtigt zu zweit",
     "No signing authorization": "Keine Unterschriftsberechtigung",
-
     "auto": "auto",
     "video": "video",
     "manual": "manuell",
-
     "Not started": "Nicht gestartet",
     "In progress": "In Bearbeitung",
     "In review": "In Prüfung",
@@ -169,9 +157,7 @@
     "Failed": "Gescheitert",
     "Outdated": "Veraltet",
     "Data requested": "Daten angefordert",
-
     "Optional": "Optional",
-
     "Account Type": "Kontotyp",
     "Personal": "Privatkonto",
     "Organization / company": "Organisation / Firma",
@@ -210,21 +196,17 @@
     "Identification document": "Identifikationsdokument",
     "Document type": "Dokumenttyp",
     "Document number": "Dokumentnummer",
-
     "Sole proprietorship confirmation": "Bestätigung als Einzelunternehmen",
     "Commercial register extract, trade license/permit, AHV confirmation, or another document proving the existence of the business": "Handelsregisterauszug, Gewerbeschein/-bewilligung, AHV-Bestätigung, oder ein anderes Dokument welches die Existenz des Gewerbes nachweist",
-
     "Please fill in personal information to continue": "Bitte gib Deine persönlichen Daten ein, um fortzufahren",
     "How did you hear about DFX?": "Wie bist Du auf DFX aufmerksam geworden?",
     "Please enter your contact information so that we can find your account": "Bitte gib Deine Kontaktinformationen ein, damit wir Dein Konto finden können",
-
     "How many natural persons are there who directly or indirectly hold 25% or more of company shares?": "Wie viele natürliche Personen gibt es, die direkt oder indirekt 25 % oder mehr der Unternehmensanteile halten?",
     "None": "Keine",
     "Is the account holder {{name}}{{role}}?": "Ist der Kontoinhaber {{name}}{{role}}?",
     "the managing director": "der Geschäftsführer",
     "a beneficial owner": "ein wirtschaftlich Berechtigter",
     "Managing director": "Geschäftsführer",
-
     "It looks like you already have an account with DFX.": "Wie es aussieht, hast Du bereits ein Konto bei DFX.",
     "We have just sent you an email. To continue with your existing account, please confirm your email address by clicking on the link sent.": "Wir haben Dir gerade eine E-Mail geschickt. Um mit Deinem bestehenden Konto fortzufahren, bestätige bitte Deine E-Mail-Adresse, indem Du auf den zugesandten Link klickst.",
     "We have sent a 6-digit code to your new email address. Please enter it here.": "Wir haben einen 6-stelligen Code an Deine neue E-Mail-Adresse gesendet. Bitte gib ihn hier ein.",
@@ -255,34 +237,28 @@
     "I am already verified with DFX": "Ich bin bereits bei DFX verifiziert",
     "I hereby authorize DFX to transfer my KYC data to {{client}}.": "Hiermit beauftrage ich DFX, meine KYC-Daten an {{client}} zu übermitteln.",
     "The identification has failed.": "Die Identifizierung ist fehlgeschlagen.",
-
     "Merging your accounts...": "Deine Konten werden zusammengeführt...",
     "Account merged successfully!": "Konto erfolgreich zusammengeführt!",
     "You can now access your account.": "Du kannst jetzt auf Dein Konto zugreifen.",
     "My account": "Mein Konto",
-
     "Upload your SEPA file here": "Lade Deine SEPA-Datei hier hoch",
     "Uploaded": "Hochgeladen",
-
     "KYC file": "KYC Datei",
     "Name check": "Namensprüfung",
     "User information": "Benutzerinformationen",
     "User notes": "Benutzernotizen",
     "Transaction notes": "Transaktionsnotizen",
     "Stock register": "Aktienregister",
-
     "File download": "Datei-Download",
     "Data upload": "Data Upload",
     "UserData ID": "UserData ID",
     "UserData IDs": "UserData IDs",
     "Event date": "Datum des Ereignisses",
     "Comment": "Kommentar",
-
     "Is the organization operationally active?": "Ist die Organisation operativ tätig?",
     "Organizations that primarily manage their own money, such as investment companies, are considered non-operating. Operationally active organizations are those that offer and sell goods or services, conduct regular business activities that generate revenue, employ staff and have operational structures.": "Organisationen, die in erster Linie ihr eigenes Geld verwalten, wie z. B. Investmentgesellschaften, gelten als nicht-operativ. Operativ tätige Organisationen sind solche, die Waren oder Dienstleistungen anbieten und verkaufen, regelmäßige Geschäftstätigkeiten durchführen, die Einnahmen generieren, Personal beschäftigen und über betriebliche Strukturen verfügen.",
     "Organization website (optional)": "Website der Organisation (optional)",
     "https://my-organization.org": "https://meine-firma.org",
-
     "Purpose of the payments": "Zweck der Zahlungen",
     "Purpose": "Zweck",
     "Assignment agreement": "Forderungsabtretungsvertrag (Zession)",
@@ -292,12 +268,10 @@
     "My organization": "Meine Firma",
     "Registration number": "Registrierungsnummer",
     "CHE-000.000.000": "CHE-000.000.000",
-
     "Store type": "Geschäftstyp",
     "Online": "Online",
     "Physical": "Physisch",
     "Online and physical": "Online und physisch",
-
     "Merchant category": "Händlerkategorie",
     "Accommodation and food services": "Beherbergung und Gastronomie",
     "Administrative support & waste management": "Verwaltungsdienstleistungen & Abfallwirtschaft",
@@ -344,11 +318,9 @@
     "Transportation & warehousing": "Transport & Lagerung",
     "Utilities": "Versorgungsunternehmen",
     "Other crypto/Web3 services": "Andere Krypto-/Web3-Dienste",
-
     "Goods type": "Warenart",
     "Tangible": "Physisch",
     "Virtual": "Virtuell",
-
     "Goods category": "Warenkategorie",
     "Electronics & computers": "Elektronik & Computer",
     "Books, music & movies": "Bücher, Musik & Filme",
@@ -366,18 +338,14 @@
     "Food, grocery & health products": "Lebensmittel, Supermarkt & Gesundheitsprodukte",
     "Pet supplies": "Tierbedarf",
     "Industry & science": "Industrie & Wissenschaft",
-
     "Recall agreement": "Rückrufvereinbarung",
-
     "ownFundsWarning": "Die <1>vorsätzliche</1> Angabe falscher Informationen in diesem Formular ist eine strafbare Handlung (Urkundenfälschung gemäss Artikel 251 des Schweizerischen Strafgesetzbuchs).",
-
     "Recommendation": "Empfehlung",
     "Please enter the email address or referral code of your contact person. This lets us know you have a trusted contact to guide you into the crypto space.": "Gib bitte die E-Mail-Adresse oder den Empfehlungs-/Referenzcode Deiner Ansprechperson ein. Damit wissen wir, dass Du einen vertrauenswürdigen Kontakt hast, der Dich beim Einstieg ins Kryptoumfeld begleitet.",
     "Invitation/referral code or email": "Einladungs-/Referral-Code oder E-Mail",
     "No matching user found": "Kein passender Benutzer gefunden",
     "Invalid invitation code": "Ungültiger Einladungscode",
     "Invalid key": "Ungültiger Key",
-
     "FAQ": "FAQ",
     "How can I become a DFX customer?": "Wie kann ich Kunde bei DFX werden?",
     "Opening an account with DFX is only possible through a referral. You need either the ref code, ref link, or email address of an existing customer. This person serves as your point of contact and must additionally confirm their referral. Once this confirmation is received, you can complete your onboarding and use your DFX account.": "Eine Kontoeröffnung bei DFX ist ausschliesslich über Empfehlung möglich. Du benötigst dafür entweder den Ref-Code, den Ref-Link oder die E-Mail-Adresse eines Bestandskunden. Diese Person dient Dir als Ansprechstelle und muss ihre Empfehlung zusätzlich bestätigen. Sobald diese Bestätigung vorliegt, kannst Du Dein Onboarding vollständig abschliessen und Deinen DFX Account nutzen.",
@@ -441,7 +409,19 @@
     "Re-screen": "Neu screenen",
     "Re-screen transaction": "Transaktion neu screenen",
     "Re-screening consumes provider quota and costs money – continue?": "Ein erneutes Screening verbraucht Provider-Kontingent und kostet Geld – fortfahren?",
-    "Linked transaction": "Verknüpfte Transaktion"
+    "Linked transaction": "Verknüpfte Transaktion",
+    "This refund has already been approved or paid out and cannot be submitted again.": "Diese Rückzahlung wurde bereits freigegeben oder ausgezahlt und kann nicht erneut eingereicht werden.",
+    "Refund details expired. Reload the page and try again.": "Die Rückzahlungsdaten sind abgelaufen. Seite neu laden und erneut versuchen.",
+    "This transaction cannot be refunded with the current AML reason.": "Diese Transaktion kann mit dem aktuellen AML-Grund nicht zurückgezahlt werden.",
+    "Creditor details are required for bank refunds.": "Für Bank-Rückzahlungen sind Gläubigerdaten erforderlich.",
+    "The chargeback IBAN is invalid or the BIC is missing.": "Die Chargeback-IBAN ist ungültig oder die BIC fehlt.",
+    "Customer refund request — review the details and approve to release the payout.": "Kunden-Rückzahlungsantrag — Details prüfen und freigeben, um die Auszahlung anzustossen.",
+    "Name mismatch: the creditor name differs from the KYC name. Confirm the recipient before approving.": "Namensabweichung: Gläubigername weicht vom KYC-Namen ab. Empfänger vor Freigabe bestätigen.",
+    "KYC verified name": "KYC-verifizierter Name",
+    "Complete name": "Vollständiger Name",
+    "Creditor name": "Gläubigername",
+    "Requested chargeback amount": "Beantragter Chargeback-Betrag",
+    "Waiting for manual approval": "Wartet auf manuelle Freigabe"
   },
   "screens/2fa": {
     "2FA": "2FA",
@@ -482,7 +462,6 @@
   },
   "screens/error": {
     "Oh, sorry, something went wrong": "Entschuldigung, irgendwas hat nicht funktioniert",
-
     "Invalid link": "Ungültiger Link",
     "Merge is already completed": "Zusammenführung ist bereits abgeschlossen",
     "Merging your accounts is taking longer than expected. Please try again later.": "Die Zusammenführung Deiner Konten dauert länger als erwartet. Bitte versuche es später erneut.",
@@ -497,12 +476,9 @@
     "Coming Soon": "Coming Soon",
     "Login to DFX Services": "Login bei DFX Services",
     "We have sent an email with further instructions to the address provided.": "Wir haben eine E-Mail mit weiteren Anweisungen an die angegebene Adresse gesendet.",
-
     "Logging in...": "Anmelden...",
-
     "Scan with your wallet": "Scanne mit Deiner Wallet",
     "Connect your wallet": "Verbinde Deine Wallet",
-
     "Please confirm the connection in your MetaMask.": "Bitte bestätige die Verbindung in Deiner MetaMask.",
     "Please confirm the connection in the Alby browser extension.": "Bitte bestätige die Verbindung in der Alby Browsererweiterung.",
     "Please confirm the connection in your Phantom browser extension.": "Bitte bestätige die Verbindung in der Phantom Browsererweiterung.",
@@ -512,37 +488,29 @@
     "Please confirm the connection with your Ledger.": "Bitte bestätige die Verbindung mit Deinem Ledger.",
     "Connection failed!": "Verbindung fehlgeschlagen!",
     "Please make sure that all other applications and browser extensions that are connected to the ledger are completely closed when you try to connect.\nThis includes third-party wallets (Ledger Live, Metamask, Daedalus, MyEtherWallet) or other applications that could interfere with the connection between DFX.swiss and your ledger device.": "Bitte stelle sicher, dass alle anderen Anwendungen und Browsererweiterungen, die mit dem Ledger verbunden sind, vollständig geschlossen sind, wenn Du versuchst, eine Verbindung herzustellen.\nDazu gehören Wallets von Drittanbietern (Ledger Live, Metamask, Daedalus, MyEtherWallet) oder andere Anwendungen, die die Verbindung zwischen DFX.swiss und Deinem Ledger-Gerät stören könnten.",
-
     "Connect your {{device}} with your computer": "Verbinde Deinen {{device}} mit Deinem Computer",
     "Click on \"Connect\"": "Klicke auf \"Verbinden\"",
     "Click on \"Continue\"": "Klicke auf \"Weiter\"",
     "Confirm \"Sign message\" on your {{device}}": "Bestätige \"Sign message\" auf Deinem {{device}}",
-
     "Load more addresses": "Lade mehr Adressen",
     "Address type": "Adresstyp",
     "Address index": "Adressindex",
     "Account index": "Accountindex",
-
     "Open the {{app}} app on your Ledger": "Öffne die {{app}} App auf Deinem Ledger",
-
     "Enter your password on your BitBox": "Gib Dein Passwort auf Deinem BitBox ein",
     "Confirm the pairing code": "Bestätige den Pairing-Code",
     "Pairing code": "Pairing-Code",
     "Check that the pairing code below matches the one displayed on your BitBox": "Prüfe, ob der untenstehende Pairing-Code mit dem auf Deinem BitBox angezeigten übereinstimmt",
     "Confirm the pairing code on your BitBox": "Bestätige den Pairing-Code auf Deinem BitBox",
-
     "Click on \"Continue in Trezor Connect\"": "Klicke auf \"Weiter zu Trezor Connect\"",
     "Follow the steps in the Trezor Connect website": "Führe die Schritte in der Trezor Connect Webseite aus",
-
     "Login with your BTC Taro Wallet": "Anmeldung mit Deiner BTC Taro Wallet",
     "Install BTC Taro": "BTC Taro installieren",
     "Pay in app": "Bezahlen in der App",
     "Open app and scan QR code again": "App öffnen und QR Code erneut scannen",
     "App temporarily unavailable": "App vorübergehend nicht verfügbar",
-
     "Log in to your DFX account by verifying with your signature that you are the sole owner of the provided blockchain address.": "Melde Dich bei Deinem DFX-Konto an, indem Du mit Deiner Unterschrift bestätigst, dass Du der alleinige Eigentümer der angegebenen Blockchain-Adresse bist.",
     "Don't show this again.": "Nicht mehr anzeigen.",
-
     "Please install MetaMask or Rabby!": "Bitte installiere MetaMask oder Rabby!",
     "You need to install the MetaMask or Rabby browser extension to be able to use this service.": "Um diesen Dienst nutzen zu können, musst Du die Browsererweiterung MetaMask oder Rabby installieren.",
     "Please install Alby!": "Bitte installiere Alby!",
@@ -557,26 +525,21 @@
     "Mobile not supported!": "Mobile nicht unterstützt!",
     "Please use a desktop device with a compatible browser (e.g. Chrome) to be able to use this service.": "Bitte verwende ein Desktop-Gerät mit einem kompatiblen Browser (z.B. Chrome), um diesen Dienst nutzen zu können.",
     "visit": "Siehe <1></1> für mehr Details.",
-
     "Please install {{wallet}} from the wallet provider's website.": "Bitte installiere {{wallet}} von der Website des Wallet-Anbieters.",
     "Open website": "Website öffnen",
-
     "Unfortunately, DFX.swiss does not offer the purchase and sale of {{token}} tokens.": "Leider bietet DFX.swiss den Kauf und Verkauf von {{token}} Token nicht an.",
     "If you are still interested, you can visit their website.": "Falls Du dennoch Interesse hast, kannst Du ihre Website besuchen.",
     "private": "Falls Du dennoch Interesse hast, kannst Du die Website <2></2> über den unten stehenden Button besuchen.",
     "The website allows you to interact with the {{name}} smart contract and trade {{symbol}} tokens. Please note that this is not an offer from DFX, it is not a recommendation and it is in no way a solicitation to trade. With this message DFX only points out that this technical possibility exists, nothing more. It is imperative that you inform yourself about all the details beforehand and always be aware that you are always trading on your own responsibility.": "Die Website ermöglicht, mit dem {{name}} Smart Contract zu interagieren und {{symbol}} Token zu handeln. Bitte beachte, dass dies kein Angebot von DFX ist, dass es keine Empfehlung ist und dass es in keinster Weise eine Handelsaufforderung ist. DFX weist mit dieser Nachricht einzig darauf hin, dass es diese technische Möglichkeit gibt, mehr nicht. Informiere Dich zwingend vorher über alle Details und sei Dir stehts bewusst, dass Du immer in eigener Verantwortung handelst.",
-
     "Blockchain": "Blockchain",
     "Address": "Adresse",
     "Signature": "Signatur",
     "Sign message": "Nachricht zum Signieren",
     "Instructions": "Anleitung",
-
     "Account": "Konto",
     "Profile": "Profil",
     "Email": "E-Mail",
     "Name": "Name",
-    "Address": "Adresse",
     "Organization": "Organisation",
     "Activity": "Aktivität",
     "Active address": "Aktive Adresse",
@@ -594,12 +557,9 @@
     "Paid credit": "Ausgezahltes Guthaben",
     "User count": "Anzahl Benutzer",
     "Active user count": "Anzahl aktiver Benutzer",
-
     "Please select an address or add a new one to continue.": "Bitte wähle eine Adresse aus oder füge eine neue hinzu, um fortzufahren.",
-
     "PDF Download Address Report": "PDF Adressbericht herunterladen",
     "Date": "Datum",
-
     "Change phone number": "Telefonnummer ändern",
     "Change address": "Adresse ändern",
     "Change name": "Name ändern",
@@ -611,52 +571,38 @@
     "You spend": "Du zahlst",
     "You get": "Du erhältst",
     "You get about": "Du erhältst ungefähr",
-
     "Target address": "Ziel-Adresse",
     "Switch address": "Adresse wechseln",
     "Login with a different address": "Mit einer anderen Adresse anmelden",
     "Are you sure you want to send to a different address?": "Bist Du sicher, dass Du auf eine andere Adresse senden willst?",
-
     "Use {{chain}} as a Layer 2 solution to benefit from lower transaction fees": "Verwende {{chain}} als Layer-2-Lösung, um von niedrigeren Transaktionsgebühren zu profitieren",
-
     "Done!": "Fertig!",
     "Click here once you have issued the transfer": "Klicke hier, sobald Du die Überweisung getätigt hast",
-
     "Please transfer the purchase amount using this information via your banking application. The remittance info is important!": "Bitte überweise den Kaufbetrag mit diesen Angaben über Deine Bankanwendung. Der Verwendungszweck ist wichtig!",
     "Please transfer the purchase amount using this information via your banking application. This IBAN is unique to this asset, no remittance info is required.": "Bitte überweise den Kaufbetrag mit diesen Angaben über Deine Bankanwendung. Dieser IBAN ist einzigartig für dieses Asset, kein Verwendungszweck erforderlich.",
-
     "The remittance info remains identical for the selected asset and can be used for recurring payments and standing orders": "Der Verwendungszweck bleibt für das ausgewählte Asset identisch und kann für wiederkehrende Zahlungen und Daueraufträge verwendet werden",
-
     "Name": "Name",
     "Address": "Adresse",
-
     "As soon as the transfer arrives in our bank account, we will transfer your asset to your wallet.": "Sobald die Überweisung auf unserem Bankkonto eingegangen ist, werden wir das Asset in Deine Wallet übertragen.",
     "Waiting for the payment confirmation ... this may take a moment.": "Warten auf die Zahlungsbestätigung ... das kann einen Moment dauern.",
-
     "PDF Invoice": "PDF-Rechnung",
     "QR-bill": "QR-Rechnung",
-
     "The output amount is computed as the input amount minus the DFX fee, bank fee and the network fee over the base rate. That is, {{output}} {{outputSymbol}} = ({{input}} {{inputSymbol}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}) ÷ {{baseRate}}.": "Der Ausgabebetrag wird als Eingabebetrag abzüglich der DFX-Gebühr, Bankgebühr und Netzwerkgebühr über dem Basiskurs berechnet. Das heißt, {{output}} {{outputSymbol}} = ({{input}} {{inputSymbol}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}) ÷ {{baseRate}}.",
     "Output amount = (Input amount - DFX fee - Network fee) ÷ Base rate.": "Ausgabebetrag = (Eingabebetrag - DFX-Gebühr - Netzwerkgebühr) ÷ Basiskurs."
   },
   "screens/sell": {
     "Add or select your IBAN": "Deine IBAN hinzufügen oder auswählen",
     "Select payment account": "Bankkonto auswählen",
-
     "Send the selected amount to the address below. This address can be used multiple times, it is always the same for payouts from {{chain}} to your IBAN {{iban}} in {{currency}}.": "Sende den ausgewählten Betrag an die untenstehende Adresse. Diese Adresse kann mehrfach verwendet werden, sie ist immer die gleiche für Auszahlungen von {{chain}} an Deine IBAN {{iban}} in {{currency}}.",
     "Address": "Adresse",
-
     "Click here once you have issued the transaction": "Klicke hier, sobald Du die Transaktion getätigt hast",
     "Complete transaction in your wallet": "Schliesse die Transaktion in Deiner Wallet ab",
     "Pay with your wallet": "Bezahle mit Deiner Wallet",
     "Transaction hash": "Transaktions-Hash",
     "Transaction failed. Click Retry to see the deposit address for manual transfer.": "Transaktion fehlgeschlagen. Klicke auf Wiederholen, um die Einzahlungsadresse für eine manuelle Überweisung zu sehen.",
-
     "Optional - Account Designation": "Optional - Kontobezeichnung",
     "e.g. Deutsche Bank": "z.B. Deutsche Bank",
-
     "As soon as the transaction arrives in our wallet, we will transfer your money to your bank account.": "Sobald die Transaktion in unserem Wallet eingegangen ist, werden wir Dein Guthaben auf Dein Bankkonto überweisen.",
-
     "The output amount is computed as the input amount times the base rate minus the DFX fee, bank fee and the network fee. That is, {{output}} {{inputSymbol}} = {{input}} {{outputSymbol}} × {{baseRate}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}.": "Der Ausgabebetrag wird als Eingabebetrag multipliziert mit dem Basiskurs abzüglich der DFX-Gebühr, Bankgebühr und Netzwerkgebühr berechnet. Das heißt, {{output}} {{inputSymbol}} = {{input}} {{outputSymbol}} × {{baseRate}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}.",
     "Output amount = Input amount × Base rate - DFX fee - Network fee.": "Ausgabebetrag = Eingabebetrag × Basiskurs - DFX-Gebühr - Netzwerkgebühr."
   },
@@ -706,7 +652,6 @@
     "This bank no longer accepts payments. Please start a new purchase.": "Diese Bank akzeptiert keine Zahlungen mehr. Bitte starte einen neuen Kauf.",
     "The selected currency is not available. Please try a different currency or contact support.": "Die gewählte Währung ist nicht verfügbar. Bitte wähle eine andere Währung oder kontaktiere den Support.",
     "No bank is available for this currency. Please try a different currency or contact support.": "Für diese Währung ist keine Bank verfügbar. Bitte wähle eine andere Währung oder kontaktiere den Support.",
-
     "Exchange rate": "Wechselkurs",
     "Base rate": "Basiskurs",
     "Total fee": "Gesamtgebühr",
@@ -717,9 +662,7 @@
     "Bank fee (fixed)": "Bankgebühr (fix)",
     "Bank fee (percent)": "Bankgebühr (prozentual)",
     "Network start fee": "Netzwerk-Startgebühr",
-
     "Your payment has failed. Please try again.": "Deine Zahlung ist fehlgeschlagen. Bitte versuche es erneut.",
-
     "Transactions": "Transaktionen",
     "Transaction": "Transaktion",
     "Your Transactions": "Deine Transaktionen",
@@ -730,7 +673,6 @@
     "Transaction refund": "Rückerstattung der Transaktion",
     "{{from}} to {{to}} at {{price}} {{from}}/{{to}} ({{source}}, {{timestamp}})": "{{from}} zu {{to}} bei {{price}} {{from}}/{{to}} ({{source}}, {{timestamp}})",
     "No transactions yet": "Noch keine Transaktionen",
-
     "ID": "ID",
     "External ID": "Externe ID",
     "Date": "Datum",
@@ -741,7 +683,6 @@
     "Output 2": "Output 2",
     "TX": "TX",
     "Native coin to cover future transaction fees": "Native Coins zur Deckung künftiger Transaktionsgebühren",
-
     "Chargeback IBAN": "Chargeback-IBAN",
     "Chargeback address": "Chargeback-Adresse",
     "Chargeback amount": "Chargeback-Betrag",
@@ -752,13 +693,11 @@
     "Fee": "Gebühr",
     "Refund amount is the transaction amount minus the fee.": "Der Rückerstattungsbetrag ist der Transaktionsbetrag minus der Gebühr.",
     "This IBAN cannot be used for refunds. Please select a personal bank account.": "Diese IBAN kann nicht für Rückerstattungen verwendet werden. Bitte wähle ein persönliches Bankkonto.",
-
     "Type": "Typ",
     "Buy": "Kauf",
     "Sell": "Verkauf",
     "Swap": "Tausch",
     "Staking": "Staking",
-
     "State": "Status",
     "Created": "Erstellt",
     "Processing": "In Bearbeitung",
@@ -780,9 +719,7 @@
     "Liquidity pending": "Liquidität ausstehend",
     "Payout in progress": "Auszahlung in Bearbeitung",
     "Price undeterminable": "Preis nicht bestimmbar",
-
     "LNURL decoded": "LNURL dekodiert",
-
     "Failure reason": "Fehlerursache",
     "Unknown": "Unbekannt",
     "Annual volume": "Jährliches Volumen",
@@ -816,19 +753,15 @@
     "we will call you at {{phone}}": "wir werden Dich unter {{phone}} anrufen",
     "Bank release pending": "Bankfreigabe ausstehend",
     "Input not yet confirmed": "Einzahlung noch nicht bestätigt",
-
     "Loading countries...": "Länder werden geladen...",
-
     "Payment method": "Zahlungsmethode",
     "Standard bank transaction": "Standard-Banktransaktion",
     "Instant bank transaction": "Sofort-Banktransaktion",
     "Credit card": "Kreditkarte",
-
     "Show on block explorer": "Im Block-Explorer anzeigen",
     "Report an issue": "Ein Problem melden",
     "Export CSV": "CSV-Export",
     "Assign transaction": "Transaktion zuordnen",
-
     "{{from}} to {{to}} at {{price}} {{from}}/{{to}} on {{source}}": "{{from}} zu {{to}} bei {{price}} {{from}}/{{to}} auf {{source}}.",
     "This exchange rate is not guaranteed. The effective rate will be determined once the transactions have been received by DFX and the crypto assets can be delivered.": "Dieser Wechselkurs ist nicht garantiert. Der effektive Kurs wird ermittelt, wenn die Transaktionen bei DFX eingegangen ist und die Krypto-Assets ausgeliefert werden können.",
     "Please note that by using this service you automatically accept our terms and conditions. The effective exchange rate is fixed when the money is received and processed by DFX.": "Bitte beachte, dass Du mit der Nutzung dieses Dienstes automatisch unsere Allgemeinen Geschäftsbedingungen akzeptierst. Der effektive Wechselkurs wird festegelegt wenn das Geld bei DFX eingegangen ist und verarbeitet wird.",
@@ -839,13 +772,11 @@
     "Nice! You are all set! Give us a minute to handle your transaction.": "Sehr schön! Alles erledigt! Gib uns eine Minute, um Deine Transaktion zu bearbeiten.",
     "We will inform you by email about the progress of your transactions.": "Wir werden Dich per E-Mail über den Fortschritt Deiner Transaktionen informieren.",
     "Enter your email address if you want to be informed about the progress of your transactions": "Gib Deine E-Mail Adresse ein, wenn Du über den Fortschritt Deiner Transaktionen informiert werden willst",
-
     "The exchange rate of {{rate}} {{currency}}/{{asset}} is fixed for {{timer}}, after which it will be recalculated.": "Der Wechselkurs von {{rate}} {{currency}}/{{asset}} ist für {{timer}} festgelegt, danach wird er neu berechnet.",
     "Please send the specified amount to the address below.": "Bitte sende den angegebenen Betrag an die unten stehende Adresse.",
     "Please note that by using this service you automatically accept our terms and conditions.": "Bitte beachte, dass Du mit der Nutzung dieses Dienstes automatisch unsere Allgemeinen Geschäftsbedingungen akzeptierst.",
     "By using this service, the outstanding claim of the above-mentioned company against DFX is assigned, and the General Terms and Conditions of DFX AG apply.": "Mit der Nutzung dieses Dienstes wird die offene Forderung des oben genannten Unternehmen an DFX abgetreten und es gelten  die Allgemeinen Geschäftsbedingungen der DFX AG.",
     "Learn more about OpenCryptoPay": "Mehr über OpenCryptoPay erfahren",
-
     "Payment routes": "Payment Routen",
     "Payment route": "Payment Route",
     "Purpose of payment": "Zahlungszweck",
@@ -872,11 +803,9 @@
     "Deactivate": "Deaktivieren",
     "Expires at": "Gültig bis",
     "Public": "Öffentlich",
-
     "Payment Methods": "Zahlungsmethoden",
     "Supported cryptocurrencies and blockchains": "Unterstützte Kryptowährungen und Blockchains",
     "Locations": "Standorte",
-
     "Configuration": "Konfiguration",
     "Default configuration": "Standardkonfiguration",
     "Payment standards": "Zahlungsstandards",
@@ -884,26 +813,21 @@
     "Display QR code": "QR-Code anzeigen",
     "Payment timeout (seconds)": "Zahlungs-Timeout (Sekunden)",
     "Payment cancellable": "Zahlung stornierbar",
-
     "Actual": "Aktuell",
     "Transaction received": "Transaktion erhalten",
     "Transaction in mempool": "Transaktion im Mempool",
     "Transaction in blockchain": "Transaktion in der Blockchain",
     "Transaction completed": "Transaktion abgeschlossen",
     "Transaction failed": "Transaktion fehlgeschlagen",
-
     "Token contract": "Token-Contract",
-
     "Create Invoice": "Rechnung erstellen",
     "Invoice ID": "Rechnungs-ID",
     "Recipient not found": "Empfänger nicht gefunden",
-
     "Route": "Route",
     "External IDs (comma separated)": "Externe IDs (kommagetrennt)",
     "Summary": "Zusammenfassung",
     "N/A": "N/A",
     "delete": "Bist Du sicher, dass Du Deine <1>{{type}}-Zahlungsroute</1> mit der <1>ID {{id}}</1> löschen möchtest?",
-
     "Payment details": "Zahlungsdetails",
     "Your payment details at a glance": "Deine Zahlungsdetails auf einen Blick",
     "{{blockchain}} address": "{{blockchain}} Adresse",
@@ -917,7 +841,6 @@
     "Compatible apps": "Kompatible Apps",
     "Semi compatible apps": "Teilweise kompatible Apps",
     "Invalid Payment Link": "Ungültiger Payment Link",
-
     "Cointracking": "Cointracking",
     "Compact": "Kompakt",
     "Chain-Report": "Chain-Report",
@@ -947,10 +870,8 @@
     "Latest transactions": "Letzte Transaktionen",
     "Create Payment": "Zahlung erstellen",
     "Copy POS link": "POS-Link kopieren",
-
     "Assign payment link '{{id}}'": "Payment Link '{{id}}' zuweisen",
     "Assign": "Zuweisen",
-
     "Total amount": "Gesamtbetrag",
     "You will be redirected to the site shortly": "Du wirst in Kürze zur Seite weitergeleitet",
     "Go back to the payment page": "Zurück zur Zahlungsseite",
@@ -1004,10 +925,8 @@
     "Support tickets": "Support-Tickets",
     "View tickets": "Tickets anzeigen",
     "The existing EUR IBAN (CH8583019DFXSWISSEURX) is currently experiencing technical issues. Please use your personal IBAN for EUR transactions instead. You can find your personal IBAN on the Buy page.": "Die bestehende EUR-IBAN (CH8583019DFXSWISSEURX) hat derzeit technische Probleme. Bitte verwende stattdessen deine persönliche IBAN für EUR-Transaktionen. Du findest deine persönliche IBAN auf der Kaufseite.",
-
     "Support issue": "Supportanfrage",
     "The issue has been successfully submitted. You will be contacted by email.": "Die Anfrage wurde erfolgreich eingereicht. Du wirst per E-Mail kontaktiert.",
-
     "Issue type": "Art der Anfrage",
     "Generic issue": "Allgemeine Anfrage",
     "Transaction issue": "Transaktionsbezogene Anfrage",
@@ -1017,7 +936,6 @@
     "Notification of changes": "Mitteilung von Änderungen",
     "Bug report": "Fehlermeldung",
     "Verification call": "Verifizierungsanruf",
-
     "Reason": "Grund",
     "Other": "Andere",
     "Data request": "Datenanfrage",
@@ -1028,16 +946,12 @@
     "Name changed": "Name geändert",
     "Address changed": "Adresse geändert",
     "Civil status changed": "Zivilstand geändert",
-
     "contactDataChangeHint": "Name, Adresse, Telefonnummer und E-Mail-Adresse können direkt in Deinem <2></2> geändert werden.",
-
     "Transaction ID": "Transaktions-ID",
     "Select a transaction to proceed with": "Wähle eine Transaktion aus, um fortzufahren",
-
     "Name": "Name",
     "Description": "Beschreibung",
     "File": "Datei",
-
     "Select the transaction for which you would like to create an issue.": "Wähle die Transaktion aus, für die Du eine Anfrage erstellen möchtest.",
     "Please provide us with all relevant information about the transaction you are missing.": "Bitte gib uns alle relevanten Informationen über die fehlende Transaktion an.",
     "Sender IBAN": "Absender-IBAN",
@@ -1048,19 +962,16 @@
     "Please log in so that we can also check your personal IBAN.": "Bitte melde Dich an, damit wir auch Deine persönliche IBAN prüfen können.",
     "We could not check this IBAN at the moment. You can submit your request anyway.": "Wir konnten diese IBAN gerade nicht prüfen. Du kannst Deine Anfrage trotzdem absenden.",
     "Date of the transaction": "Datum der Transaktion",
-
     "FAQ": "FAQ",
     "We have summarized the most common questions for you in our FAQ.": "Wir haben die häufigsten Fragen für Dich in unseren FAQs zusammengefasst.",
     "Search now": "Jetzt suchen",
     "Submit Ticket": "Ticket einreichen",
     "Contact us": "Kontaktiere uns",
     "If you have a specific question or problem, you can submit a ticket here.": "Wenn Du eine spezifische Frage oder ein Problem hast, kannst Du hier ein Ticket einreichen.",
-
     "Write a message...": "Schreibe eine Nachricht...",
     "Downloading...": "Herunterladen...",
     "Image": "Bild",
     "Document": "Dokument",
-
     "Created on": "Erstellt am",
     "Hide completed tickets": "Abgeschlossene Tickets ausblenden",
     "Show completed tickets": "Abgeschlossene Tickets anzeigen"
@@ -1088,14 +999,11 @@
     "Label": "Bezeichnung",
     "Address name": "Adressname",
     "Default": "Standard",
-
     "Show deleted addresses": "Gelöschte Adressen anzeigen",
     "Hide deleted addresses": "Gelöschte Adressen ausblenden",
-
     "delete": "Bist Du sicher, dass Du die Adresse <1>{{address}}</1> von Deinem DFX-Konto löschen möchtest? Diese Aktion ist nicht rückgängig zu machen.",
     "delete_iban": "Bist Du sicher, dass Du das Bankkonto <1>{{address}}</1> von Deinem DFX-Konto löschen möchtest?",
     "Your data will remain on our servers temporarily before permanent deletion. If you have any questions, please contact our support team.": "Deine Daten verbleiben vorübergehend auf unseren Servern, bevor sie dauerhaft gelöscht werden. Wenn Du Fragen hast, wende Dich bitte an unser Support-Team.",
-
     "Verification Call": "Verifizierungsanruf",
     "Preferred call time": "Bevorzugte Anrufzeit",
     "Morning": "Vormittag",
@@ -1105,7 +1013,6 @@
     "No, don't call me": "Nein, ruft mich nicht an",
     "Verification may require a phone call. Should we call you?": "Die Verifizierung kann einen Anruf erfordern. Sollen wir Dich anrufen?",
     "Phone verification": "Telefonische Verifizierung",
-
     "Danger Zone": "Gefahrenzone"
   },
   "screens/safe": {

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -71,9 +71,7 @@
     "Allowed formats: PDF, JPG, JPEG, PNG": "Formats autorisés : PDF, JPG, JPEG, PNG",
     "Invalid date format": "Format de date invalide",
     "Maximum allowed characters: 4000": "Nombre maximum de caractères autorisés : 4000",
-
     "No entries yet": "Aucune entrée pour le moment",
-
     "Something went wrong. Please try again. If the issue persists please reach out to our support.": "Un problème s'est produit. Veuillez réessayer. Si le problème persiste, veuillez contacter notre service d'assistance.",
     "invoice": "DFX ne reconnaît pas un destinataire nommé <strong>{{recipient}}</strong>. Ce service ne peut être utilisé que pour des destinataires ayant un compte actif chez DFX et activés pour le service de facturation. Si vous souhaitez vous inscrire en tant que destinataire chez DFX, veuillez contacter le support à <link>{{supportLink}}</link>.",
     "iban": "Il s'agit d'un IBAN multi-comptes qui ne peut pas être ajouté en tant que compte personnel. Veuillez ouvrir un ticket de support sur <1></1> et joindre la confirmation de la transaction bancaire au format PDF."
@@ -92,15 +90,12 @@
     "KYC progress": "Progression du KYC",
     "This step has already been finished.": "Cette étape est déjà terminée.",
     "This step has failed.": "Cette étape a échoué.",
-
     "per 24h": "par 24h",
     "per 30 days": "par 30 jours",
     "per year": "par an",
-
     "Terminated": "Terminé",
     "Rejected": "Refusé",
     "Level {{level}}": "Level {{level}}",
-
     "Contact data": "Données de contact",
     "Personal data": "Données personnelles",
     "Identification": "Identification",
@@ -120,7 +115,6 @@
     "Residence permit": "Permis de séjour",
     "Association statutes": "Statuts de l'association",
     "DFX approval": "Approbation DFX",
-
     "Stock corporation (AG, Ltd, SA)": "Société anonyme (AG, Ltd, SA)",
     "Limited liability company under Swiss/German/Austrian law (GmbH, LLC, Sàrl)": "Société à responsabilité limitée (GmbH, LLC, Sàrl)",
     "Entrepreneurial company (UG)": "Société entrepreneuriale (UG)",
@@ -143,25 +137,19 @@
     "Simple and flexible form of cooperation between two or more people who join forces for a common purpose": "Forme simple et flexible de coopération entre deux ou plusieurs personnes qui s'associent dans un but commun",
     "An internet excerpt is sufficient. No notarization is required. The extract must not be older than 2 months.": "Un extrait d'internet suffit. Aucune authentification n'est requise. L'extrait ne doit pas dater de plus de 2 mois.",
     "Document template": "Modèle de document",
-
     "Female": "Femme",
     "Male": "Homme",
-
     "Birthday": "Anniversaire",
     "YYYY-MM-DD": "AAAA-MM-JJ",
-
     "Passport": "Passeport",
     "ID card": "Carte d'identité",
     "Driver's license": "Permis de conduire",
-
     "Authorized to sign individually": "Autorisé à signer individuellement",
     "Authorized to sign jointly": "Autorisé à signer conjointement",
     "No signing authorization": "Pas d'autorisation de signature",
-
     "auto": "auto",
     "video": "vidéo",
     "manual": "manuel",
-
     "Not started": "Non commencé",
     "In progress": "En cours",
     "In review": "En révision",
@@ -169,9 +157,7 @@
     "Failed": "Échoué",
     "Outdated": "Obsolète",
     "Data requested": "Données demandées",
-
     "Optional": "Facultatif",
-
     "Account Type": "Type de compte",
     "Personal": "Personnel",
     "Organization / company": "Organisation / entreprise",
@@ -210,21 +196,17 @@
     "Identification document": "Document d'identification",
     "Document type": "Type de document",
     "Document number": "Numéro de document",
-
     "Sole proprietorship confirmation": "Confirmation comme entreprise individuelle",
     "Commercial register extract, trade license/permit, AHV confirmation, or another document proving the existence of the business": "Extrait du registre du commerce, licence/autorisation commerciale, attestation AVS ou tout autre document prouvant l'existence de l'activité commerciale.",
-
     "Please fill in personal information to continue": "Veuillez compléter vos informations personnelles pour continuer",
     "How did you hear about DFX?": "Comment avez-vous découvert DFX ?",
     "Please enter your contact information so that we can find your account": "Veuillez saisir vos coordonnées afin que nous puissions retrouver votre compte",
-
     "How many natural persons are there who directly or indirectly hold 25% or more of company shares?": "Combien de personnes physiques détiennent directement ou indirectement 25 % ou plus des parts de l'entreprise ?",
     "None": "Aucune",
     "Is the account holder {{name}}{{role}}?": "Le titulaire du compte {{name}}est-il {{role}} ?",
     "the managing director": "le directeur général",
     "a beneficial owner": "un bénéficiaire effectif",
     "Managing director": "Directeur général",
-
     "It looks like you already have an account with DFX.": "Il semble que vous ayez déjà un compte chez DFX.",
     "We have just sent you an email. To continue with your existing account, please confirm your email address by clicking on the link sent.": "Nous venons de vous envoyer un e-mail. Pour continuer avec votre compte existant, veuillez confirmer votre adresse e-mail en cliquant sur le lien envoyé.",
     "We have sent a 6-digit code to your new email address. Please enter it here.": "Nous avons envoyé un code à 6 chiffres à votre nouvelle adresse e-mail. Veuillez le saisir ici.",
@@ -255,34 +237,28 @@
     "I am already verified with DFX": "Je suis déjà vérifié par DFX",
     "I hereby authorize DFX to transfer my KYC data to {{client}}.": "Par la présente, je charge DFX de transmettre mes données KYC à {{client}}.",
     "The identification has failed.": "L'identification a échoué.",
-
     "Merging your accounts...": "Fusion de vos comptes...",
     "Account merged successfully!": "Compte fusionné avec succès!",
     "You can now access your account.": "Vous pouvez maintenant accéder à votre compte.",
     "My account": "Mon compte",
-
     "Upload your SEPA file here": "Téléchargez votre fichier SEPA ici",
     "Uploaded": "Téléchargé",
-
     "KYC file": "KYC-Datei",
     "Name check": "Vérification de nom",
     "User information": "Informations utilisateur",
     "User notes": "Notes utilisateur",
     "Transaction notes": "Notes de transaction",
     "Stock register": "Registre des actions",
-
     "File download": "Téléchargement de fichier",
     "Data upload": "Téléchargement des données",
     "UserData ID": "UserData ID",
     "UserData IDs": "UserData IDs",
     "Event date": "Date de l'événement",
     "Comment": "Commentaire",
-
     "Is the organization operationally active?": "L'organisation est-elle opérationnellement active ?",
     "Organizations that primarily manage their own money, such as investment companies, are considered non-operating. Operationally active organizations are those that offer and sell goods or services, conduct regular business activities that generate revenue, employ staff and have operational structures.": "Les organisations qui gèrent principalement leur propre argent, comme les sociétés d'investissement, sont considérées comme non opérationnelles. Les organisations opérationnelles sont celles qui offrent et vendent des biens ou des services, exercent des activités commerciales régulières générant des revenus, emploient du personnel et disposent de structures opérationnelles.",
     "Organization website (optional)": "Site web de l'organisation (optionnel)",
     "https://my-organization.org": "https://mon-entreprise.org",
-
     "Purpose of the payments": "Objet des paiements",
     "Purpose": "Objet",
     "Assignment agreement": "Contrat de cession",
@@ -292,12 +268,10 @@
     "My organization": "Mon entreprise",
     "Registration number": "Numéro d'enregistrement",
     "CHE-000.000.000": "CHE-000.000.000",
-
     "Store type": "Type de magasin",
     "Online": "En ligne",
     "Physical": "Physique",
     "Online and physical": "En ligne et physique",
-
     "Merchant category": "Catégorie de commerçant",
     "Accommodation and food services": "Hébergement et services de restauration",
     "Administrative support & waste management": "Services administratifs et gestion des déchets",
@@ -344,11 +318,9 @@
     "Transportation & warehousing": "Transport & entreposage",
     "Utilities": "Services publics",
     "Other crypto/Web3 services": "Autres services crypto/Web3",
-
     "Goods type": "Type de produit",
     "Tangible": "Tangible",
     "Virtual": "Virtuel",
-
     "Goods category": "Catégorie de produit",
     "Electronics & computers": "Électronique & informatique",
     "Books, music & movies": "Livres, musique & films",
@@ -366,18 +338,14 @@
     "Food, grocery & health products": "Alimentation, épicerie & produits de santé",
     "Pet supplies": "Fournitures pour animaux",
     "Industry & science": "Industrie & science",
-
     "Recall agreement": "Contrat de rappel",
-
     "ownFundsWarning": "L'indication <1>délibérée</1> de fausses informations dans ce formulaire constitue une infraction pénale (faux dans les titres selon l'article 251 du Code pénal suisse).",
-
     "Recommendation": "Recommandation",
     "Please enter the email address or referral code of your contact person. This lets us know you have a trusted contact to guide you into the crypto space.": "Veuillez saisir l'adresse e-mail ou le code de parrainage de votre personne de contact. Cela nous permet de savoir que vous avez un contact de confiance pour vous accompagner dans l'univers des cryptomonnaies.",
     "Invitation/referral code or email": "Code d'invitation/parrainage ou e-mail",
     "No matching user found": "Aucun utilisateur correspondant trouvé",
     "Invalid invitation code": "Code d'invitation invalide",
     "Invalid key": "Key invalide",
-
     "FAQ": "FAQ",
     "How can I become a DFX customer?": "Comment puis-je devenir client chez DFX ?",
     "Opening an account with DFX is only possible through a referral. You need either the ref code, ref link, or email address of an existing customer. This person serves as your point of contact and must additionally confirm their referral. Once this confirmation is received, you can complete your onboarding and use your DFX account.": "L'ouverture d'un compte chez DFX n'est possible que par parrainage. Vous avez besoin soit du code de parrainage, du lien de parrainage ou de l'adresse e-mail d'un client existant. Cette personne vous sert de point de contact et doit confirmer son parrainage. Une fois cette confirmation reçue, vous pouvez finaliser votre inscription et utiliser votre compte DFX.",
@@ -441,7 +409,19 @@
     "Re-screen": "Ré-analyser",
     "Re-screen transaction": "Ré-analyser la transaction",
     "Re-screening consumes provider quota and costs money – continue?": "Une nouvelle analyse consomme du quota fournisseur et engendre des coûts – continuer ?",
-    "Linked transaction": "Transaction liée"
+    "Linked transaction": "Transaction liée",
+    "This refund has already been approved or paid out and cannot be submitted again.": "Ce remboursement a déjà été approuvé ou payé et ne peut pas être soumis à nouveau.",
+    "Refund details expired. Reload the page and try again.": "Les données de remboursement ont expiré. Rechargez la page et réessayez.",
+    "This transaction cannot be refunded with the current AML reason.": "Cette transaction ne peut pas être remboursée avec le motif AML actuel.",
+    "Creditor details are required for bank refunds.": "Les données du créancier sont requises pour les remboursements bancaires.",
+    "The chargeback IBAN is invalid or the BIC is missing.": "L'IBAN de chargeback est invalide ou le BIC est manquant.",
+    "Customer refund request — review the details and approve to release the payout.": "Demande de remboursement client — vérifiez les détails et approuvez pour libérer le paiement.",
+    "Name mismatch: the creditor name differs from the KYC name. Confirm the recipient before approving.": "Écart de nom : le nom du créancier diffère du nom KYC. Confirmez le destinataire avant d'approuver.",
+    "KYC verified name": "Nom vérifié KYC",
+    "Complete name": "Nom complet",
+    "Creditor name": "Nom du créancier",
+    "Requested chargeback amount": "Montant de chargeback demandé",
+    "Waiting for manual approval": "En attente d'approbation manuelle"
   },
   "screens/2fa": {
     "2FA": "2FA",
@@ -482,7 +462,6 @@
   },
   "screens/error": {
     "Oh, sorry, something went wrong": "Désolé, il y a eu un problème",
-
     "Invalid link": "Lien invalide",
     "Merge is already completed": "La fusion est déjà terminée",
     "Merging your accounts is taking longer than expected. Please try again later.": "La fusion de vos comptes prend plus de temps que prévu. Veuillez réessayer plus tard.",
@@ -497,12 +476,9 @@
     "Coming Soon": "Bientôt disponible",
     "Login to DFX Services": "Login aux services DFX",
     "We have sent an email with further instructions to the address provided.": "Nous avons envoyé un e-mail avec des instructions supplémentaires à l'adresse fournie.",
-
     "Logging in...": "Connexion en cours...",
-
     "Scan with your wallet": "Scannez avec votre portefeuille",
     "Connect your wallet": "Connectez votre portefeuille",
-
     "Please confirm the connection in your MetaMask.": "Veuillez confirmer la connexion dans votre MetaMask.",
     "Please confirm the connection in the Alby browser extension.": "Veuillez confirmer la connexion dans l'extension du navigateur Alby.",
     "Please confirm the connection in your Phantom browser extension.": "Veuillez confirmer la connexion dans l'extension du navigateur Phantom.",
@@ -512,37 +488,29 @@
     "Please confirm the connection with your Ledger.": "Veuillez confirmer la connexion avec votre Ledger.",
     "Connection failed!": "Échec de la connexion !",
     "Please make sure that all other applications and browser extensions that are connected to the ledger are completely closed when you try to connect.\nThis includes third-party wallets (Ledger Live, Metamask, Daedalus, MyEtherWallet) or other applications that could interfere with the connection between DFX.swiss and your ledger device.": "Veuillez vous assurer que toutes les autres applications et extensions de navigateur connectées au Ledger sont complètement fermées lorsque vous essayez de vous connecter.\nCela inclut les portefeuilles tiers (Ledger Live, Metamask, Daedalus, MyEtherWallet) ou d'autres applications qui pourraient interférer avec la connexion entre DFX.swiss et votre appareil Ledger.",
-
     "Connect your {{device}} with your computer": "Connectez votre {{device}} à votre ordinateur",
     "Click on \"Connect\"": "Cliquez sur \"Connecter\"",
     "Click on \"Continue\"": "Cliquez sur \"Continuer\"",
     "Confirm \"Sign message\" on your {{device}}": "Confirmez \"Sign message\" sur votre {{device}}",
-
     "Load more addresses": "Charger d'autres adresses",
     "Address type": "Type d'adresse",
     "Address index": "Index de l'adresse",
     "Account index": "Index de l'compte",
-
     "Open the {{app}} app on your Ledger": "Ouvrez l'application {{app}} sur votre Ledger",
-
     "Enter your password on your BitBox": "Entrez votre mot de passe sur votre BitBox",
     "Confirm the pairing code": "Confirmer le code d'appairage",
     "Pairing code": "Code d'appariement",
     "Check that the pairing code below matches the one displayed on your BitBox": "Vérifiez que le code d'appariement ci-dessous correspond à celui affiché sur votre BitBox.",
     "Confirm the pairing code on your BitBox": "Confirmez le code d'appairage sur votre BitBox",
-
     "Click on \"Continue in Trezor Connect\"": "Cliquez sur \"Continuer dans Trezor Connect\"",
     "Follow the steps in the Trezor Connect website": "Suivez les étapes du site web Trezor Connect",
-
     "Login with your BTC Taro Wallet": "Login avec votre wallet BTC Taro",
     "Install BTC Taro": "Installer BTC Taro",
     "Pay in app": "Payer dans l'app",
     "Open app and scan QR code again": "Ouvrir l'app et scanner à nouveau le code QR",
     "App temporarily unavailable": "App temporairement indisponible",
-
     "Log in to your DFX account by verifying with your signature that you are the sole owner of the provided blockchain address.": "Connectez-vous à votre compte DFX en vérifiant par votre signature que vous êtes l'unique propriétaire de l'adresse blockchain fournie.",
     "Don't show this again.": "Ne le montrez plus.",
-
     "Please install MetaMask or Rabby!": "Veuillez installer MetaMask ou Rabby !",
     "You need to install the MetaMask or Rabby browser extension to be able to use this service.": "Vous devez installer l'extension de navigateur MetaMask ou Rabby pour pouvoir utiliser ce service.",
     "Please install Alby!": "Installez Alby !",
@@ -557,26 +525,21 @@
     "Mobile not supported!": "Mobile non pris en charge !",
     "Please use a desktop device with a compatible browser (e.g. Chrome) to be able to use this service.": "Veuillez utiliser un appareil desktop avec un navigateur compatible (par exemple Chrome) pour pouvoir utiliser ce service.",
     "visit": "Voir <1></1> pour plus de détails.",
-
     "Please install {{wallet}} from the wallet provider's website.": "Veuillez installer {{wallet}} à partir du site web du fournisseur du portefeuille.",
     "Open website": "Ouvrir le site web",
-
     "Unfortunately, DFX.swiss does not offer the purchase and sale of {{token}} tokens.": "Malheureusement, DFX.swiss ne propose pas l'achat et la vente de tokens {{token}}.",
     "If you are still interested, you can visit their website.": "Si vous êtes toujours intéressé, vous pouvez visiter leur site web.",
     "private": "Si vous êtes toujours intéressé, vous pouvez visiter le site web <2></2> en utilisant le bouton ci-dessous.",
     "The website allows you to interact with the {{name}} smart contract and trade {{symbol}} tokens. Please note that this is not an offer from DFX, it is not a recommendation and it is in no way a solicitation to trade. With this message DFX only points out that this technical possibility exists, nothing more. It is imperative that you inform yourself about all the details beforehand and always be aware that you are always trading on your own responsibility.": "Ce site vous permet d'interagir avec le smart contract {{name}} et d'échanger des tokens {{symbol}}. Veuillez noter qu'il ne s'agit pas d'une offre de DFX, ni d'une recommandation, ni d'une sollicitation à négocier. Avec ce message, DFX signale seulement que cette possibilité technique existe, rien de plus. Il est impératif que vous vous informiez de tous les détails au préalable et que vous soyez toujours conscient que vous négociez toujours sous votre propre responsabilité.",
-
     "Blockchain": "Blockchain",
     "Address": "Adresse",
     "Signature": "Signature",
     "Sign message": "Signer le message",
     "Instructions": "Instructions",
-
     "Account": "Compte",
     "Profile": "Profil",
     "Email": "E-mail",
     "Name": "Nom",
-    "Address": "Adresse",
     "Organization": "Organisation",
     "Activity": "Activité",
     "Active address": "Adresse active",
@@ -594,12 +557,9 @@
     "Paid credit": "Crédit payé",
     "User count": "Nombre d'utilisateurs",
     "Active user count": "Nombre d'utilisateurs actifs",
-
     "Please select an address or add a new one to continue.": "Veuillez sélectionner une adresse ou en ajouter une nouvelle pour continuer.",
-
     "PDF Download Address Report": "Télécharger le rapport d'adresse PDF",
     "Date": "Date",
-
     "Change phone number": "Modifier le numéro de téléphone",
     "Change address": "Modifier l'adresse",
     "Change name": "Modifier le nom",
@@ -611,52 +571,38 @@
     "You spend": "Vous dépensez",
     "You get": "Vous obtenez",
     "You get about": "Vous obtenez environ",
-
     "Target address": "Adresse de destination",
     "Switch address": "Changer l'adresse",
     "Login with a different address": "Se connecter avec une autre adresse",
     "Are you sure you want to send to a different address?": "Êtes-vous sûr de vouloir envoyer à une autre adresse ?",
-
     "Use {{chain}} as a Layer 2 solution to benefit from lower transaction fees": "Utilisez {{chain}} comme solution Layer 2 pour bénéficier de frais de transaction réduits",
-
     "Done!": "Fait!",
     "Click here once you have issued the transfer": "Cliquez ici une fois que vous avez émis le virement",
-
     "Please transfer the purchase amount using this information via your banking application. The remittance info is important!": "Veuillez transférer le montant de l'achat à l'aide de ces informations via votre application bancaire. L'objet du paiement est important !",
     "Please transfer the purchase amount using this information via your banking application. This IBAN is unique to this asset, no remittance info is required.": "Veuillez transférer le montant de l'achat à l'aide de ces informations via votre application bancaire. Cet IBAN est unique à cet actif, aucun objet de paiement n'est requis.",
-
     "The remittance info remains identical for the selected asset and can be used for recurring payments and standing orders": "L'objet du paiement reste identique pour l'immobilisation sélectionnée et peut être utilisé pour les paiements récurrents et les ordres permanents.",
-
     "Name": "Nom",
     "Address": "Adresse",
-
     "As soon as the transfer arrives in our bank account, we will transfer your asset to your wallet.": "Dès que le virement arrive sur notre compte bancaire, nous transférons votre avoir sur votre porte-monnaie.",
     "Waiting for the payment confirmation ... this may take a moment.": "En attente de la confirmation du paiement ... cela peut prendre un moment.",
-
     "PDF Invoice": "Facture PDF",
     "QR-bill": "QR-facture",
-
     "The output amount is computed as the input amount minus the DFX fee, bank fee and the network fee over the base rate. That is, {{output}} {{outputSymbol}} = ({{input}} {{inputSymbol}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}) ÷ {{baseRate}}.": "Le montant de sortie est calculé comme le montant d'entrée moins les frais DFX, les frais bancaires et les frais de réseau sur le taux de base. C'est-à-dire, {{output}} {{outputSymbol}} = ({{input}} {{inputSymbol}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}) ÷ {{baseRate}}.",
     "Output amount = (Input amount - DFX fee - Network fee) ÷ Base rate.": "Montant de sortie = (Montant d'entrée - Frais DFX - Frais de réseau) ÷ Taux de base."
   },
   "screens/sell": {
     "Add or select your IBAN": "Ajouter ou sélectionner votre IBAN",
     "Select payment account": "Sélectionner le compte de paiement",
-
     "Send the selected amount to the address below. This address can be used multiple times, it is always the same for payouts from {{chain}} to your IBAN {{iban}} in {{currency}}.": "Envoyez le montant sélectionné à l'adresse ci-dessous. Cette adresse peut être utilisée plusieurs fois, elle est toujours la même pour les paiements de {{chain}} à votre IBAN {{iban}} en {{currency}}.",
     "Address": "Adresse",
-
     "Click here once you have issued the transaction": "Cliquez ici une fois que vous avez émis la transaction",
     "Complete transaction in your wallet": "Transaction complète dans votre portefeuille",
     "Pay with your wallet": "Payer avec son portefeuille",
     "Transaction hash": "Hachage de transaction",
     "Transaction failed. Click Retry to see the deposit address for manual transfer.": "Échec de la transaction. Cliquez sur Réessayer pour voir l'adresse de dépôt pour un transfert manuel.",
-
     "Optional - Account Designation": "Facultatif - Désignation du compte",
     "e.g. Deutsche Bank": "par exemple, la Deutsche Bank",
-
     "As soon as the transaction arrives in our wallet, we will transfer your money to your bank account.": "Dès que la transaction arrive dans notre portefeuille, nous transférons votre argent sur votre compte bancaire.",
-
     "The output amount is computed as the input amount times the base rate minus the DFX fee, bank fee and the network fee. That is, {{output}} {{inputSymbol}} = {{input}} {{outputSymbol}} × {{baseRate}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}.": "Le montant de sortie est calculé comme le montant d'entrée multiplié par le taux de base moins les frais DFX, les frais bancaires et les frais de réseau. C'est-à-dire, {{output}} {{inputSymbol}} = {{input}} {{outputSymbol}} × {{baseRate}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}.",
     "Output amount = Input amount × Base rate - DFX fee - Network fee.": "Montant de sortie = Montant d'entrée × Taux de base - Frais DFX - Frais de réseau."
   },
@@ -706,7 +652,6 @@
     "This bank no longer accepts payments. Please start a new purchase.": "Cette banque n'accepte plus les paiements. Veuillez démarrer un nouvel achat.",
     "The selected currency is not available. Please try a different currency or contact support.": "La devise sélectionnée n'est pas disponible. Veuillez essayer une autre devise ou contacter le support.",
     "No bank is available for this currency. Please try a different currency or contact support.": "Aucune banque n'est disponible pour cette devise. Veuillez essayer une autre devise ou contacter le support.",
-
     "Exchange rate": "Taux de change",
     "Base rate": "Taux de base",
     "Total fee": "Frais totaux",
@@ -717,9 +662,7 @@
     "Bank fee (fixed)": "Frais bancaires (fixe)",
     "Bank fee (percent)": "Frais bancaires (pourcentage)",
     "Network start fee": "Frais de démarrage du réseau",
-
     "Your payment has failed. Please try again.": "Votre paiement a échoué. Veuillez réessayer.",
-
     "Transactions": "Transactions",
     "Transaction": "Transaction",
     "Your Transactions": "Vos transactions",
@@ -730,7 +673,6 @@
     "Transaction refund": "Remboursement de la transaction",
     "{{from}} to {{to}} at {{price}} {{from}}/{{to}} ({{source}}, {{timestamp}})": "{{from}} vers {{to}} à {{price}} {{from}}/{{to}} ({{source}}, {{timestamp}})",
     "No transactions yet": "Aucune transaction",
-
     "ID": "ID",
     "External ID": "ID externe",
     "Date": "Date",
@@ -741,7 +683,6 @@
     "Output 2": "Output 2",
     "TX": "TX",
     "Native coin to cover future transaction fees": "Crypto native pour couvrir les frais de transaction futurs",
-
     "Chargeback IBAN": "IBAN de rétrofacturation",
     "Chargeback address": "Adresse de rétrofacturation",
     "Chargeback amount": "Montant de la rétrofacturation",
@@ -752,13 +693,11 @@
     "Fee": "Frais",
     "Refund amount is the transaction amount minus the fee.": "Le montant du remboursement correspond au montant de la transaction moins les frais.",
     "This IBAN cannot be used for refunds. Please select a personal bank account.": "Cet IBAN ne peut pas être utilisé pour les remboursements. Veuillez sélectionner un compte bancaire personnel.",
-
     "Type": "Type",
     "Buy": "Achat",
     "Sell": "Vente",
     "Swap": "Échange",
     "Staking": "Staking",
-
     "State": "Statut",
     "Created": "Créé",
     "Processing": "En cours",
@@ -780,9 +719,7 @@
     "Liquidity pending": "Liquidité en attente",
     "Payout in progress": "Paiement en cours",
     "Price undeterminable": "Prix indéterminable",
-
     "LNURL decoded": "LNURL décodé",
-
     "Failure reason": "Cause de l'erreur",
     "Unknown": "Inconnu",
     "Annual volume": "Volume annuel",
@@ -816,19 +753,15 @@
     "we will call you at {{phone}}": "nous vous appellerons au {{phone}}",
     "Bank release pending": "Libération bancaire en attente",
     "Input not yet confirmed": "Entrée non encore confirmée",
-
     "Loading countries...": "Chargement des pays...",
-
     "Payment method": "Mode de paiement",
     "Standard bank transaction": "Transaction bancaire standard",
     "Instant bank transaction": "Transaction bancaire instantanée",
     "Credit card": "Carte de crédit",
-
     "Show on block explorer": "Afficher sur l'explorateur de blocs",
     "Report an issue": "Signaler un problème",
     "Export CSV": "Exporter CSV",
     "Assign transaction": "Attribuer transaction",
-
     "{{from}} to {{to}} at {{price}} {{from}}/{{to}} on {{source}}": "{{from}} vers {{to}} à {{price}} {{from}}/{{to}} sur {{source}}.",
     "This exchange rate is not guaranteed. The effective rate will be determined once the transactions have been received by DFX and the crypto assets can be delivered.": "Ce taux de change n'est pas garanti. Le taux effectif sera déterminé une fois que les transactions auront été reçues par DFX et que les crypto-actifs pourront être livrés.",
     "Please note that by using this service you automatically accept our terms and conditions. The effective exchange rate is fixed when the money is received and processed by DFX.": "Veuillez noter qu'en utilisant ce service, vous acceptez automatiquement nos conditions générales. Le taux de change effectif est fixé lorsque l'argent est reçu et traité par DFX.",
@@ -839,13 +772,11 @@
     "Nice! You are all set! Give us a minute to handle your transaction.": "C'est très bien ! Vous êtes prêt ! Donnez-nous une minute pour traiter votre transaction.",
     "We will inform you by email about the progress of your transactions.": "Nous vous informerons par e-mail de l'état d'avancement de vos transactions.",
     "Enter your email address if you want to be informed about the progress of any purchase or sale": "Saisissez votre adresse électronique si vous souhaitez être informé de l'avancement de vos transactions",
-
     "The exchange rate of {{rate}} {{currency}}/{{asset}} is fixed for {{timer}}, after which it will be recalculated.": "Le taux de change de {{rate}} {{currency}}/{{asset}} est fixé pour {{timer}}, après quoi il sera recalculé.",
     "Please send the specified amount to the address below.": "Veuillez envoyer le montant spécifié à l'adresse ci-dessous.",
     "Please note that by using this service you automatically accept our terms and conditions.": "Veuillez noter qu'en utilisant ce service, vous acceptez automatiquement nos conditions générales.",
     "By using this service, the outstanding claim of the above-mentioned company against DFX is assigned, and the General Terms and Conditions of DFX AG apply.": "En utilisant ce service, la créance en souffrance de l’entreprise susmentionnée envers DFX est cédée, et les Conditions Générales de DFX AG s’appliquent.",
     "Learn more about OpenCryptoPay": "En savoir plus sur OpenCryptoPay",
-
     "Payment routes": "Itinéraires de paiement",
     "Payment route": "Itinéraire de paiement",
     "Purpose of payment": "Objet du paiement",
@@ -872,11 +803,9 @@
     "Deactivate": "Désactiver",
     "Expires at": "Expire à",
     "Public": "Public",
-
     "Payment Methods": "Méthodes de paiement",
     "Supported cryptocurrencies and blockchains": "Cryptomonnaies et blockchains supportées",
     "Locations": "Emplacements",
-
     "Configuration": "Configuration",
     "Default configuration": "Configuration par défaut",
     "Payment standards": "Normes de paiement",
@@ -884,26 +813,21 @@
     "Display QR code": "Afficher le code QR",
     "Payment timeout (seconds)": "Délai de paiement (secondes)",
     "Payment cancellable": "Paiement annulable",
-
     "Actual": "Actuel",
     "Transaction received": "Transaction reçue",
     "Transaction in mempool": "Transaction dans le mempool",
     "Transaction in blockchain": "Transaction dans la blockchain",
     "Transaction completed": "Transaction terminée",
     "Transaction failed": "Transaction échouée",
-
     "Token contract": "Contrat de token",
-
     "Create Invoice": "Créer une facture",
     "Invoice ID": "ID de facture",
     "Recipient not found": "Bénéficiaire non trouvé",
-
     "Route": "Route",
     "External IDs (comma separated)": "IDs externes (séparés par des virgules)",
     "Summary": "Résumé",
     "N/A": "N/A",
     "delete": "Êtes-vous sûr de vouloir supprimer votre <1>itinéraire de paiement {{type}}</1> avec l’<1>ID {{id}}</1>?",
-
     "Payment details": "Détails du paiement",
     "Your payment details at a glance": "Vos détails de paiement en un coup d'œil",
     "{{blockchain}} address": "Adresse {{blockchain}}",
@@ -917,7 +841,6 @@
     "Compatible apps": "Applications compatibles",
     "Semi compatible apps": "Applications semi compatibles",
     "Invalid Payment Link": "Payment Link invalide",
-
     "Cointracking": "Cointracking",
     "Compact": "Compact",
     "Chain-Report": "Chain-Report",
@@ -947,10 +870,8 @@
     "Latest transactions": "Dernières transactions",
     "Create Payment": "Créer un paiement",
     "Copy POS link": "Copier le lien POS",
-
     "Assign payment link '{{id}}'": "Attribuer le lien de paiement '{{id}}'",
     "Assign": "Attribuer",
-
     "Total amount": "Montant total",
     "You will be redirected to the site shortly": "Vous serez redirigé vers le site dans quelques secondes",
     "Go back to the payment page": "Retour à la page de paiement",
@@ -1003,10 +924,8 @@
     "Support": "Support",
     "Support tickets": "Tickets de support",
     "The existing EUR IBAN (CH8583019DFXSWISSEURX) is currently experiencing technical issues. Please use your personal IBAN for EUR transactions instead. You can find your personal IBAN on the Buy page.": "L'IBAN EUR existant (CH8583019DFXSWISSEURX) rencontre actuellement des problèmes techniques. Veuillez utiliser votre IBAN personnel pour les transactions en EUR. Vous trouverez votre IBAN personnel sur la page d'achat.",
-
     "Support issue": "Demande de support",
     "The issue has been successfully submitted. You will be contacted by email.": "La demande a été soumise avec succès. Vous serez contacté par e-mail.",
-
     "Issue type": "Type de demande",
     "Generic issue": "Demande générique",
     "Transaction issue": "Demande relative aux transactions",
@@ -1016,7 +935,6 @@
     "Notification of changes": "Notification de changements",
     "Bug report": "Rapport de bug",
     "Verification call": "Appel de vérification",
-
     "Reason": "Motif",
     "Other": "Autres",
     "Data request": "Demande de données",
@@ -1027,16 +945,12 @@
     "Name changed": "Nom modifié",
     "Address changed": "Adresse modifiée",
     "Civil status changed": "État civil modifié",
-
     "contactDataChangeHint": "Le nom, l'adresse, le numéro de téléphone et l'adresse e-mail peuvent être modifiés directement dans votre <2></2>.",
-
     "Transaction ID": "ID de transaction",
     "Select a transaction to proceed with": "Sélectionnez une transaction pour continuer",
-
     "Name": "Nom",
     "Description": "Description",
     "File": "Fichier",
-
     "Select the transaction for which you would like to create an issue.": "Sélectionnez la transaction pour laquelle vous souhaitez créer un problème.",
     "Please provide us with all relevant information about the transaction you are missing.": "Veuillez nous fournir toutes les informations pertinentes concernant la transaction manquante.",
     "Sender IBAN": "IBAN de l'expéditeur",
@@ -1047,19 +961,16 @@
     "Please log in so that we can also check your personal IBAN.": "Veuillez vous connecter afin que nous puissions également vérifier votre IBAN personnel.",
     "We could not check this IBAN at the moment. You can submit your request anyway.": "Nous n'avons pas pu vérifier cet IBAN pour le moment. Vous pouvez tout de même soumettre votre demande.",
     "Date of the transaction": "Date de transaction",
-
     "FAQ": "FAQ",
     "We have summarized the most common questions for you in our FAQ.": "Nous avons résumé les questions les plus courantes pour vous dans notre FAQ.",
     "Search now": "Rechercher maintenant",
     "Submit Ticket": "Soumettre un ticket",
     "Contact us": "Contactez-nous",
     "If you have a specific question or problem, you can submit a ticket here.": "Si vous avez une question ou un problème spécifique, vous pouvez soumettre un ticket ici.",
-
     "Write a message...": "Écrire un message...",
     "Downloading...": "Téléchargement...",
     "Image": "Image",
     "Document": "Document",
-
     "Created on": "Créé le",
     "Hide completed tickets": "Masquer les tickets terminés",
     "Show completed tickets": "Afficher les tickets terminés"
@@ -1087,14 +998,11 @@
     "Label": "Étiquette",
     "Address name": "Nom de l'adresse",
     "Default": "Défaut",
-
     "Show deleted addresses": "Afficher les adresses supprimées",
     "Hide deleted addresses": "Masquer les adresses supprimées",
-
     "delete": "Êtes-vous sûr de vouloir supprimer l'adresse <1>{{address}}</1> de votre compte DFX ? Cette action est irréversible.",
     "delete_iban": "Êtes-vous sûr de vouloir supprimer le compte bancaire <1>{{address}}</1> de votre compte DFX ?",
     "Your data will remain on our servers temporarily before permanent deletion. If you have any questions, please contact our support team.": "Vos données resteront temporairement sur nos serveurs avant la suppression définitive. Si vous avez des questions, veuillez contacter notre équipe de support.",
-
     "Verification Call": "Appel de vérification",
     "Preferred call time": "Heure d'appel préférée",
     "Morning": "Matin",
@@ -1104,7 +1012,6 @@
     "No, don't call me": "Non, ne m'appelez pas",
     "Verification may require a phone call. Should we call you?": "La vérification peut nécessiter un appel téléphonique. Devons-nous vous appeler?",
     "Phone verification": "Vérification téléphonique",
-
     "Danger Zone": "Zone de danger"
   },
   "screens/safe": {

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -71,9 +71,7 @@
     "Allowed formats: PDF, JPG, JPEG, PNG": "Formati consentiti: PDF, JPG, JPEG, PNG",
     "Invalid date format": "Formato data non valido",
     "Maximum allowed characters: 4000": "Caratteri massimi consentiti: 4000",
-
     "No entries yet": "Nessuna voce ancora",
-
     "Something went wrong. Please try again. If the issue persists please reach out to our support.": "Qualcosa è andato storto. Riprovare. Se il problema persiste, contattate il nostro supporto.",
     "invoice": "DFX non riconosce un destinatario con il nome <strong>{{recipient}}</strong>. Questo servizio può essere utilizzato solo per i destinatari che hanno un account attivo con DFX e sono attivati per il servizio di fatturazione. Se desideri registrarti come destinatario presso DFX, contatta l’assistenza all’indirizzo <link>{{supportLink}}</link>.",
     "iban": "Questo è un IBAN multi-account e non può essere aggiunto come conto personale. Aprire un ticket di supporto a <1></1> e allegare la conferma della transazione bancaria come PDF."
@@ -92,15 +90,12 @@
     "KYC progress": "Progressi KYC",
     "This step has already been finished.": "Questo passo è già stato completato.",
     "This step has failed.": "Questo passo è fallito.",
-
     "per 24h": "per 24h",
     "per 30 days": "per 30 giorni",
     "per year": "all'anno",
-
     "Terminated": "Terminato",
     "Rejected": "Rifiutato",
     "Level {{level}}": "Level {{level}}",
-
     "Contact data": "Dati di contatto",
     "Personal data": "Dati personali",
     "Identification": "Identificazione",
@@ -120,7 +115,6 @@
     "Residence permit": "Permesso di soggiorno",
     "Association statutes": "Statuti dell'associazione",
     "DFX approval": "Approvazione DFX",
-
     "Stock corporation (AG, Ltd, SA)": "Società per azioni (AG, Ltd, SA)",
     "Limited liability company under Swiss/German/Austrian law (GmbH, LLC, Sàrl)": "Società a responsabilità limitata (GmbH, LLC, Sàrl)",
     "Entrepreneurial company (UG)": "Società imprenditoriale (UG)",
@@ -143,25 +137,19 @@
     "Simple and flexible form of cooperation between two or more people who join forces for a common purpose": "Forma semplice e flessibile di cooperazione tra due o più persone che uniscono le forze per uno scopo comune",
     "An internet excerpt is sufficient. No notarization is required. The extract must not be older than 2 months.": "È sufficiente un estratto da Internet. Non è richiesta l'autenticazione notarile. L'estratto non deve essere più vecchio di 2 mesi.",
     "Document template": "Modello di documento",
-
     "Female": "Femmina",
     "Male": "Maschio",
-
     "Birthday": "Compleanno",
     "YYYY-MM-DD": "AAAA-MM-GG",
-
     "Passport": "Passaporto",
     "ID card": "Carta d'identità",
     "Driver's license": "Patente di guida",
-
     "Authorized to sign individually": "Autorizzato a firmare individualmente",
     "Authorized to sign jointly": "Autorizzato a firmare congiuntamente",
     "No signing authorization": "Nessuna autorizzazione a firmare",
-
     "auto": "auto",
     "video": "video",
     "manual": "manuale",
-
     "Not started": "Non iniziato",
     "In progress": "In corso",
     "In review": "In revisione",
@@ -169,9 +157,7 @@
     "Failed": "Fallito",
     "Outdated": "Obsoleto",
     "Data requested": "Dati richiesti",
-
     "Optional": "Opzionale",
-
     "Account Type": "Tipo di conto",
     "Personal": "Personale",
     "Organization / company": "Organizzazione / azienda",
@@ -210,21 +196,17 @@
     "Identification document": "Documento d'identità",
     "Document type": "Tipo di documento",
     "Document number": "Numero del documento",
-
     "Sole proprietorship confirmation": "Conferma come impresa individuale",
     "Commercial register extract, trade license/permit, AHV confirmation, or another document proving the existence of the business": "Estratto del registro di commercio, licenza/autorizzazione commerciale, attestato AVS o altro documento che comprovi l'esistenza dell'attività commerciale.",
-
     "Please fill in personal information to continue": "Compilare i dati personali per continuare",
     "How did you hear about DFX?": "Come hai scoperto DFX?",
     "Please enter your contact information so that we can find your account": "Inserite le vostre informazioni di contatto per consentirci di trovare il vostro account",
-
     "How many natural persons are there who directly or indirectly hold 25% or more of company shares?": "Quante persone fisiche detengono direttamente o indirettamente il 25% o più delle quote societarie?",
     "None": "Nessuna",
     "Is the account holder {{name}}{{role}}?": "Il titolare del conto {{name}}è {{role}}?",
     "the managing director": "il direttore generale",
     "a beneficial owner": "un beneficiario effettivo",
     "Managing director": "Direttore generale",
-
     "It looks like you already have an account with DFX.": "Sembra che tu abbia già un account con DFX.",
     "We have just sent you an email. To continue with your existing account, please confirm your email address by clicking on the link sent.": "Le abbiamo appena inviato un'e-mail. Per continuare con l'account esistente, confermare l'indirizzo e-mail facendo clic sul link inviato.",
     "We have sent a 6-digit code to your new email address. Please enter it here.": "Abbiamo inviato un codice a 6 cifre al vostro nuovo indirizzo e-mail. Inseritelo qui.",
@@ -255,34 +237,28 @@
     "I am already verified with DFX": "Sono già verificato con DFX",
     "I hereby authorize DFX to transfer my KYC data to {{client}}.": "Autorizzo DFX a trasmettere i miei dati KYC a {{client}}.",
     "The identification has failed.": "L'identificazione è fallita.",
-
     "Merging your accounts...": "Unione dei vostri account...",
     "Account merged successfully!": "Account unito con successo!",
     "You can now access your account.": "Ora puoi accedere al tuo account.",
     "My account": "Il mio account",
-
     "Upload your SEPA file here": "Carica il tuo file SEPA qui",
     "Uploaded": "Caricato",
-
     "KYC file": "KYC-Datei",
     "Name check": "Controllo del nome",
     "User information": "Informazioni utente",
     "User notes": "Note utente",
     "Transaction notes": "Note di transazione",
     "Stock register": "Registro azionario",
-
     "File download": "Download del file",
     "Data upload": "Caricamento dati",
     "UserData ID": "UserData ID",
     "UserData IDs": "UserData IDs",
     "Event date": "Data dell'evento",
     "Comment": "Commento",
-
     "Is the organization operationally active?": "L'organizzazione è operativamente attiva?",
     "Organizations that primarily manage their own money, such as investment companies, are considered non-operating. Operationally active organizations are those that offer and sell goods or services, conduct regular business activities that generate revenue, employ staff and have operational structures.": "Le organizzazioni che gestiscono principalmente il proprio denaro, come le società di investimento, sono considerate non operative. Le organizzazioni operative sono quelle che offrono e vendono beni o servizi, svolgono attività commerciali regolari che generano entrate, impiegano personale e dispongono di strutture operative.",
     "Organization website (optional)": "Sito web dell'organizzazione (opzionale)",
     "https://my-organization.org": "https://mia-azienda.org",
-
     "Purpose of the payments": "Finalità dei pagamenti",
     "Purpose": "Finalità",
     "Assignment agreement": "Contratto di cessione",
@@ -292,12 +268,10 @@
     "My organization": "La mia azienda",
     "Registration number": "Numero di registrazione",
     "CHE-000.000.000": "CHE-000.000.000",
-
     "Store type": "Tipo di negozio",
     "Online": "Online",
     "Physical": "Fisico",
     "Online and physical": "Online e fisico",
-
     "Merchant category": "Categoria del commerciante",
     "Accommodation and food services": "Servizi di alloggio e ristorazione",
     "Administrative support & waste management": "Servizi amministrativi e gestione dei rifiuti",
@@ -344,11 +318,9 @@
     "Transportation & warehousing": "Trasporti e magazzinaggio",
     "Utilities": "Servizi pubblici",
     "Other crypto/Web3 services": "Altri servizi crypto/Web3",
-
     "Goods type": "Tipo di prodotto",
     "Tangible": "Tangibile",
     "Virtual": "Virtuale",
-
     "Goods category": "Categoria di prodotto",
     "Electronics & computers": "Elettronica e informatica",
     "Books, music & movies": "Libri, musica e film",
@@ -366,18 +338,14 @@
     "Food, grocery & health products": "Alimentari, spesa e prodotti per la salute",
     "Pet supplies": "Prodotti per animali",
     "Industry & science": "Industria e scienza",
-
     "Recall agreement": "Accordo di richiamo",
-
     "ownFundsWarning": "L'indicazione <1>deliberata</1> di false informazioni in questo modulo costituisce un reato penale (falsità in documenti ai sensi dell'articolo 251 del Codice penale svizzero).",
-
     "Recommendation": "Raccomandazione",
     "Please enter the email address or referral code of your contact person. This lets us know you have a trusted contact to guide you into the crypto space.": "Inserisci l'indirizzo e-mail o il codice di riferimento della tua persona di contatto. In questo modo sapremo che hai un contatto fidato che ti accompagna nel mondo delle criptovalute.",
     "Invitation/referral code or email": "Codice invito/referral o e-mail",
     "No matching user found": "Nessun utente corrispondente trovato",
     "Invalid invitation code": "Codice di invito non valido",
     "Invalid key": "Key non valida",
-
     "FAQ": "FAQ",
     "How can I become a DFX customer?": "Come posso diventare cliente di DFX?",
     "Opening an account with DFX is only possible through a referral. You need either the ref code, ref link, or email address of an existing customer. This person serves as your point of contact and must additionally confirm their referral. Once this confirmation is received, you can complete your onboarding and use your DFX account.": "L'apertura di un conto presso DFX è possibile solo tramite referral. È necessario il codice referral, il link referral o l'indirizzo e-mail di un cliente esistente. Questa persona funge da punto di contatto e deve confermare il suo referral. Una volta ricevuta questa conferma, puoi completare la registrazione e utilizzare il tuo account DFX.",
@@ -441,7 +409,19 @@
     "Re-screen": "Ri-analizza",
     "Re-screen transaction": "Ri-analizza la transazione",
     "Re-screening consumes provider quota and costs money – continue?": "Un nuovo screening consuma quota del provider e comporta costi – continuare?",
-    "Linked transaction": "Transazione collegata"
+    "Linked transaction": "Transazione collegata",
+    "This refund has already been approved or paid out and cannot be submitted again.": "Questo rimborso è già stato approvato o pagato e non può essere inviato di nuovo.",
+    "Refund details expired. Reload the page and try again.": "I dati del rimborso sono scaduti. Ricarica la pagina e riprova.",
+    "This transaction cannot be refunded with the current AML reason.": "Questa transazione non può essere rimborsata con il motivo AML attuale.",
+    "Creditor details are required for bank refunds.": "I dati del creditore sono richiesti per i rimborsi bancari.",
+    "The chargeback IBAN is invalid or the BIC is missing.": "L'IBAN di chargeback non è valido o manca il BIC.",
+    "Customer refund request — review the details and approve to release the payout.": "Richiesta di rimborso del cliente — controlla i dettagli e approva per rilasciare il pagamento.",
+    "Name mismatch: the creditor name differs from the KYC name. Confirm the recipient before approving.": "Discrepanza di nome: il nome del creditore differisce dal nome KYC. Conferma il destinatario prima di approvare.",
+    "KYC verified name": "Nome verificato KYC",
+    "Complete name": "Nome completo",
+    "Creditor name": "Nome del creditore",
+    "Requested chargeback amount": "Importo chargeback richiesto",
+    "Waiting for manual approval": "In attesa di approvazione manuale"
   },
   "screens/2fa": {
     "2FA": "2FA",
@@ -482,7 +462,6 @@
   },
   "screens/error": {
     "Oh, sorry, something went wrong": "Oh, scusate, qualcosa è andato storto",
-
     "Invalid link": "Link non valido",
     "Merge is already completed": "La fusione è già completata",
     "Merging your accounts is taking longer than expected. Please try again later.": "La fusione dei tuoi account sta richiedendo più tempo del previsto. Riprova più tardi.",
@@ -497,12 +476,9 @@
     "Coming Soon": "Prossimamente",
     "Login to DFX Services": "Login ai servizi DFX",
     "We have sent an email with further instructions to the address provided.": "Abbiamo inviato un'e-mail con ulteriori istruzioni all'indirizzo fornito.",
-
     "Logging in...": "Accesso in corso...",
-
     "Scan with your wallet": "Scansione con il portafoglio",
     "Connect your wallet": "Collegare il portafoglio",
-
     "Please confirm the connection in your MetaMask.": "Confermare la connessione nella MetaMask.",
     "Please confirm the connection in the Alby browser extension.": "Confermare la connessione nell'estensione del browser Alby.",
     "Please confirm the connection in your Phantom browser extension.": "Confermare la connessione nell'estensione del browser Phantom.",
@@ -512,37 +488,29 @@
     "Please confirm the connection with your Ledger.": "Confermare il collegamento con il Ledger.",
     "Connection failed!": "Connessione fallita!",
     "Please make sure that all other applications and browser extensions that are connected to the ledger are completely closed when you try to connect.\nThis includes third-party wallets (Ledger Live, Metamask, Daedalus, MyEtherWallet) or other applications that could interfere with the connection between DFX.swiss and your ledger device.": "Assicurarsi che tutte le altre applicazioni e le estensioni del browser collegate al ledger siano completamente chiuse quando si cerca di connettersi.\nCiò include portafogli di terze parti (Ledger Live, Metamask, Daedalus, MyEtherWallet) o altre applicazioni che potrebbero interferire con la connessione tra DFX.swiss e il dispositivo ledger.",
-
     "Connect your {{device}} with your computer": "Collegare il  {{device}} al computer",
     "Click on \"Connect\"": "Fare clic su \"Collegare\"",
     "Click on \"Continue\"": "Fare clic su \"Continua\"",
     "Confirm \"Sign message\" on your {{device}}": "Confermare \"Sign message\" sul {{device}}",
-
     "Load more addresses": "Carica altri indirizzi",
     "Address type": "Tipo di indirizzo",
     "Address index": "Indice dell'indirizzo",
     "Account index": "Indice del conto",
-
     "Open the {{app}} app on your Ledger": "Aprire l'applicazione {{app}} sul proprio Ledger",
-
     "Enter your password on your BitBox": "Inserire la password sul BitBox",
     "Confirm the pairing code": "Confermare il codice di accoppiamento",
     "Pairing code": "Codice di accoppiamento",
     "Check that the pairing code below matches the one displayed on your BitBox": "Verificare che il codice di accoppiamento riportato di seguito corrisponda a quello visualizzato sul proprio BitBox",
     "Confirm the pairing code on your BitBox": "Confermare il codice di accoppiamento sul BitBox",
-
     "Click on \"Continue in Trezor Connect\"": "Fare clic su \"Continua in Trezor Connect\"",
     "Follow the steps in the Trezor Connect website": "Seguire i passaggi del sito web Trezor Connect",
-
     "Login with your BTC Taro Wallet": "Login con l'app BTC Taro",
     "Install BTC Taro": "Installare BTC Taro",
     "Pay in app": "Pagare nell'app",
     "Open app and scan QR code again": "Aprire l'app e scansionare nuovamente il codice QR",
     "App temporarily unavailable": "App temporaneamente non disponibile",
-
     "Log in to your DFX account by verifying with your signature that you are the sole owner of the provided blockchain address.": "Accedere al proprio conto DFX verificando con la propria firma di essere l'unico proprietario dell'indirizzo blockchain fornito.",
     "Don't show this again.": "Non mostrarlo più.",
-
     "Please install MetaMask or Rabby!": "Installare MetaMask o Rabby!",
     "You need to install the MetaMask or Rabby browser extension to be able to use this service.": "Per poter utilizzare questo servizio è necessario installare l'estensione del browser MetaMask o Rabby.",
     "Please install Alby!": "Installare Alby!",
@@ -557,26 +525,21 @@
     "Mobile not supported!": "Mobile non supportato!",
     "Please use a desktop device with a compatible browser (e.g. Chrome) to be able to use this service.": "Per poter utilizzare questo servizio, utilizzare un dispositivo desktop con un browser compatibile (ad esempio Chrome).",
     "visit": "Vedere <1></1> per maggiori dettagli.",
-
     "Please install {{wallet}} from the wallet provider's website.": "Installare {{wallet}} dal sito web del fornitore del portafoglio.",
     "Open website": "Aprire il sito web",
-
     "Unfortunately, DFX.swiss does not offer the purchase and sale of {{token}} tokens.": "Purtroppo, DFX.swiss non offre l'acquisto e la vendita di token {{token}}.",
     "If you are still interested, you can visit their website.": "Se siete ancora interessati, potete visitare il loro sito web.",
     "private": "Se siete ancora interessati, potete visitare il sito web <2></2> utilizzando il pulsante sottostante.",
     "The website allows you to interact with the {{name}} smart contract and trade {{symbol}} tokens. Please note that this is not an offer from DFX, it is not a recommendation and it is in no way a solicitation to trade. With this message DFX only points out that this technical possibility exists, nothing more. It is imperative that you inform yourself about all the details beforehand and always be aware that you are always trading on your own responsibility.": "Il sito web consente di interagire con lo smart contract {{name}} e di scambiare i token {{symbol}}. Si prega di notare che questa non è un'offerta di DFX, non è una raccomandazione e non è in alcun modo una sollecitazione al commercio. Con questo messaggio DFX segnala solo l'esistenza di questa possibilità tecnica, niente di più. È indispensabile informarsi preventivamente su tutti i dettagli ed essere sempre consapevoli che si opera sempre sotto la propria responsabilità.",
-
     "Blockchain": "Blockchain",
     "Address": "Indirizzo",
     "Signature": "Firma",
     "Sign message": "Messaggio del cartello",
     "Instructions": "Istruzioni",
-
     "Account": "Conto",
     "Profile": "Profilo",
     "Email": "E-mail",
     "Name": "Nome",
-    "Address": "Indirizzo",
     "Organization": "Organizzazione",
     "Activity": "Attività",
     "Active address": "Indirizzo attivo",
@@ -594,12 +557,9 @@
     "Paid credit": "Credito pagato",
     "User count": "Conteggio utenti",
     "Active user count": "Conteggio utenti attivi",
-
     "Please select an address or add a new one to continue.": "Selezionare un indirizzo o aggiungerne uno nuovo per continuare.",
-
     "PDF Download Address Report": "Scarica report indirizzo PDF",
     "Date": "Data",
-
     "Change phone number": "Modifica numero di telefono",
     "Change address": "Modifica indirizzo",
     "Change name": "Modifica nome",
@@ -611,52 +571,38 @@
     "You spend": "Si spende",
     "You get": "Si riceve",
     "You get about": "Riceverete circa",
-
     "Target address": "Indirizzo di destinazione",
     "Switch address": "Cambiamento dell'indirizzo",
     "Login with a different address": "Accesso con un altro indirizzo",
     "Are you sure you want to send to a different address?": "Sei sicuro di voler trasmettere a un altro indirizzo?",
-
     "Use {{chain}} as a Layer 2 solution to benefit from lower transaction fees": "Utilizzate {{chain}} come soluzione di Layer 2 per beneficiare di commissioni di transazione più basse",
-
     "Done!": "Fatto!",
     "Click here once you have issued the transfer": "Fare clic qui una volta emesso il trasferimento",
-
     "Please transfer the purchase amount using this information via your banking application. The remittance info is important!": "Si prega di trasferire l'importo dell'acquisto utilizzando queste informazioni tramite la propria applicazione bancaria. Lo scopo del pagamento è importante!",
     "Please transfer the purchase amount using this information via your banking application. This IBAN is unique to this asset, no remittance info is required.": "Si prega di trasferire l'importo dell'acquisto utilizzando queste informazioni tramite la propria applicazione bancaria. Questo IBAN è unico per questo asset, non è richiesto alcun scopo di pagamento.",
-
     "The remittance info remains identical for the selected asset and can be used for recurring payments and standing orders": "Lo scopo del pagamento rimane identico per l'attività selezionata e può essere utilizzato per pagamenti ricorrenti e ordini permanenti",
-
     "Name": "Nome",
     "Address": "Indirizzo",
-
     "As soon as the transfer arrives in our bank account, we will transfer your asset to your wallet.": "Non appena il bonifico arriverà sul nostro conto bancario, trasferiremo il vostro bene nel vostro portafoglio.",
     "Waiting for the payment confirmation ... this may take a moment.": "In attesa della conferma del pagamento ... potrebbe volerci un attimo.",
-
     "PDF Invoice": "Fattura PDF",
     "QR-bill": "QR-fattura",
-
     "The output amount is computed as the input amount minus the DFX fee, bank fee and the network fee over the base rate. That is, {{output}} {{outputSymbol}} = ({{input}} {{inputSymbol}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}) ÷ {{baseRate}}.": "L'importo di output è calcolato come l'importo di input meno la commissione DFX, la commissione bancaria e la commissione di rete sul tasso base. Cioè, {{output}} {{outputSymbol}} = ({{input}} {{inputSymbol}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}) ÷ {{baseRate}}.",
     "Output amount = (Input amount - DFX fee - Network fee) ÷ Base rate.": "Importo di output = (Importo di input - Commissione DFX - Commissione di rete) ÷ Tasso base."
   },
   "screens/sell": {
     "Add or select your IBAN": "Aggiungere o selezionare l'IBAN",
     "Select payment account": "Selezionare il conto di pagamento",
-
     "Send the selected amount to the address below. This address can be used multiple times, it is always the same for payouts from {{chain}} to your IBAN {{iban}} in {{currency}}.": "Inviare l'importo selezionato all'indirizzo sottostante. Questo indirizzo può essere utilizzato più volte, è sempre lo stesso per i versamenti da {{chain}} al vostro IBAN {{iban}} in {{currency}}.",
     "Address": "Indirizzo",
-
     "Click here once you have issued the transaction": "Fare clic qui una volta emessa la transazione",
     "Complete transaction in your wallet": "Transazione completa nel portafoglio",
     "Pay with your wallet": "Pagare con il portafoglio",
     "Transaction hash": "Hash di transazione",
     "Transaction failed. Click Retry to see the deposit address for manual transfer.": "Transazione fallita. Clicca su Riprova per vedere l'indirizzo di deposito per un trasferimento manuale.",
-
     "Optional - Account Designation": "Opzionale - Designazione del conto",
     "e.g. Deutsche Bank": "Ad esempio, Deutsche Bank",
-
     "As soon as the transaction arrives in our wallet, we will transfer your money to your bank account.": "Non appena la transazione arriva nel nostro portafoglio, trasferiamo il denaro sul vostro conto bancario.",
-
     "The output amount is computed as the input amount times the base rate minus the DFX fee, bank fee and the network fee. That is, {{output}} {{inputSymbol}} = {{input}} {{outputSymbol}} × {{baseRate}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}.": "L'importo di output è calcolato come l'importo di input moltiplicato per il tasso base meno la commissione DFX, la commissione bancaria e la commissione di rete. Cioè, {{output}} {{inputSymbol}} = {{input}} {{outputSymbol}} × {{baseRate}} - {{dfxFee}} {{feeSymbol}} - {{bankFee}} {{feeSymbol}} - {{networkFee}} {{feeSymbol}}.",
     "Output amount = Input amount × Base rate - DFX fee - Network fee.": "Importo di output = Importo di input × Tasso base - Commissione DFX - Commissione di rete."
   },
@@ -706,7 +652,6 @@
     "This bank no longer accepts payments. Please start a new purchase.": "Questa banca non accetta più pagamenti. Avvia un nuovo acquisto.",
     "The selected currency is not available. Please try a different currency or contact support.": "La valuta selezionata non è disponibile. Prova un'altra valuta o contatta l'assistenza.",
     "No bank is available for this currency. Please try a different currency or contact support.": "Nessuna banca è disponibile per questa valuta. Prova un'altra valuta o contatta l'assistenza.",
-
     "Exchange rate": "Tasso di cambio",
     "Base rate": "Tasso base",
     "Total fee": "Commissione totale",
@@ -717,9 +662,7 @@
     "Bank fee (fixed)": "Commissione bancaria (fissa)",
     "Bank fee (percent)": "Commissione bancaria (percentuale)",
     "Network start fee": "Commissione di avvio della rete",
-
     "Your payment has failed. Please try again.": "Il tuo pagamento non è andato a buon fine. Per favore, riprova.",
-
     "Transactions": "Transazioni",
     "Transaction": "Transazione",
     "Your Transactions": "Le vostre transazioni",
@@ -730,7 +673,6 @@
     "Transaction refund": "Rimborso della transazione",
     "{{from}} to {{to}} at {{price}} {{from}}/{{to}} ({{source}}, {{timestamp}})": "{{from}} a {{to}} a {{price}} {{from}}/{{to}} ({{source}}, {{timestamp}})",
     "No transactions yet": "Nessuna transazione",
-
     "ID": "ID",
     "External ID": "ID esterno",
     "Date": "Data",
@@ -741,7 +683,6 @@
     "Output 2": "Output 2",
     "TX": "TX",
     "Native coin to cover future transaction fees": "Moneta nativa per coprire le commissioni sulle transazioni future",
-
     "Chargeback IBAN": "IBAN per il chargeback",
     "Chargeback address": "Indirizzo per il chargeback",
     "Chargeback amount": "Importo del chargeback",
@@ -752,13 +693,11 @@
     "Fee": "Commissione",
     "Refund amount is the transaction amount minus the fee.": "L'importo del rimborso è l'importo della transazione meno la commissione.",
     "This IBAN cannot be used for refunds. Please select a personal bank account.": "Questo IBAN non può essere utilizzato per i rimborsi. Seleziona un conto bancario personale.",
-
     "Type": "Tipo",
     "Buy": "Acquisto",
     "Sell": "Vendita",
     "Swap": "Scambio",
     "Staking": "Staking",
-
     "State": "Stato",
     "Created": "Creato",
     "Processing": "In corso",
@@ -780,9 +719,7 @@
     "Liquidity pending": "Liquidità in sospeso",
     "Payout in progress": "Pagamento in corso",
     "Price undeterminable": "Prezzo indeterminabile",
-
     "LNURL decoded": "LNURL decodificato",
-
     "Failure reason": "Causa dell'errore",
     "Unknown": "Sconosciuto",
     "Annual volume": "Volume annuale",
@@ -816,19 +753,15 @@
     "we will call you at {{phone}}": "ti chiameremo al {{phone}}",
     "Bank release pending": "Rilascio bancario in attesa di conferma",
     "Input not yet confirmed": "Input non ancora confermato",
-
     "Loading countries...": "Caricamento dei paesi...",
-
     "Payment method": "Metodo di pagamento",
     "Standard bank transaction": "Transazione bancaria standard",
     "Instant bank transaction": "Transazione bancaria istantanea",
     "Credit card": "Carta di credito",
-
     "Show on block explorer": "Mostra su block explorer",
     "Report an issue": "Segnala un problema",
     "Export CSV": "Esportare CSV",
     "Assign transaction": "Assegnare transazione",
-
     "{{from}} to {{to}} at {{price}} {{from}}/{{to}} on {{source}}": "{from}} a {{to}} a {{price}} {{from}}/{{to}} su {{source}}.",
     "This exchange rate is not guaranteed. The effective rate will be determined once the transactions have been received by DFX and the crypto assets can be delivered.": "Questo tasso di cambio non è garantito. Il tasso effettivo sarà determinato una volta che le transazioni saranno state ricevute da DFX e le criptovalute potranno essere consegnate.",
     "Please note that by using this service you automatically accept our terms and conditions. The effective exchange rate is fixed when the money is received and processed by DFX.": "Si ricorda che utilizzando questo servizio si accettano automaticamente i nostri termini e condizioni. Il tasso di cambio effettivo viene fissato quando il denaro viene ricevuto e trattato da DFX.",
@@ -839,13 +772,11 @@
     "Nice! You are all set! Give us a minute to handle your transaction.": "Bello! Siete pronti! Dateci un minuto per gestire la vostra transazione.",
     "We will inform you by email about the progress of your transactions.": "Vi informeremo via e-mail sull'andamento delle vostre transazioni.",
     "Enter your email address if you want to be informed about the progress of any purchase or sale": "Inserite il vostro indirizzo e-mail se volete essere informati sull'andamento delle vostre transazioni",
-
     "The exchange rate of {{rate}} {{currency}}/{{asset}} is fixed for {{timer}}, after which it will be recalculated.": "Il tasso di cambio di {{rate}} {{currency}}/{{asset}} è fisso per {{timer}}, dopo di che sarà ricalcolato.",
     "Please send the specified amount to the address below.": "Si prega di inviare l'importo specificato all'indirizzo sottostante.",
     "Please note that by using this service you automatically accept our terms and conditions.": "Si ricorda che utilizzando questo servizio si accettano automaticamente i nostri termini e condizioni.",
     "By using this service, the outstanding claim of the above-mentioned company against DFX is assigned, and the General Terms and Conditions of DFX AG apply.": "Con l’utilizzo di questo servizio, il credito insoluto della suddetta azienda nei confronti di DFX viene ceduto, e si applicano i Termini e Condizioni Generali della DFX AG.",
     "Learn more about OpenCryptoPay": "Scopri di più su OpenCryptoPay",
-
     "Payment routes": "Modalità di pagamento",
     "Payment route": "Modalità di pagamento",
     "Purpose of payment": "Scopo del pagamento",
@@ -872,11 +803,9 @@
     "Deactivate": "Disattivare",
     "Expires at": "Scade il",
     "Public": "Pubblico",
-
     "Payment Methods": "Metodi di pagamento",
     "Supported cryptocurrencies and blockchains": "Criptovalute e blockchain supportate",
     "Locations": "Posizioni",
-
     "Configuration": "Configurazione",
     "Default configuration": "Configurazione predefinita",
     "Payment standards": "Standard di pagamento",
@@ -884,26 +813,21 @@
     "Display QR code": "Mostra codice QR",
     "Payment timeout (seconds)": "Timeout di pagamento (secondi)",
     "Payment cancellable": "Pagamento annullabile",
-
     "Actual": "Attuale",
     "Transaction received": "Transazione ricevuta",
     "Transaction in mempool": "Transazione nel mempool",
     "Transaction in blockchain": "Transazione nella blockchain",
     "Transaction completed": "Transazione completata",
     "Transaction failed": "Transazione fallita",
-
     "Token contract": "Contratto del token",
-
     "Create Invoice": "Crea fattura",
     "Invoice ID": "ID della fattura",
     "Recipient not found": "Destinatario non trovato",
-
     "Route": "Modalità",
     "External IDs (comma separated)": "ID esterni (separati da virgole)",
     "Summary": "Riepilogo",
     "N/A": "N/A",
     "delete": "Sei sicuro di voler eliminare il tuo <1>percorso di pagamento {{type}}</1> con <1>ID {{id}}</1>?",
-
     "Payment details": "Dettagli del pagamento",
     "Your payment details at a glance": "I tuoi dettagli di pagamento a colpo d’occhio",
     "{{blockchain}} address": "Indirizzo {{blockchain}}",
@@ -917,7 +841,6 @@
     "Compatible apps": "Apps compatibili",
     "Semi compatible apps": "Apps semi compatibili",
     "Invalid Payment Link": "Payment Link non valido",
-
     "Cointracking": "Cointracking",
     "Compact": "Compatto",
     "Chain-Report": "Chain-Report",
@@ -947,10 +870,8 @@
     "Latest transactions": "Ultime transazioni",
     "Create Payment": "Crea pagamento",
     "Copy POS link": "Copia link POS",
-
     "Assign payment link '{{id}}'": "Assegnare il link di pagamento '{{id}}'",
     "Assign": "Assegnare",
-
     "Total amount": "Importo totale",
     "You will be redirected to the site shortly": "Verrai reindirizzato al sito in breve",
     "Go back to the payment page": "Torna alla pagina di pagamento",
@@ -1003,10 +924,8 @@
     "Support": "Supporto",
     "Support tickets": "Ticket di supporto",
     "The existing EUR IBAN (CH8583019DFXSWISSEURX) is currently experiencing technical issues. Please use your personal IBAN for EUR transactions instead. You can find your personal IBAN on the Buy page.": "L'IBAN EUR esistente (CH8583019DFXSWISSEURX) sta attualmente riscontrando problemi tecnici. Si prega di utilizzare il proprio IBAN personale per le transazioni in EUR. Puoi trovare il tuo IBAN personale nella pagina Acquista.",
-
     "Support issue": "Problema di supporto",
     "The issue has been successfully submitted. You will be contacted by email.": "Il problema è stato inviato con successo. Sarete contattati via e-mail.",
-
     "Issue type": "Tipo di problema",
     "Generic issue": "Problema generica",
     "Transaction issue": "Problema di transazione",
@@ -1016,7 +935,6 @@
     "Notification of changes": "Notifica di cambiamenti",
     "Bug report": "Segnalazione di un errore",
     "Verification call": "Chiamata di verifica",
-
     "Reason": "Motivo",
     "Other": "Altro",
     "Data request": "Richiesta di dati",
@@ -1027,16 +945,12 @@
     "Name changed": "Nome cambiato",
     "Address changed": "Indirizzo cambiato",
     "Civil status changed": "Stato civile cambiato",
-
     "contactDataChangeHint": "Nome, indirizzo, numero di telefono e indirizzo e-mail possono essere modificati direttamente nel tuo <2></2>.",
-
     "Transaction ID": "ID della transazione",
     "Select a transaction to proceed with": "Selezionare una transazione per procedere",
-
     "Name": "Nome",
     "Description": "Descrizione",
     "File": "File",
-
     "Select the transaction for which you would like to create an issue.": "Selezionare la transazione per la quale si desidera creare un problema.",
     "Please provide us with all relevant information about the transaction you are missing.": "Vi preghiamo di fornirci tutte le informazioni rilevanti sulla transazione mancante.",
     "Sender IBAN": "IBAN del mittente",
@@ -1047,19 +961,16 @@
     "Please log in so that we can also check your personal IBAN.": "Vi preghiamo di accedere affinché possiamo verificare anche il vostro IBAN personale.",
     "We could not check this IBAN at the moment. You can submit your request anyway.": "Al momento non è stato possibile verificare questo IBAN. Potete comunque inviare la vostra richiesta.",
     "Date of the transaction": "Data della transazione",
-
     "FAQ": "FAQ",
     "We have summarized the most common questions for you in our FAQ.": "Abbiamo riassunto le domande più comuni nelle nostre FAQ.",
     "Search now": "Cerca ora",
     "Submit Ticket": "Invia un ticket",
     "Contact us": "Contattaci",
     "If you have a specific question or problem, you can submit a ticket here.": "Se avete una domanda o un problema specifico, potete inviare un ticket qui.",
-
     "Write a message...": "Scrivi un messaggio...",
     "Downloading...": "Scaricamento...",
     "Image": "Immagine",
     "Document": "Documento",
-
     "Created on": "Creato il",
     "Hide completed tickets": "Nascondi i ticket completati",
     "Show completed tickets": "Mostra i ticket completati"
@@ -1087,14 +998,11 @@
     "Label": "Etichetta",
     "Address name": "Nome dell'indirizzo",
     "Default": "Predefinito",
-
     "Show deleted addresses": "Mostra indirizzi eliminati",
     "Hide deleted addresses": "Nascondi indirizzi eliminati",
-
     "delete": "Siete sicuri di voler eliminare l'indirizzo <1>{{address}}</1> dal vostro account DFX? Questa azione è irreversibile.",
     "delete_iban": "Siete sicuri di voler eliminare il conto bancario <1>{{address}}</1> dal vostro account DFX?",
     "Your data will remain on our servers temporarily before permanent deletion. If you have any questions, please contact our support team.": "I tuoi dati rimarranno sui nostri server temporaneamente prima della cancellazione definitiva. Se hai domande, contatta il nostro team di supporto.",
-
     "Verification Call": "Chiamata di verifica",
     "Preferred call time": "Orario di chiamata preferito",
     "Morning": "Mattina",
@@ -1104,7 +1012,6 @@
     "No, don't call me": "No, non chiamatemi",
     "Verification may require a phone call. Should we call you?": "La verifica potrebbe richiedere una telefonata. Dobbiamo chiamarti?",
     "Phone verification": "Verifica telefonica",
-
     "Danger Zone": "Zona pericolosa"
   },
   "screens/safe": {

--- a/src/util/__tests__/refund-error.test.ts
+++ b/src/util/__tests__/refund-error.test.ts
@@ -1,0 +1,36 @@
+import { isPendingChargebackNavState, mapRefundApiError } from '../refund-error';
+
+describe('mapRefundApiError', () => {
+  it('maps already-charged-back to a clear non-generic message', () => {
+    expect(mapRefundApiError('Transaction already charged back')).toBe(
+      'This refund has already been approved or paid out and cannot be submitted again.',
+    );
+  });
+
+  it('maps expired refund session messages', () => {
+    expect(mapRefundApiError('Request refund data first')).toBe(
+      'Refund details expired. Reload the page and try again.',
+    );
+    expect(mapRefundApiError('Refund data expired')).toBe('Refund details expired. Reload the page and try again.');
+  });
+
+  it('passes through unknown messages unchanged', () => {
+    expect(mapRefundApiError('Something custom from the API')).toBe('Something custom from the API');
+  });
+
+  it('trims whitespace before matching', () => {
+    expect(mapRefundApiError('  Transaction already charged back  ')).toContain('already been approved');
+  });
+});
+
+describe('isPendingChargebackNavState', () => {
+  it('accepts a payload with blockReasons array', () => {
+    expect(isPendingChargebackNavState({ blockReasons: ['NameMismatch'] })).toBe(true);
+  });
+
+  it('rejects null and incomplete objects', () => {
+    expect(isPendingChargebackNavState(null)).toBe(false);
+    expect(isPendingChargebackNavState({})).toBe(false);
+    expect(isPendingChargebackNavState({ blockReasons: 'NameMismatch' })).toBe(false);
+  });
+});

--- a/src/util/__tests__/refund-error.test.ts
+++ b/src/util/__tests__/refund-error.test.ts
@@ -14,8 +14,25 @@ describe('mapRefundApiError', () => {
     expect(mapRefundApiError('Refund data expired')).toBe('Refund details expired. Reload the page and try again.');
   });
 
+  it('maps AML-reason and creditor/IBAN validation messages', () => {
+    expect(mapRefundApiError('Cannot refund with this AML reason')).toBe(
+      'This transaction cannot be refunded with the current AML reason.',
+    );
+    expect(mapRefundApiError('Creditor data is required for bank refunds')).toBe(
+      'Creditor details are required for bank refunds.',
+    );
+    expect(mapRefundApiError('IBAN not valid or BIC not available')).toBe(
+      'The chargeback IBAN is invalid or the BIC is missing.',
+    );
+  });
+
   it('passes through unknown messages unchanged', () => {
     expect(mapRefundApiError('Something custom from the API')).toBe('Something custom from the API');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(mapRefundApiError('')).toBe('');
+    expect(mapRefundApiError('   ')).toBe('');
   });
 
   it('trims whitespace before matching', () => {

--- a/src/util/refund-error.ts
+++ b/src/util/refund-error.ts
@@ -1,0 +1,41 @@
+/**
+ * Maps raw API refund/chargeback error strings to compliance-facing English source keys
+ * (for translate('screens/compliance', …)). Unknown messages are returned unchanged.
+ */
+export function mapRefundApiError(message: string): string {
+  const m = message.trim();
+  if (!m) return m;
+
+  if (/transaction already charged back/i.test(m)) {
+    return 'This refund has already been approved or paid out and cannot be submitted again.';
+  }
+  if (/request refund data first/i.test(m) || /refund data expired/i.test(m)) {
+    return 'Refund details expired. Reload the page and try again.';
+  }
+  if (/cannot refund with this aml reason/i.test(m)) {
+    return 'This transaction cannot be refunded with the current AML reason.';
+  }
+  if (/creditor data is required/i.test(m)) {
+    return 'Creditor details are required for bank refunds.';
+  }
+  if (/iban not valid|bic not available/i.test(m)) {
+    return 'The chargeback IBAN is invalid or the BIC is missing.';
+  }
+
+  return m;
+}
+
+export interface PendingChargebackNavState {
+  blockReasons: string[];
+  verifiedName?: string;
+  completeName?: string;
+  creditorName?: string;
+  chargebackAmount?: number;
+  chargebackAsset?: string;
+}
+
+export function isPendingChargebackNavState(value: unknown): value is PendingChargebackNavState {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as PendingChargebackNavState;
+  return Array.isArray(v.blockReasons);
+}


### PR DESCRIPTION
## Summary

Follow-up UX for the pending chargeback refund flow (API guard already on develop).

Compliance sees plain-language refund errors instead of only a raw API string under the generic failure banner. The return screen shows a **manual approval** banner (including name-mismatch context from the pending list) and keeps prefilled creditor details for review.

## Change

- `mapRefundApiError` for known refund API errors
- Return screen + chargeback modal use the mapping
- Pending list passes `pendingChargeback` navigation state
- Manual-approval / name-mismatch banner on the return form
- DE / FR / IT strings
- Unit tests for mapping, list navigation state, and return-screen banner/errors
- E2E visual-regression spec + handbook `metadata.json` entry for `compliance-bank-tx-return`

## Completeness notes

- **Handbook baselines:** Playwright baselines under `e2e/screenshots/baseline/` for the new return-screen variants are generated via `npx playwright test e2e/compliance-bank-tx-return.spec.ts --update-snapshots` when a local API stack (ADMIN_SEED) is available. Spec + metadata are in this PR; screenshot PNGs may land in the same PR after snapshot generation on a configured host.
- **Full-file coverage pin:** services does not use the api coverage ratchet; new unit tests cover the new pure util fully and the changed UI paths of the return screen and list.

## Test plan

- [x] Unit: `refund-error`, chargeback list navigation state, return screen banner + error mapping
- [ ] Playwright: generate/update baselines for `compliance-bank-tx-return` when API env is available
- [ ] Manual after deploy: pending name-mismatch row → banner + prefill; second approve attempt → plain “already approved/paid” message

## Related

Complements the API refund-guard fix already on develop.