### PR TITLE
019fff50 - Treat RealUnit holders empty-state e2e as passing

### DIFF
--- a/e2e-stack/specs/realunit.spec.ts
+++ b/e2e-stack/specs/realunit.spec.ts
@@ -174,24 +174,21 @@ test.describe('RealUnit area', () => {
   // Empty holders list must render the table chrome (heading, columns, pager)
   // without an uncaught page error. CI recorded this former test.fail as
   // "Expected to fail, but passed" on the full-stack run.
-  test(
-    '/realunit/holders empty state — table chrome without uncaught error',
-    async ({ page }) => {
-      const { jwt } = await loginAs('RealUnit');
-      const { pageErrors, consoleErrors } = attachErrorListeners(page);
+  test('/realunit/holders empty state — table chrome without uncaught error', async ({ page }) => {
+    const { jwt } = await loginAs('RealUnit');
+    const { pageErrors, consoleErrors } = attachErrorListeners(page);
 
-      await openScreen(page, '/realunit/holders', jwt);
+    await openScreen(page, '/realunit/holders', jwt);
 
-      await expect(page.getByRole('heading', { name: /All Holders/ })).toBeVisible();
-      await expect(tableHeader(page, 'Address')).toBeVisible();
-      await expect(tableHeader(page, 'Balance')).toBeVisible();
-      await expect(tableHeader(page, 'Percentage')).toBeVisible();
-      await expect(page.getByRole('button', { name: 'Previous' })).toBeVisible();
-      await expect(page.getByRole('button', { name: 'Next' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /All Holders/ })).toBeVisible();
+    await expect(tableHeader(page, 'Address')).toBeVisible();
+    await expect(tableHeader(page, 'Balance')).toBeVisible();
+    await expect(tableHeader(page, 'Percentage')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Previous' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Next' })).toBeVisible();
 
-      assertNoErrors(pageErrors, consoleErrors);
-    },
-  );
+    assertNoErrors(pageErrors, consoleErrors);
+  });
 
   test('/realunit/quotes list renders empty or ErrorHint without crash', async ({ page }) => {
     const { jwt } = await loginAs('RealUnit');

--- a/e2e-stack/specs/realunit.spec.ts
+++ b/e2e-stack/specs/realunit.spec.ts
@@ -171,10 +171,11 @@ test.describe('RealUnit area', () => {
     },
   );
 
-  // CONFIRMED product bug (live uncaught pageerror): fetchHolders() has no .catch() in
-  // realunit.context.tsx. Observed: ApiException: Cannot read properties of undefined (reading 'document').
-  test.fail(
-    '/realunit/holders empty state — uncaught ApiException from fetchHolders() (no .catch; reading document)',
+  // Empty holders list must render the table chrome (heading, columns, pager)
+  // without an uncaught page error. CI recorded this former test.fail as
+  // "Expected to fail, but passed" on the full-stack run.
+  test(
+    '/realunit/holders empty state — table chrome without uncaught error',
     async ({ page }) => {
       const { jwt } = await loginAs('RealUnit');
       const { pageErrors, consoleErrors } = attachErrorListeners(page);


### PR DESCRIPTION
EN:
The RealUnit holders empty-state full-stack test now passes, so it is no longer marked expected-to-fail.

DE:
Der RealUnit-Holders-Leerzustand im Full-Stack-Test besteht jetzt, deshalb ist er nicht mehr als erwarteter Fehler markiert.

<details>
<summary>Details</summary>

The API full-stack E2E run failed with a single error: Playwright `test.fail` for `/realunit/holders empty state` reported "Expected to fail, but passed". The dashboard spinner and `/realunit/user/:address` cases remain `test.fail` because they still fail as documented.

This change only flips that one case to a regular `test` and updates the comment. Assertions are unchanged.

</details>