### PR TITLE
019ffa1c - Reject pull requests into main that are not from develop

### DIFF
--- a/.github/workflows/main-from-develop.yml
+++ b/.github/workflows/main-from-develop.yml
@@ -33,6 +33,10 @@ jobs:
           THIS_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          if [ -z "$HEAD_REF" ] || [ -z "$HEAD_REPO" ] || [ -z "$THIS_REPO" ]; then
+            echo "::error::Missing pull_request head metadata; refusing to pass."
+            exit 1
+          fi
           if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
             echo "::error::PRs into main must come from ${THIS_REPO}@develop, not a fork (${HEAD_REPO})."
             exit 1

--- a/.github/workflows/main-from-develop.yml
+++ b/.github/workflows/main-from-develop.yml
@@ -1,0 +1,44 @@
+# PRs into main must come from this repository's develop branch.
+# GitHub has no native source-branch restriction; this job is the gate.
+# Do not add a job-level `if:` that skips on the wrong head: a skipped
+# required check counts as passing.
+
+name: Main source branch
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - edited
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+
+jobs:
+  only-develop:
+    name: Main only from develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject any head other than this repo's develop
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          THIS_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
+            echo "::error::PRs into main must come from ${THIS_REPO}@develop, not a fork (${HEAD_REPO})."
+            exit 1
+          fi
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "::error::PRs into main must come from develop (got '${HEAD_REF}'). Merge into develop first."
+            exit 1
+          fi
+          echo "Head is ${THIS_REPO}@develop."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,12 @@ granted in writing on the pull request.
 A follow-up that exists only as an intention is a follow-up nobody opens. The
 next reviewer then finds the same points again and the work is done twice.
 
+### Releases into main
+
+Open feature pull requests against `develop`. CI rejects a pull request into
+`main` unless its head is this repository's `develop` (check name `Main only
+from develop`).
+
 ### Report every bug you find, including pre-existing ones
 
 A defect in code a pull request touches is reported as a bug — with the same


### PR DESCRIPTION
## What

Adds `.github/workflows/main-from-develop.yml`. A pull request into `main` fails unless its head is this repository's `develop` branch (check name `Main only from develop`). Fork heads are rejected even if they are named `develop`. Empty head metadata fails closed.

## Why

GitHub has no native source-branch restriction. Feature work goes to `develop`; only the release PR updates `main`.

## Deviation

Branch name `guard/main-from-develop` is shared across the three application repositories for this gate; that is a declared deviation from the usual `feat/` / `fix/` / `chore/` prefix.

Enforcement after this is on `develop`: add a main ruleset `workflows` rule that runs this file from `refs/heads/develop`. Do not require the check name alone — that would use the pull-request head YAML.