### PR TITLE
feat(support): add kycStep nationality result

### DIFF
--- a/src/components/compliance/detail-tabs.tsx
+++ b/src/components/compliance/detail-tabs.tsx
@@ -85,17 +85,32 @@ export function UsersTable({ users }: { users: UserInfo[] }): JSX.Element {
 
 function formatStepResult(stepName: string, result?: string): string {
   if (!result) return '-';
-  // Only Recommendation step results are shown (key = refCode | mail | invitationCode).
-  // Other steps store complex JSON that is not useful as a column value.
-  if (stepName !== 'Recommendation') return '-';
-  try {
-    const parsed = JSON.parse(result) as unknown;
-    if (parsed && typeof parsed === 'object' && 'key' in parsed) {
-      return String((parsed as { key: unknown }).key);
+
+  switch (stepName) {
+    case 'Recommendation': {
+      try {
+        const parsed = JSON.parse(result) as unknown;
+        if (parsed && typeof parsed === 'object' && 'key' in parsed) {
+          return String((parsed as { key: unknown }).key);
+        }
+      } catch {
+        // not JSON
+      }
+      return result;
     }
-    return result;
-  } catch {
-    return result;
+
+    case 'NationalityData': {
+      try {
+        const parsed = JSON.parse(result) as { nationality?: { id: number; symbol: string } };
+        if (parsed.nationality?.symbol) return parsed.nationality.symbol;
+      } catch {
+        // not JSON
+      }
+      return '-';
+    }
+
+    default:
+      return '-';
   }
 }
 


### PR DESCRIPTION
<h2>feat(compliance): show NationalityData result in KYC steps table</h2>

<p>
  The KYC steps table in the compliance search user detail view only rendered a result value for
  <code>Recommendation</code> steps — every other step showed <code>"-"</code> regardless of the
  data the API returned.
</p>

<h3>Changes</h3>
<ul>
  <li>
    Refactored <code>formatStepResult</code> in <code>detail-tabs.tsx</code> from a single
    <code>if</code>-chain into a <code>switch</code> over <code>stepName</code>, making it
    straightforward to add further step-specific formatters.
  </li>
  <li>
    Added a <code>NationalityData</code> case that parses the step result JSON
    (<code>{ nationality: { id, symbol } }</code>) and returns the country symbol (e.g.
    <code>"CH"</code>). If the value is not valid JSON or the expected shape is absent, it falls
    back to <code>"-"</code> as before.
  </li>
  <li>All other steps continue to show <code>"-"</code>.</li>
</ul>

<h3>Not changed</h3>
<ul>
  <li>
    <strong>API:</strong> no changes — <code>kycSteps[].result</code> was already included in the
    <code>GET support/{id}</code> response; the data just wasn't surfaced in the UI.
  </li>
  <li><strong>Public transaction endpoint:</strong> untouched.</li>
</ul>
