### PR TITLE
019ffa1c - Scope develop PR tests and e2e, and honour ci:full

### DIFF
--- a/.github/workflows/e2e-stack.yml
+++ b/.github/workflows/e2e-stack.yml
@@ -12,6 +12,7 @@
 #
 # Documentation-only PRs (docs/ and *.md) with safe path characters bring up no stack
 # (mode=none); the job still runs and the Playwright step succeeds with a message.
+# API checkout, bootstrap resolution, and harness tsc run only when mode != none.
 # PRs into main, workflow_dispatch, and PRs with the `ci:full` label always run the full
 # suite. A change under e2e-stack/ or to .github/workflows/e2e-stack.yml always forces
 # full (the workflow must not classify itself as none). Every other remaining change
@@ -166,6 +167,7 @@ jobs:
           echo "mode=full" >> "$GITHUB_OUTPUT"
 
       - name: Checkout API
+        if: steps.scope.outputs.mode != 'none'
         uses: actions/checkout@v4
         with:
           repository: DFXswiss/api
@@ -180,6 +182,7 @@ jobs:
       # this step is skipped. It also refuses to bootstrap from a pull request that is no longer
       # open, so it cannot quietly re-arm later and build a years-old revision.
       - name: Resolve the API revision to build
+        if: steps.scope.outputs.mode != 'none'
         id: api_source
         env:
           API_REF: ${{ inputs.api_ref }}
@@ -215,7 +218,7 @@ jobs:
           fi
 
       - name: Check out the API revision that carries the guard
-        if: steps.api_source.outputs.bootstrap == 'true'
+        if: steps.scope.outputs.mode != 'none' && steps.api_source.outputs.bootstrap == 'true'
         uses: actions/checkout@v4
         with:
           repository: DFXswiss/api
@@ -223,6 +226,7 @@ jobs:
           path: api-repo
 
       - name: Setup Node.js
+        if: steps.scope.outputs.mode != 'none'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -236,6 +240,7 @@ jobs:
       # so nothing else in CI type-checks it. Doing it here costs under a minute and fails on a
       # type error before the run spends eight on Docker.
       - name: Type-check the harness
+        if: steps.scope.outputs.mode != 'none'
         working-directory: e2e-stack
         run: |
           npm ci

--- a/.github/workflows/e2e-stack.yml
+++ b/.github/workflows/e2e-stack.yml
@@ -30,6 +30,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - edited
       - labeled
       - unlabeled
   workflow_dispatch:

--- a/.github/workflows/e2e-stack.yml
+++ b/.github/workflows/e2e-stack.yml
@@ -9,6 +9,14 @@
 # find e2e-stack/, so it reads whatever is on develop at the time it runs. Until this pull
 # request has merged, that workflow bootstraps the harness from this pull request's head
 # instead, which means neither side is blocked on the other and either merge order works.
+#
+# Documentation-only PRs (docs/ and *.md) with safe path characters bring up no stack
+# (mode=none); the job still runs and the Playwright step succeeds with a message.
+# PRs into main, workflow_dispatch, and PRs with the `ci:full` label always run the full
+# suite. A change under e2e-stack/ or to .github/workflows/e2e-stack.yml always forces
+# full (the workflow must not classify itself as none). Every other remaining change
+# after filtering docs/ and *.md is treated as runtime-relevant and runs full. There is
+# no selected/partial spec mapping in this repository.
 
 name: Full-stack E2E
 
@@ -17,6 +25,13 @@ on:
     branches:
       - main
       - develop
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
   workflow_dispatch:
     inputs:
       api_ref:
@@ -38,8 +53,116 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      # Full history (fetch-depth: 0): the scope step below diffs against the merge base
+      # with the PR's base branch (`origin/BASE...HEAD`), which a shallow single-commit
+      # checkout cannot resolve.
       - name: Checkout services
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Decides in-job whether to bring the stack up — never via a job `if:` or a `paths:`
+      # filter, because a skipped check counts as passing (see header comment). Modes are
+      # only full and none; there is no selected/partial spec mapping in this repository.
+      - name: Determine e2e scope
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          # Release PRs into main (and any non-develop base) and manual dispatches always
+          # run everything: they are the last gate before a release, so no selection there.
+          if [ "$EVENT_NAME" != 'pull_request' ] || [ "$BASE" != 'develop' ]; then
+            echo "Scope: full (event=$EVENT_NAME, base=${BASE:-n/a})"
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Exact `.name == "ci:full"` via jq: GitHub's `contains()` on label arrays is
+          # not case-sensitive. jq exit 1 (no match) must not be conflated with >=2
+          # (failure) - a failed jq must fail the step, not silently shrink the gate.
+          rc=0
+          jq -e 'any(.pull_request.labels[]?; .name == "ci:full")' "$GITHUB_EVENT_PATH" >/dev/null || rc=$?
+          if (( rc >= 2 )); then
+            echo "::error::jq failed while checking for the ci:full label (exit $rc)."
+            exit 1
+          fi
+          if (( rc == 0 )); then
+            echo 'Full run: the PR has the ci:full label.'
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Safety net: guarantee the base ref exists locally even if the checkout behavior changes.
+          git fetch --quiet origin "$BASE"
+
+          # Deletions stay in the diff on purpose (no --diff-filter=d): a PR that only
+          # deletes a runtime-relevant file would otherwise produce an empty list, select
+          # 'none' and bring up no stack at all.
+          #
+          # --no-renames: git's rename detection reports only the NEW path of a renamed
+          # file. With --no-renames a rename is classified as a deletion plus an addition.
+          CHANGED=$(git diff --no-renames --name-only "origin/$BASE...HEAD")
+          echo 'Changed files:'
+          printf '%s\n' "$CHANGED"
+
+          # Path-safety guard on the RAW diff, before filtering: git quotes exotic path
+          # names (core.quotePath), which would distort the classification below - the full
+          # run is the lossless answer for anything outside the safe character set.
+          # Herestring instead of a pipe: with pipefail, grep -q quitting early could turn
+          # a hit into a SIGPIPE failure and silently defuse the guard. grep exit codes 1
+          # (no match) and >=2 (failure) must not be conflated.
+          rc=0
+          grep -qv '^[A-Za-z0-9._/-]*$' <<< "$CHANGED" || rc=$?
+          if (( rc >= 2 )); then
+            echo "::error::grep failed while validating changed paths (exit $rc)."
+            exit 1
+          fi
+          if (( rc == 0 )); then
+            echo 'Full run: a changed path contains characters outside the safe set A-Za-z0-9._/-.'
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Harness and this workflow are taken from the PR head. A change to either must
+          # not be allowed to classify itself as mode=none.
+          rc=0
+          e2e_hit=$(grep -E '^(e2e-stack/|\.github/workflows/e2e-stack\.yml$)' <<< "$CHANGED") || rc=$?
+          if (( rc >= 2 )); then
+            echo "::error::grep failed while matching e2e-stack or workflow paths (exit $rc)."
+            exit 1
+          fi
+          if (( rc == 0 )); then
+            echo 'Full run: the PR touches e2e-stack/ or this workflow:'
+            echo "$e2e_hit"
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Drop documentation: a path is documentation if it starts with docs/ or ends
+          # with .md. Empty remainder (docs-only or originally empty diff) → none. Every
+          # leftover path is treated as runtime-relevant → full. grep exit 1 (no remaining
+          # files) is none; >=2 must fail the step.
+          rc=0
+          remaining=$(grep -Ev '(^docs/|\.md$)' <<< "$CHANGED") || rc=$?
+          if (( rc >= 2 )); then
+            echo "::error::grep failed while filtering documentation paths (exit $rc)."
+            exit 1
+          fi
+          # rc==1: grep found no remaining files. Empty remaining after command
+          # substitution also covers an originally empty diff (grep may still exit 0
+          # on a blank herestring line that then collapses to "").
+          if (( rc == 1 )) || [[ -z "$remaining" ]]; then
+            echo 'No run: documentation-only or empty diff (no runtime-relevant changes).'
+            echo "mode=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo 'Full run: remaining paths are treated as runtime-relevant:'
+          echo "$remaining"
+          echo "mode=full" >> "$GITHUB_OUTPUT"
 
       - name: Checkout API
         uses: actions/checkout@v4
@@ -124,6 +247,7 @@ jobs:
       # artifacts from the still-present named volumes / tests container, and
       # only then tear down in a final always() step.
       - name: Bring stack up
+        if: steps.scope.outputs.mode != 'none'
         run: E2E_API_REPO=$GITHUB_WORKSPACE/api-repo bash e2e-stack/scripts/up.sh
 
       - name: Run Playwright tests
@@ -131,19 +255,37 @@ jobs:
         # `if: always()` so artifact collection and teardown still run.
         # --env-file is not optional here: up.sh writes the values it resolved into that file, and
         # a compose run that resolves them differently recreates the API container mid-run.
+        # The step always runs: selection is in-job rather than a skip, so the merge gate
+        # cannot be defeated by a skipped check (see header comment).
         env:
-          # Every spec is in scope here, so the coverage gate checks navigations, not just claims.
-          E2E_FULL_RUN: '1'
+          MODE: ${{ steps.scope.outputs.mode }}
         run: |
-          docker compose \
-            -p dfx-e2e-stack \
-            --env-file e2e-stack/.env.generated \
-            -f e2e-stack/compose.yml \
-            -f e2e-stack/compose.tests.yml \
-            run --name dfx-e2e-stack-tests tests
+          set -euo pipefail
+          case "$MODE" in
+            none)
+              echo 'No runtime-relevant changes in this PR (documentation-only or empty diff) — not running the e2e stack.'
+              ;;
+            full)
+              # Every spec is in scope here, so the coverage gate checks navigations, not just claims.
+              # E2E_FULL_RUN is inline on this command only — not a static step env that would also
+              # apply to mode=none.
+              E2E_FULL_RUN=1 docker compose \
+                -p dfx-e2e-stack \
+                --env-file e2e-stack/.env.generated \
+                -f e2e-stack/compose.yml \
+                -f e2e-stack/compose.tests.yml \
+                run --name dfx-e2e-stack-tests tests
+              ;;
+            *)
+              # An unknown mode must fail loud — the check would otherwise succeed
+              # without having run anything (interface drift protection).
+              echo "::error::Unknown scope mode: '$MODE'."
+              exit 1
+              ;;
+          esac
 
       - name: Collect test artifacts
-        if: always()
+        if: always() && steps.scope.outputs.mode != 'none'
         run: |
           mkdir -p e2e-stack-artifacts
           # Named volumes back these paths inside the tests container. Bind mounts
@@ -156,7 +298,7 @@ jobs:
             || true
 
       - name: Upload test artifacts
-        if: always()
+        if: always() && steps.scope.outputs.mode != 'none'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-stack-report
@@ -165,5 +307,5 @@ jobs:
           if-no-files-found: warn
 
       - name: Tear down stack
-        if: always()
+        if: always() && steps.scope.outputs.mode != 'none'
         run: bash e2e-stack/scripts/down.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,3 +1,13 @@
+# PR CI: lint, format, tests, and builds.
+#
+# The job has no `if:` because a skipped required check counts as passing.
+# Develop PRs without the `ci:full` label run only Jest `--findRelatedTests` on
+# changed files under `src/**` and `functions/**`. The full suite runs for PRs
+# into main, workflow_dispatch, the `ci:full` label, test/build infrastructure
+# changes, unsafe path characters, and any deleted (or renamed-as-deleted)
+# source file under `src/` or `functions/`. Lint, Markdown format check,
+# `build:dev`, and `widget:dev` always run in full.
+
 name: PR CI
 
 on:
@@ -5,6 +15,13 @@ on:
     branches:
       - main
       - develop
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
   workflow_dispatch:
 
 permissions:
@@ -16,11 +33,140 @@ env:
 jobs:
   build:
     name: Build and test
-    if: github.head_ref != 'develop'
     runs-on: ubuntu-latest
     steps:
+      # Full history (fetch-depth: 0): the scope step below diffs against the merge base
+      # with the PR's base branch (`origin/BASE...HEAD`), which a shallow single-commit
+      # checkout cannot resolve.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Decides, inside the job, whether this run needs the full suite or only the tests
+      # related to the PR's changed files. Never a job `if:` or a `paths:` filter: a
+      # skipped required check counts as passing.
+      - name: Determine test scope
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          # Writes both outputs and ends the step - keeps every terminal case below a
+          # one-liner guard clause. Omitting the second argument keeps `files` empty,
+          # which matters for full/none: a leftover file list must not switch Jest into
+          # changed-files mode.
+          finish_scope() {
+            local mode=$1 files=${2-}
+            { echo "mode=$mode"; echo "files=$files"; } >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          if [[ "$EVENT_NAME" != 'pull_request' ]]; then
+            echo "Full run: event is '$EVENT_NAME', not a pull request."
+            finish_scope full
+          fi
+
+          if [[ "$BASE" == 'main' ]]; then
+            echo 'Full run: pull request targets main (release PR - the backstop for indirect regressions).'
+            finish_scope full
+          fi
+
+          # Exact `.name == "ci:full"` via jq: GitHub's `contains()` on label arrays is
+          # not case-sensitive. grep/jq exit 1 (no match) must not be conflated with
+          # >=2 (failure) - a failed jq must fail the step, not silently shrink the gate.
+          rc=0
+          jq -e 'any(.pull_request.labels[]?; .name == "ci:full")' "$GITHUB_EVENT_PATH" >/dev/null || rc=$?
+          if (( rc >= 2 )); then
+            echo "::error::jq failed while checking for the ci:full label (exit $rc)."
+            exit 1
+          fi
+          if (( rc == 0 )); then
+            echo 'Full run: the PR has the ci:full label.'
+            finish_scope full
+          fi
+
+          # Safety net: guarantee the base ref exists locally even if the checkout behavior changes.
+          git fetch --quiet origin "$BASE"
+
+          # Two diffs on purpose. The infra and deleted-source checks must also see
+          # DELETED files; filtering deletions out first would let such a PR dodge the
+          # full run.
+          #
+          # --no-renames on both: git's rename detection reports only the NEW path of a
+          # renamed file, so infrastructure or source renamed away would dodge the checks.
+          # With --no-renames the old path shows up as a deletion in diff_all.
+          diff_all=$(git diff --no-renames --name-only "origin/$BASE...HEAD")
+
+          # The files list keeps --diff-filter=d: it feeds --findRelatedTests, and deleted
+          # files no longer exist, so handing them to Jest would only error.
+          diff=$(git diff --no-renames --name-only --diff-filter=d "origin/$BASE...HEAD")
+
+          # This guard must run on the RAW diff, before any filtering: git quotes exotic
+          # path names (core.quotePath), which would distort classification below. Herestring
+          # instead of a pipe: with pipefail, grep -q quitting early could turn a hit into a
+          # SIGPIPE failure and silently defuse the guard. grep exit codes 1 (no match) and
+          # >=2 (failure) must not be conflated.
+          rc=0
+          grep -qv '^[A-Za-z0-9._/-]*$' <<< "$diff_all" || rc=$?
+          if (( rc >= 2 )); then
+            echo "::error::grep failed while validating changed paths (exit $rc)."
+            exit 1
+          fi
+          if (( rc == 0 )); then
+            echo 'Full run: a changed path contains characters outside the safe set A-Za-z0-9._/-.'
+            finish_scope full
+          fi
+
+          # Any hit on test/build infrastructure forces the full run. Root-level / these
+          # paths only: package manifests, craco configs, CRA overrides, this workflow, and
+          # the build scripts.
+          rc=0
+          infra=$(grep -E '^(package\.json|package-lock\.json|craco[^/]*|config-overrides\.js|\.github/workflows/pr\.yml|scripts/build\.sh|scripts/build-widget\.sh)$' <<< "$diff_all") || rc=$?
+          if (( rc >= 2 )); then
+            echo "::error::grep failed while matching test infrastructure paths (exit $rc)."
+            exit 1
+          fi
+          if (( rc == 0 )); then
+            echo 'Full run: the PR touches test infrastructure:'
+            echo "$infra"
+            finish_scope full
+          fi
+
+          # The files list below drops deletions so they cannot be handed to Jest. A PR
+          # that only deletes under src/ or functions/ would then become mode=none and skip
+          # tests. Renames are delete+add under --no-renames, so they hit this too.
+          rc=0
+          deleted_src=$(git diff --no-renames --name-only --diff-filter=D "origin/$BASE...HEAD")
+          deleted_source=$(grep -E '^(src/|functions/)' <<< "$deleted_src") || rc=$?
+          if (( rc >= 2 )); then
+            echo "::error::grep failed while matching deleted source files (exit $rc)."
+            exit 1
+          fi
+          if (( rc == 0 )); then
+            echo 'Full run: the PR deletes source files under src/ or functions/ (renames included):'
+            echo "$deleted_source"
+            finish_scope full
+          fi
+
+          rc=0
+          files_lines=$(grep -E '^(src/|functions/)' <<< "$diff") || rc=$?
+          if (( rc >= 2 )); then
+            echo "::error::grep failed while extracting changed source files (exit $rc)."
+            exit 1
+          fi
+          files=$(tr '\n' ' ' <<< "$files_lines" | sed 's/ *$//')
+
+          if [[ -z "$files" ]]; then
+            echo 'No run: the PR has no non-deleted files under src/ or functions/ to test.'
+            finish_scope none
+          fi
+
+          echo 'Reduced run: tests related to the changed files:'
+          echo "$files" | tr ' ' '\n'
+          finish_scope changed "$files"
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
@@ -37,8 +183,32 @@ jobs:
       - name: Check Markdown formatting
         run: npm run format:md:check
 
+      # One step for all three scope modes: the step always runs so the check cannot be
+      # defeated by a skip. Full suite for main/dispatch/ci:full/infra/unsafe/deleted;
+      # related tests for develop PRs with changed src/ or functions/ files; none when
+      # there is nothing under those trees to hand to Jest.
       - name: Run tests
-        run: npm run test
+        env:
+          MODE: ${{ steps.scope.outputs.mode }}
+          FILES: ${{ steps.scope.outputs.files }}
+        run: |
+          set -euo pipefail
+          case "$MODE" in
+            full)
+              CI=true npm test
+              ;;
+            changed)
+              # Word-splitting of $FILES is intentional — one path per Jest argument.
+              CI=true npm test -- --findRelatedTests $FILES --passWithNoTests
+              ;;
+            none)
+              echo 'Nothing to test: the PR has no non-deleted files under src/ or functions/.'
+              ;;
+            *)
+              echo "::error::Unknown scope mode: '$MODE'."
+              exit 1
+              ;;
+          esac
 
       - name: Build code
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - edited
       - labeled
       - unlabeled
   workflow_dispatch:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -122,10 +122,10 @@ jobs:
           fi
 
           # Any hit on test/build infrastructure forces the full run. Root-level / these
-          # paths only: package manifests, craco configs, CRA overrides, this workflow, and
-          # the build scripts.
+          # paths only: package manifests, craco configs, CRA overrides, this workflow, the
+          # build scripts, and the Jest test helper src/setupTests.ts.
           rc=0
-          infra=$(grep -E '^(package\.json|package-lock\.json|craco[^/]*|config-overrides\.js|\.github/workflows/pr\.yml|scripts/build\.sh|scripts/build-widget\.sh)$' <<< "$diff_all") || rc=$?
+          infra=$(grep -E '^(package\.json|package-lock\.json|craco[^/]*|config-overrides\.js|\.github/workflows/pr\.yml|scripts/build\.sh|scripts/build-widget\.sh|src/setupTests\.ts)$' <<< "$diff_all") || rc=$?
           if (( rc >= 2 )); then
             echo "::error::grep failed while matching test infrastructure paths (exit $rc)."
             exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,10 @@ npm run test
 ```
 
 Unit tests run in CI on every pull request against `develop` or `main` and must
-pass. The one exception is the release pull request, whose head branch is
-`develop` — there the build job is skipped by design.
+pass. Develop PRs without the `ci:full` label run Jest `--findRelatedTests` on
+the changed files under `src/` and `functions/`. Apply `ci:full` (or target
+`main`, or touch test/build infrastructure) to force the full suite. Lint,
+`build:dev` and `widget:dev` always run in full. The job is never skipped.
 
 #### Coverage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,8 +80,9 @@ The PR CI job always runs. Develop PRs without `ci:full` run Jest
 no such files and no full-run trigger records `mode=none` and skips the suite
 without failing. Apply `ci:full` to force the full suite, as do PRs into `main`,
 `workflow_dispatch`, unsafe path characters, test/build infrastructure, and
-deleting or renaming files under `src/` or `functions/`. Lint, `build:dev` and
-`widget:dev` always run in full. The job is never skipped.
+deleting or renaming files under `src/` or `functions/`. Lint, Markdown
+formatting (`format:md:check`), `build:dev` and `widget:dev` always run in full.
+The job is never skipped.
 
 #### Coverage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ above, which does not run in CI — this harness's job runs on every pull reques
 The stack comes up only for runtime-relevant changes. Documentation-only PRs with
 safe path characters record `mode=none` and skip the stack. Apply `ci:full` (or
 target `main`, run `workflow_dispatch`, use unsafe path characters, or touch
-`e2e-stack/` / the e2e workflow) to force a full run.
+`e2e-stack/` / `.github/workflows/e2e-stack.yml`) to force a full run.
 
 A pull request that changes a screen or an API contract should bring or update
 the matching full-stack test.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,8 @@ suite under `e2e/` — see [Visual regression tests (Playwright)](#visual-regres
 above, which does not run in CI — this harness's job runs on every pull request.
 The stack comes up only for runtime-relevant changes. Documentation-only PRs with
 safe path characters record `mode=none` and skip the stack. Apply `ci:full` (or
-target `main`, or touch `e2e-stack/` / the e2e workflow) to force a full run.
+target `main`, run `workflow_dispatch`, use unsafe path characters, or touch
+`e2e-stack/` / the e2e workflow) to force a full run.
 
 A pull request that changes a screen or an API contract should bring or update
 the matching full-stack test.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,11 +75,13 @@ Two obligations follow from it for every pull request:
 npm run test
 ```
 
-Unit tests run in CI on every pull request against `develop` or `main` and must
-pass. Develop PRs without the `ci:full` label run Jest `--findRelatedTests` on
-the changed files under `src/` and `functions/`. Apply `ci:full` (or target
-`main`, or touch test/build infrastructure) to force the full suite. Lint,
-`build:dev` and `widget:dev` always run in full. The job is never skipped.
+The PR CI job always runs. Develop PRs without `ci:full` run Jest
+`--findRelatedTests` on changed files under `src/` and `functions/`. A PR with
+no such files and no full-run trigger records `mode=none` and skips the suite
+without failing. Apply `ci:full` to force the full suite, as do PRs into `main`,
+`workflow_dispatch`, unsafe path characters, test/build infrastructure, and
+deleting or renaming files under `src/` or `functions/`. Lint, `build:dev` and
+`widget:dev` always run in full. The job is never skipped.
 
 #### Coverage
 
@@ -197,14 +199,18 @@ yourself, so nothing fails at build time.
 The full-stack harness under `e2e-stack/` runs the real frontend, API, and
 Postgres together (external providers are mocked). Unlike the visual-regression
 suite under `e2e/` — see [Visual regression tests (Playwright)](#visual-regression-tests-playwright)
-above, which does not run in CI — this harness runs on every pull request in CI.
+above, which does not run in CI — this harness's job runs on every pull request.
+The stack comes up only for runtime-relevant changes. Documentation-only PRs with
+safe path characters record `mode=none` and skip the stack. Apply `ci:full` (or
+target `main`, or touch `e2e-stack/` / the e2e workflow) to force a full run.
 
 A pull request that changes a screen or an API contract should bring or update
 the matching full-stack test.
 
 Coverage of the route tree is enforced, not tracked by hand. The suite reads the
 route definitions out of `src/App.tsx` and fails if a route is claimed by no test
-file or by more than one, and — on a full run, which is what CI does — if a route
+file or by more than one, and — on a full run (`E2E_FULL_RUN=1`, which CI sets
+whenever it brings the stack up) — if a route
 was never actually opened by any test. The browser records every navigation it
 makes, and the gate compares that recording against the route list, so a claim
 pointing at a file that never visits the route does not satisfy it. Adding a route

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -12,8 +12,8 @@ built yet; nothing here may describe a capability as existing when it does not.
 
 | Layer             | Location     | What it proves                                                               | What it cannot prove                                               | Runs in CI |
 | ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------- |
-| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | yes        |
-| Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — every process-gated job is off during the run | job always; stack not on docs-only |
+| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | job always; suite full / related / none |
+| Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — every process-gated job is off during the run | job always; stack not on safe-path docs-only |
 | Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                           | no         |
 
 The processing chain behind the API — incoming transfers, AML, purchase calculation, liquidity,
@@ -71,8 +71,9 @@ the spec file a claim names does not exist. When `E2E_FULL_RUN=1` is set, it add
 claimed route the browser never opened. That flag is declared by the run, not measured from it, so it may
 only be set when the run really covers every spec: `e2e-stack/scripts/run.sh` sets it when it was given
 no arguments and clears it otherwise — clearing matters because `e2e-stack/compose.tests.yml` forwards
-whatever the caller's environment holds — and the CI workflow sets it when it brings the stack up (full run). Documentation-only
-PRs never set it; `ci:full` forces that full invocation.
+whatever the caller's environment holds — and the CI workflow sets it when it brings the stack up (full run). Safe-path
+documentation-only PRs never set it; `ci:full`, a retarget onto `main`, unsafe
+paths and `e2e-stack/` changes force that full invocation.
 Adding a route therefore means adding a claim in `e2e-stack/specs/registry/` and a test that navigates
 there.
 

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -10,11 +10,11 @@ built yet; nothing here may describe a capability as existing when it does not.
 
 ## The layers this repository owns
 
-| Layer             | Location     | What it proves                                                               | What it cannot prove                                               | Runs in CI |
-| ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------- |
-| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | job always; suite full / related / none |
+| Layer             | Location     | What it proves                                                               | What it cannot prove                                               | Runs in CI                                   |
+| ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------- |
+| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | job always; suite full / related / none      |
 | Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — every process-gated job is off during the run | job always; stack not on safe-path docs-only |
-| Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                           | no         |
+| Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                           | no                                           |
 
 The processing chain behind the API — incoming transfers, AML, purchase calculation, liquidity,
 payout, ledger booking — is **not** testable from this repository. It belongs to the integration
@@ -72,8 +72,9 @@ claimed route the browser never opened. That flag is declared by the run, not me
 only be set when the run really covers every spec: `e2e-stack/scripts/run.sh` sets it when it was given
 no arguments and clears it otherwise — clearing matters because `e2e-stack/compose.tests.yml` forwards
 whatever the caller's environment holds — and the CI workflow sets it when it brings the stack up (full run). Safe-path
-documentation-only PRs never set it; `ci:full`, a retarget onto `main`, unsafe
-paths and `e2e-stack/` changes force that full invocation.
+documentation-only PRs never set it; `ci:full`, PRs into `main`,
+`workflow_dispatch`, unsafe path characters, and changes under `e2e-stack/` or
+`.github/workflows/e2e-stack.yml` force that full invocation.
 Adding a route therefore means adding a claim in `e2e-stack/specs/registry/` and a test that navigates
 there.
 

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -13,7 +13,7 @@ built yet; nothing here may describe a capability as existing when it does not.
 | Layer             | Location     | What it proves                                                               | What it cannot prove                                               | Runs in CI |
 | ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------- |
 | Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | yes        |
-| Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — every process-gated job is off during the run | yes        |
+| Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — every process-gated job is off during the run | job always; stack not on docs-only |
 | Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                           | no         |
 
 The processing chain behind the API — incoming transfers, AML, purchase calculation, liquidity,
@@ -71,7 +71,8 @@ the spec file a claim names does not exist. When `E2E_FULL_RUN=1` is set, it add
 claimed route the browser never opened. That flag is declared by the run, not measured from it, so it may
 only be set when the run really covers every spec: `e2e-stack/scripts/run.sh` sets it when it was given
 no arguments and clears it otherwise — clearing matters because `e2e-stack/compose.tests.yml` forwards
-whatever the caller's environment holds — and the CI workflow sets it for its own unfiltered invocation.
+whatever the caller's environment holds — and the CI workflow sets it when it brings the stack up (full run). Documentation-only
+PRs never set it; `ci:full` forces that full invocation.
 Adding a route therefore means adding a claim in `e2e-stack/specs/registry/` and a test that navigates
 there.
 

--- a/e2e-stack/README.md
+++ b/e2e-stack/README.md
@@ -123,7 +123,8 @@ The suite under `e2e/` is visual-regression testing (screenshot baselines). It d
 
 This harness checks function, not appearance. The CI job always runs; the stack
 comes up only for runtime-relevant changes. Documentation-only PRs with safe path
-characters skip the stack (`mode=none`). The `ci:full` label, PRs into `main`,
+characters skip the stack (`mode=none`). There is no selected/partial mode:
+every leftover runtime path, the `ci:full` label, PRs into `main`,
 `workflow_dispatch`, and changes under `e2e-stack/` or the e2e workflow force a
 full run. Both suites exist side by side and serve different purposes.
 

--- a/e2e-stack/README.md
+++ b/e2e-stack/README.md
@@ -125,8 +125,8 @@ This harness checks function, not appearance. The CI job always runs; the stack
 comes up only for runtime-relevant changes. Documentation-only PRs with safe path
 characters skip the stack (`mode=none`). There is no selected/partial mode:
 every leftover runtime path, the `ci:full` label, PRs into `main`,
-`workflow_dispatch`, and changes under `e2e-stack/` or the e2e workflow force a
-full run. Both suites exist side by side and serve different purposes.
+`workflow_dispatch`, unsafe path characters, and changes under `e2e-stack/` or
+`.github/workflows/e2e-stack.yml` force a full run. Both suites exist side by side and serve different purposes.
 
 ## Relationship with the API repository
 

--- a/e2e-stack/README.md
+++ b/e2e-stack/README.md
@@ -121,7 +121,11 @@ The tests container starts a `socat`-based TCP forwarder on `127.0.0.1:3000` (ov
 
 The suite under `e2e/` is visual-regression testing (screenshot baselines). It deliberately does not run in CI, because baselines are platform- and font-dependent.
 
-This harness checks function, not appearance, and therefore does run in CI on every pull request. Both suites exist side by side and serve different purposes.
+This harness checks function, not appearance. The CI job always runs; the stack
+comes up only for runtime-relevant changes. Documentation-only PRs with safe path
+characters skip the stack (`mode=none`). The `ci:full` label, PRs into `main`,
+`workflow_dispatch`, and changes under `e2e-stack/` or the e2e workflow force a
+full run. Both suites exist side by side and serve different purposes.
 
 ## Relationship with the API repository
 
@@ -179,7 +183,7 @@ docker run --rm -v "${project}_e2e-test-results:/vol" -v "$(pwd)/test-results:/d
 docker run --rm -v "${project}_e2e-playwright-report:/vol" -v "$(pwd)/playwright-report:/dest" alpine cp -a /vol/. /dest/
 ```
 
-In CI the workflow does this automatically and uploads an artifact named `e2e-stack-report`.
+In CI the workflow does this automatically on a full run and uploads an artifact named `e2e-stack-report`. Docs-only runs (`mode=none`) produce no artifact.
 
 **Stack does not become healthy**
 


### PR DESCRIPTION
## What

- Removes `if: github.head_ref != 'develop'` (the branch name is spoofable; a skipped required check counts as passing).
- Develop PRs without `ci:full` run Jest `--findRelatedTests` on changed `src/` and `functions/` files. Lint, `format:md:check`, `build:dev` and `widget:dev` stay full. A change to `src/setupTests.ts` forces the full suite (Jest loads it for every test).
- E2E: documentation-only PRs with safe path characters record `mode=none` and skip the stack, the API checkout, and the harness type-check. `ci:full`, `main`, `workflow_dispatch`, unsafe path characters, and any change under `e2e-stack/` or `.github/workflows/e2e-stack.yml` run the full suite. Other runtime changes also run full (no per-screen spec map).

The `ci:full` label is matched exactly via `jq` on `GITHUB_EVENT_PATH`. `labeled` / `unlabeled` / `edited` retrigger both workflows.

## Why

Same scoped-develop / full-on-main rule as the other application repositories after their matching pull requests.