### PR TITLE
435291ab - Publish prebuilt e2e images and let the harness skip local builds

### DIFF
--- a/.github/workflows/e2e-images.yml
+++ b/.github/workflows/e2e-images.yml
@@ -1,0 +1,66 @@
+# Publishes the prebuilt frontend and widget images the E2E workflows use as an accelerator.
+#
+# The companion workflow in the API repository pulls these images SHA-tagged for exactly the
+# services revision it checks out, exports E2E_FRONTEND_IMAGE / E2E_WIDGET_IMAGE, and the
+# harness (e2e-stack/scripts/up.sh) then skips the ~8-minute local builds. If the tag for a
+# revision does not exist, that workflow falls back — loudly — to building locally, so this
+# workflow is deliberately NOT a merge gate and must never become one.
+#
+# No `paths:` filter on purpose: the SHA lookup on the consumer side only hits if an image
+# exists for *every* develop commit, including commits that touch nothing the images contain.
+# Filtering would leave holes in the tag history and silently push consumers onto the slow
+# build fallback.
+#
+# One-time setup after the first publish: the two GHCR packages
+# (services-e2e-frontend, services-e2e-widget) must be switched to public visibility so the
+# companion repository can pull them without extra credentials. Until that is done, its pulls
+# fail and the build fallback covers the gap — slower, but correct.
+
+name: E2E images
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and push E2E images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # Build with exactly the context and arguments the harness uses (compose.yml /
+      # compose.tests.yml): context is the repo root, and no --build-arg overrides — the
+      # Dockerfile defaults ARE the e2e values. Any divergence here would make CI test a
+      # different image than a local run builds, which defeats the accelerator's whole point.
+      - name: Build frontend image
+        run: |
+          docker build \
+            -t ghcr.io/dfxswiss/services-e2e-frontend:${{ github.sha }} \
+            -t ghcr.io/dfxswiss/services-e2e-frontend:develop \
+            -f e2e-stack/images/frontend/Dockerfile .
+
+      - name: Build widget image
+        run: |
+          docker build \
+            -t ghcr.io/dfxswiss/services-e2e-widget:${{ github.sha }} \
+            -t ghcr.io/dfxswiss/services-e2e-widget:develop \
+            -f e2e-stack/images/frontend-widget/Dockerfile .
+
+      # The SHA tag is what the companion workflow looks up; the develop tag is a moving
+      # convenience pointer for manual pulls and debugging.
+      - name: Push images
+        run: |
+          docker push --all-tags ghcr.io/dfxswiss/services-e2e-frontend
+          docker push --all-tags ghcr.io/dfxswiss/services-e2e-widget

--- a/.github/workflows/e2e-images.yml
+++ b/.github/workflows/e2e-images.yml
@@ -48,19 +48,20 @@ jobs:
         run: |
           docker build \
             -t ghcr.io/dfxswiss/services-e2e-frontend:${{ github.sha }} \
-            -t ghcr.io/dfxswiss/services-e2e-frontend:develop \
             -f e2e-stack/images/frontend/Dockerfile .
 
       - name: Build widget image
         run: |
           docker build \
             -t ghcr.io/dfxswiss/services-e2e-widget:${{ github.sha }} \
-            -t ghcr.io/dfxswiss/services-e2e-widget:develop \
             -f e2e-stack/images/frontend-widget/Dockerfile .
 
-      # The SHA tag is what the companion workflow looks up; the develop tag is a moving
-      # convenience pointer for manual pulls and debugging.
+      # SHA tags only, on purpose. The companion workflow looks up the exact commit it checked
+      # out, so an immutable tag per commit is all that is needed - and a moving tag (such as
+      # a floating `develop` pointer) could go stale or end up pointing at different revisions
+      # for the two images when runs overlap, since this workflow is deliberately not
+      # serialised (parallel runs push disjoint SHA tags and cannot interfere).
       - name: Push images
         run: |
-          docker push --all-tags ghcr.io/dfxswiss/services-e2e-frontend
-          docker push --all-tags ghcr.io/dfxswiss/services-e2e-widget
+          docker push ghcr.io/dfxswiss/services-e2e-frontend:${{ github.sha }}
+          docker push ghcr.io/dfxswiss/services-e2e-widget:${{ github.sha }}

--- a/e2e-stack/compose.tests.yml
+++ b/e2e-stack/compose.tests.yml
@@ -48,6 +48,9 @@ services:
       - e2e-playwright-report:/work/playwright-report
 
   frontend-widget:
+    # Prebuilt-image escape hatch — same pattern and reasoning as E2E_FRONTEND_IMAGE on the
+    # `frontend` service; see the comment there in compose.yml.
+    image: ${E2E_WIDGET_IMAGE:-dfx-services-widget:e2e}
     build:
       # Relative to this file's directory (e2e-stack/), so `..` is the repo root — same
       # convention as the `tests` service build above.

--- a/e2e-stack/compose.yml
+++ b/e2e-stack/compose.yml
@@ -53,6 +53,16 @@ services:
     restart: "no"
 
   frontend:
+    # Mirrors the E2E_API_IMAGE pattern on the api service above. Unset, `compose build` tags
+    # the local build with the default name below, so `compose up` runs exactly what was just
+    # built. Set (by CI that already pulled a prebuilt image, see
+    # .github/workflows/e2e-images.yml), scripts/up.sh skips the local build and compose runs
+    # the prebuilt image instead. Either way the variable must resolve identically in every
+    # compose invocation — a service whose resolved configuration differs from the running
+    # container gets recreated mid-run — which is why up.sh records it in .env.generated.
+    # The frontend-widget service (declared in compose.tests.yml) follows the same pattern
+    # via E2E_WIDGET_IMAGE.
+    image: ${E2E_FRONTEND_IMAGE:-dfx-services-frontend:e2e}
     build:
       # Repo root: Dockerfile needs package.json, lockfile, and full app source.
       context: ..

--- a/e2e-stack/scripts/up.sh
+++ b/e2e-stack/scripts/up.sh
@@ -32,6 +32,18 @@ if [[ -z "${E2E_API_IMAGE:-}" ]]; then
   export E2E_API_IMAGE=dfx-api:e2e
 fi
 
+# Same pattern for the two images built from this repository: remember whether the caller
+# provided a prebuilt image BEFORE defaulting — after the exports below the variables are
+# always set and that distinction is gone. CI sets them to tags it already pulled (see
+# .github/workflows/e2e-images.yml); locally they stay unset and the harness builds as usual.
+frontend_prebuilt=${E2E_FRONTEND_IMAGE:+1}
+widget_prebuilt=${E2E_WIDGET_IMAGE:+1}
+# Export concrete defaults so the ${E2E_FRONTEND_IMAGE}/${E2E_WIDGET_IMAGE} references in
+# compose.yml / compose.tests.yml resolve to the same tag in every compose invocation:
+# `compose build` tags the local build with exactly this name, and `compose up` runs it.
+export E2E_FRONTEND_IMAGE="${E2E_FRONTEND_IMAGE:-dfx-services-frontend:e2e}"
+export E2E_WIDGET_IMAGE="${E2E_WIDGET_IMAGE:-dfx-services-widget:e2e}"
+
 # The API has to be able to survive an unreachable third party on its own. It could not always:
 # a Spark SDK failure reached the process error handler, whose own logging call threw on the value
 # it was handed, and the process exited. An image without that fix cannot come up in this network,
@@ -75,17 +87,30 @@ if [[ -f "$STACK_DIR/.env" ]]; then
   printf '\n' >> "$generated_env"
 fi
 printf 'E2E_API_IMAGE=%s\n' "$E2E_API_IMAGE" >> "$generated_env"
+# Same reasoning for the frontend and widget images: every later compose call must resolve
+# them to the tags decided here, prebuilt or locally built.
+printf 'E2E_FRONTEND_IMAGE=%s\n' "$E2E_FRONTEND_IMAGE" >> "$generated_env"
+printf 'E2E_WIDGET_IMAGE=%s\n' "$E2E_WIDGET_IMAGE" >> "$generated_env"
 
-log_info "Building frontend image..."
-compose build frontend
+if [[ -z "$frontend_prebuilt" ]]; then
+  log_info "Building frontend image..."
+  compose build frontend
+else
+  log_info "Using prebuilt frontend image ${E2E_FRONTEND_IMAGE} - skipping the local build."
+fi
 
 # Rebuild frontend-widget too: Compose auto-builds a *missing* image, but never rebuilds an
 # *existing* one on its own. Without this, a source change that affects the widget bundle
 # (src/index-widget.tsx or anything it imports) would leave the previous widget image running,
 # and widget.spec.ts would keep testing stale code while staying green — the exact failure mode
-# this harness exists to catch.
-log_info "Building frontend-widget image..."
-compose build frontend-widget
+# this harness exists to catch. A prebuilt image passed in via E2E_WIDGET_IMAGE does not have
+# that problem: CI pulls it SHA-tagged for exactly the revision it checked out.
+if [[ -z "$widget_prebuilt" ]]; then
+  log_info "Building frontend-widget image..."
+  compose build frontend-widget
+else
+  log_info "Using prebuilt frontend-widget image ${E2E_WIDGET_IMAGE} - skipping the local build."
+fi
 
 log_info "Starting stack (db, api, frontend, proxy)..."
 compose up -d db api frontend proxy


### PR DESCRIPTION
## What

Two pieces, both mirroring the existing `E2E_API_IMAGE` pattern:

1. **Publish workflow** (`.github/workflows/e2e-images.yml`): on every push to `develop`, builds the harness's frontend and widget images with exactly the harness's contexts and default build args, and pushes them to GHCR as `ghcr.io/dfxswiss/services-e2e-frontend` / `services-e2e-widget`, tagged with the commit SHA (immutable, one tag per commit — deliberately no moving `develop` tag: nothing consumes it and it could go stale between overlapping runs).
2. **Harness support**: `compose.yml` / `compose.tests.yml` gain `image: ${E2E_FRONTEND_IMAGE:-…}` / `${E2E_WIDGET_IMAGE:-…}`, and `up.sh` skips the corresponding local build when a caller provides a prebuilt tag. Both variables are recorded in `.env.generated` so every compose invocation resolves the same tags (the mid-run container-recreation trap documented there).

## Why

The companion API repo's e2e workflow builds this repo's frontend and widget from `develop` on every PR run — several minutes of fixed boot cost that produce a bit-identical image each time. With this change it pulls the SHA-tagged prebuilt image for the exact services commit it checked out instead.

## Deliberately an accelerator, not a gate

- A consumer that cannot pull the image (tag not yet published, package still private, network) falls back **loudly** to the local build — the same tests always run either way.
- No `paths:` filter on the publish workflow: the image must track every `develop` commit so the consumer's SHA lookup hits.
- One-time follow-up after the first publish: flip the two GHCR packages to public visibility so the companion repo can pull them with its default token; until then its fallback keeps working.

## Verification

- Both compose files and the workflow parse; `bash -n` on `up.sh` passes.
- The skip logic was exercised in isolation: unset/empty variables → local build exactly as before; set variables → build skipped, prebuilt tag resolved in both compose invocations.
- This repo's own e2e workflow is unchanged: it builds the frontend from the PR head (that is the thing under test) and continues to do so.

