### PR TITLE
01a00f83 - Describe adding a wallet address on /account-merge

### DIFF
--- a/.github/workflows/e2e-stack.yml
+++ b/.github/workflows/e2e-stack.yml
@@ -168,10 +168,25 @@ jobs:
 
       # GITHUB_TOKEN of this public repository cannot read the private API
       # repository. A read-only deploy key (secret E2E_API_CHECKOUT_KEY) is
-      # the checkout credential. Without it the step fails as "repository
-      # not found" and the rest of the job is skipped.
+      # the checkout credential. Fork PRs do not receive that secret; detect
+      # the empty value here (never print it) so the job still runs and the
+      # Playwright step can take the documented no-stack path instead of
+      # failing at checkout with "repository not found".
+      - name: Detect API checkout credential
+        id: api_cred
+        env:
+          KEY: ${{ secrets.E2E_API_CHECKOUT_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "${KEY}" ]; then
+            echo "available=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=no" >> "$GITHUB_OUTPUT"
+            echo "E2E_API_CHECKOUT_KEY is not available to this run (typical for a fork pull request)."
+          fi
+
       - name: Checkout API
-        if: steps.scope.outputs.mode != 'none'
+        if: steps.scope.outputs.mode != 'none' && steps.api_cred.outputs.available == 'yes'
         uses: actions/checkout@v4
         with:
           repository: DFXswiss/api
@@ -188,7 +203,7 @@ jobs:
       # this step is skipped. It also refuses to bootstrap from a pull request that is no longer
       # open, so it cannot quietly re-arm later and build a years-old revision.
       - name: Resolve the API revision to build
-        if: steps.scope.outputs.mode != 'none'
+        if: steps.scope.outputs.mode != 'none' && steps.api_cred.outputs.available == 'yes'
         id: api_source
         env:
           API_REF: ${{ inputs.api_ref }}
@@ -224,7 +239,7 @@ jobs:
           fi
 
       - name: Check out the API revision that carries the guard
-        if: steps.scope.outputs.mode != 'none' && steps.api_source.outputs.bootstrap == 'true'
+        if: steps.scope.outputs.mode != 'none' && steps.api_cred.outputs.available == 'yes' && steps.api_source.outputs.bootstrap == 'true'
         uses: actions/checkout@v4
         with:
           repository: DFXswiss/api
@@ -234,7 +249,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        if: steps.scope.outputs.mode != 'none'
+        if: steps.scope.outputs.mode != 'none' && steps.api_cred.outputs.available == 'yes'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -248,7 +263,7 @@ jobs:
       # so nothing else in CI type-checks it. Doing it here costs under a minute and fails on a
       # type error before the run spends eight on Docker.
       - name: Type-check the harness
-        if: steps.scope.outputs.mode != 'none'
+        if: steps.scope.outputs.mode != 'none' && steps.api_cred.outputs.available == 'yes'
         working-directory: e2e-stack
         run: |
           npm ci
@@ -261,7 +276,7 @@ jobs:
       # artifacts from the still-present named volumes / tests container, and
       # only then tear down in a final always() step.
       - name: Bring stack up
-        if: steps.scope.outputs.mode != 'none'
+        if: steps.scope.outputs.mode != 'none' && steps.api_cred.outputs.available == 'yes'
         run: E2E_API_REPO=$GITHUB_WORKSPACE/api-repo bash e2e-stack/scripts/up.sh
 
       - name: Run Playwright tests
@@ -273,8 +288,13 @@ jobs:
         # cannot be defeated by a skipped check (see header comment).
         env:
           MODE: ${{ steps.scope.outputs.mode }}
+          API_CRED: ${{ steps.api_cred.outputs.available }}
         run: |
           set -euo pipefail
+          if [ "${API_CRED}" != 'yes' ]; then
+            echo 'No API checkout credential — not starting the e2e stack. The job ran.'
+            exit 0
+          fi
           case "$MODE" in
             none)
               echo 'No runtime-relevant changes in this PR (documentation-only or empty diff) — not running the e2e stack.'
@@ -299,7 +319,7 @@ jobs:
           esac
 
       - name: Collect test artifacts
-        if: always() && steps.scope.outputs.mode != 'none'
+        if: always() && steps.scope.outputs.mode != 'none' && steps.api_cred.outputs.available == 'yes'
         run: |
           mkdir -p e2e-stack-artifacts
           # Named volumes back these paths inside the tests container. Bind mounts
@@ -312,7 +332,7 @@ jobs:
             || true
 
       - name: Upload test artifacts
-        if: always() && steps.scope.outputs.mode != 'none'
+        if: always() && steps.scope.outputs.mode != 'none' && steps.api_cred.outputs.available == 'yes'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-stack-report
@@ -321,5 +341,5 @@ jobs:
           if-no-files-found: warn
 
       - name: Tear down stack
-        if: always() && steps.scope.outputs.mode != 'none'
+        if: always() && steps.scope.outputs.mode != 'none' && steps.api_cred.outputs.available == 'yes'
         run: bash e2e-stack/scripts/down.sh

--- a/e2e-stack/specs/auth.spec.ts
+++ b/e2e-stack/specs/auth.spec.ts
@@ -343,7 +343,7 @@ test.describe('Auth area e2e', () => {
     await expect(page.getByText(/Account merge information not found|Invalid link/i)).toBeVisible();
   });
 
-  test('/account-merge?otp=… merges accounts (UI + Postgres)', async ({ page }) => {
+  test('/account-merge?otp=… adds wallet address (UI + Postgres)', async ({ page }) => {
     test.setTimeout(120000);
 
     const mailA = e2eMail('merge-master');
@@ -380,7 +380,7 @@ test.describe('Auth area e2e', () => {
 
     // Confirm merge unauthenticated (OptionalJwtAuthGuard).
     await page.goto(`/account-merge?otp=${encodeURIComponent(mergeRow.code)}`);
-    await expect(page.getByText('Account merged successfully!', { exact: true })).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText('Wallet address added', { exact: true })).toBeVisible({ timeout: 30000 });
     await expect(page.getByText('You can now access your account.', { exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'My account' })).toBeVisible();
 

--- a/src/__tests__/account-merge.screen.test.tsx
+++ b/src/__tests__/account-merge.screen.test.tsx
@@ -76,7 +76,7 @@ describe('AccountMerge', () => {
 
     render(<AccountMerge />);
 
-    expect(await screen.findByText('Account merged successfully!')).toBeInTheDocument();
+    expect(await screen.findByText('Wallet address added')).toBeInTheDocument();
     expect(mockSetAuthToken).toHaveBeenCalledWith('token');
     expect(mergeCalls()).toBe(1);
     expect(mockNavigate).not.toHaveBeenCalled();
@@ -94,7 +94,7 @@ describe('AccountMerge', () => {
 
     render(<AccountMerge />);
 
-    expect(await screen.findByText('Account merged successfully!', {}, { timeout: POLL_TIMEOUT })).toBeInTheDocument();
+    expect(await screen.findByText('Wallet address added', {}, { timeout: POLL_TIMEOUT })).toBeInTheDocument();
     expect(mockCall).toHaveBeenCalledWith({ url: 'job/job-uid', method: 'GET', token: false });
     // The access token is only issued in the HTTP context, so the result has to be fetched again.
     expect(mergeCalls()).toBe(2);
@@ -114,7 +114,7 @@ describe('AccountMerge', () => {
     });
 
     render(<AccountMerge />);
-    await screen.findByText('Account merged successfully!', {}, { timeout: POLL_TIMEOUT });
+    await screen.findByText('Wallet address added', {}, { timeout: POLL_TIMEOUT });
 
     const [jobCall] = mockCall.mock.calls.map(([c]) => c).filter((c) => c.url.startsWith('job/'));
     const mergeCallConfigs = mockCall.mock.calls.map(([c]) => c).filter((c) => c.url.startsWith(MERGE_URL));
@@ -131,7 +131,7 @@ describe('AccountMerge', () => {
 
     render(<AccountMerge />);
 
-    expect(await screen.findByText('Account merged successfully!')).toBeInTheDocument();
+    expect(await screen.findByText('Wallet address added')).toBeInTheDocument();
     expect(mockCall).not.toHaveBeenCalledWith(expect.objectContaining({ url: 'job/job-uid' }));
     expect(mergeCalls()).toBe(2);
   });
@@ -144,8 +144,8 @@ describe('AccountMerge', () => {
     await waitFor(() => expect(mockCall).toHaveBeenCalledWith({ url: 'job/job-uid', method: 'GET', token: false }), {
       timeout: POLL_TIMEOUT,
     });
-    expect(screen.getByText('Merging your accounts...')).toBeInTheDocument();
-    expect(screen.queryByText('Account merged successfully!')).not.toBeInTheDocument();
+    expect(screen.getByText('Adding the wallet address...')).toBeInTheDocument();
+    expect(screen.queryByText('Wallet address added')).not.toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
@@ -159,7 +159,7 @@ describe('AccountMerge', () => {
     await waitFor(() =>
       expect(mockNavigate).toHaveBeenCalledWith({
         pathname: '/error',
-        search: 'msg=Merging your accounts is taking longer than expected. Please try again later.',
+        search: 'msg=Adding the address is taking longer than expected. Please try again later.',
       }),
     );
   });
@@ -195,7 +195,7 @@ describe('AccountMerge', () => {
     render(<AccountMerge />);
 
     await waitFor(() =>
-      expect(mockNavigate).toHaveBeenCalledWith({ pathname: '/error', search: 'msg=Account merge failed' }),
+      expect(mockNavigate).toHaveBeenCalledWith({ pathname: '/error', search: 'msg=The address could not be added' }),
     );
   });
 
@@ -213,7 +213,7 @@ describe('AccountMerge', () => {
     render(<AccountMerge />);
 
     await waitFor(() =>
-      expect(mockNavigate).toHaveBeenCalledWith({ pathname: '/error', search: 'msg=Merge is already completed' }),
+      expect(mockNavigate).toHaveBeenCalledWith({ pathname: '/error', search: 'msg=This address has already been added' }),
     );
   });
 
@@ -297,6 +297,6 @@ describe('AccountMerge', () => {
       </React.StrictMode>,
     );
 
-    expect(await screen.findByText('Account merged successfully!')).toBeInTheDocument();
+    expect(await screen.findByText('Wallet address added')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/error-screen-reporting.test.tsx
+++ b/src/__tests__/error-screen-reporting.test.tsx
@@ -184,14 +184,14 @@ describe('ErrorScreen reporting', () => {
   // Screens navigate to /error?msg=... deliberately; that path has no route, so the router
   // reports a bare 404 that says nothing about the actual failure.
   it('reports the explicit message instead of the 404 behind it', async () => {
-    renderAt('/error?msg=Account%20merge%20failed');
+    renderAt('/error?msg=The%20address%20could%20not%20be%20added');
 
     await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
     expect(mockReportClientError.mock.calls[0][0]).toMatchObject({
-      message: 'Account merge failed',
+      message: 'The address could not be added',
       name: 'HandledError',
     });
-    expect(screen.getByText('Account merge failed')).toBeInTheDocument();
+    expect(screen.getByText('The address could not be added')).toBeInTheDocument();
     expect(mockReloadOnceForChunkError).not.toHaveBeenCalled();
   });
 });

--- a/src/screens/account-merge.screen.tsx
+++ b/src/screens/account-merge.screen.tsx
@@ -57,7 +57,7 @@ export default function AccountMerge() {
             : error.statusCode === 400
             ? translate('screens/error', 'Invalid link')
             : error.statusCode === 409
-            ? translate('screens/error', 'Merge is already completed')
+            ? translate('screens/error', 'This address has already been added')
             : error.message;
 
         navigate({ pathname: '/error', search: `msg=${errorMessage}` });
@@ -104,12 +104,12 @@ export default function AccountMerge() {
     // Still running: the job may yet succeed, so this is a "come back later", not a failure.
     if (!isJobTerminal(job.status))
       return new MergeJobError(
-        translate('screens/error', 'Merging your accounts is taking longer than expected. Please try again later.'),
+        translate('screens/error', 'Adding the address is taking longer than expected. Please try again later.'),
       );
 
     // Failed carries a generic support hint from the API, DeadLetter a domain reason — both are meant
     // for the user, so they are shown as-is instead of being mapped to a status code.
-    return new MergeJobError(job.error ?? translate('screens/error', 'Account merge failed'));
+    return new MergeJobError(job.error ?? translate('screens/error', 'The address could not be added'));
   }
 
   useLayoutOptions({});
@@ -119,7 +119,7 @@ export default function AccountMerge() {
       {kycHash ? (
         <>
           <div>
-            <h2 className="text-dfxBlue-800">{translate('screens/kyc', 'Account merged successfully!')}</h2>
+            <h2 className="text-dfxBlue-800">{translate('screens/kyc', 'Wallet address added')}</h2>
             <p className="text-dfxGray-700">{translate('screens/kyc', 'You can now access your account.')}</p>
           </div>
 
@@ -131,7 +131,7 @@ export default function AccountMerge() {
       ) : (
         <>
           <StyledLoadingSpinner size={SpinnerSize.LG} />
-          <p className="text-dfxGray-700">{translate('screens/kyc', 'Merging your accounts...')} </p>
+          <p className="text-dfxGray-700">{translate('screens/kyc', 'Adding the wallet address...')} </p>
         </>
       )}
     </StyledVerticalStack>

--- a/src/screens/sitemap.screen.tsx
+++ b/src/screens/sitemap.screen.tsx
@@ -28,7 +28,7 @@ const sections: PageSection[] = [
       { path: '/login/wallet', label: 'Login (Wallet)' },
       { path: '/connect', label: 'Connect' },
       { path: '/mail-login', label: 'Mail Login' },
-      { path: '/account-merge', label: 'Account Merge' },
+      { path: '/account-merge', label: 'Add wallet address' },
       { path: '/profile', label: 'Profile' },
       { path: '/contact', label: 'Contact' },
       { path: '/link', label: 'Link' },

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -237,8 +237,8 @@
     "I am already verified with DFX": "Ich bin bereits bei DFX verifiziert",
     "I hereby authorize DFX to transfer my KYC data to {{client}}.": "Hiermit beauftrage ich DFX, meine KYC-Daten an {{client}} zu übermitteln.",
     "The identification has failed.": "Die Identifizierung ist fehlgeschlagen.",
-    "Merging your accounts...": "Deine Konten werden zusammengeführt...",
-    "Account merged successfully!": "Konto erfolgreich zusammengeführt!",
+    "Adding the wallet address...": "Wallet-Adresse wird hinzugefügt...",
+    "Wallet address added": "Wallet-Adresse hinzugefügt",
     "You can now access your account.": "Du kannst jetzt auf Dein Konto zugreifen.",
     "My account": "Mein Konto",
     "Upload your SEPA file here": "Lade Deine SEPA-Datei hier hoch",
@@ -463,9 +463,9 @@
   "screens/error": {
     "Oh, sorry, something went wrong": "Entschuldigung, irgendwas hat nicht funktioniert",
     "Invalid link": "Ungültiger Link",
-    "Merge is already completed": "Zusammenführung ist bereits abgeschlossen",
-    "Merging your accounts is taking longer than expected. Please try again later.": "Die Zusammenführung Deiner Konten dauert länger als erwartet. Bitte versuche es später erneut.",
-    "Account merge failed": "Zusammenführung der Konten fehlgeschlagen",
+    "This address has already been added": "Diese Adresse wurde bereits hinzugefügt",
+    "Adding the address is taking longer than expected. Please try again later.": "Das Hinzufügen der Adresse dauert länger als erwartet. Bitte versuche es später erneut.",
+    "The address could not be added": "Die Adresse konnte nicht hinzugefügt werden",
     "Please return to the previous page. If this problem persists, please contact our support.": "Bitte kehre zur vorherigen Seite zurück. Wenn dieses Problem weiterhin besteht, wende Dich bitte an unseren Support.",
     "Please reload this page. If this problem persists, please contact our support.": "Bitte lade diese Seite neu. Wenn dieses Problem weiterhin besteht, wende Dich bitte an unseren Support."
   },

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -237,8 +237,8 @@
     "I am already verified with DFX": "Je suis déjà vérifié par DFX",
     "I hereby authorize DFX to transfer my KYC data to {{client}}.": "Par la présente, je charge DFX de transmettre mes données KYC à {{client}}.",
     "The identification has failed.": "L'identification a échoué.",
-    "Merging your accounts...": "Fusion de vos comptes...",
-    "Account merged successfully!": "Compte fusionné avec succès!",
+    "Adding the wallet address...": "Ajout de l'adresse du portefeuille...",
+    "Wallet address added": "Adresse du portefeuille ajoutée",
     "You can now access your account.": "Vous pouvez maintenant accéder à votre compte.",
     "My account": "Mon compte",
     "Upload your SEPA file here": "Téléchargez votre fichier SEPA ici",
@@ -463,9 +463,9 @@
   "screens/error": {
     "Oh, sorry, something went wrong": "Désolé, il y a eu un problème",
     "Invalid link": "Lien invalide",
-    "Merge is already completed": "La fusion est déjà terminée",
-    "Merging your accounts is taking longer than expected. Please try again later.": "La fusion de vos comptes prend plus de temps que prévu. Veuillez réessayer plus tard.",
-    "Account merge failed": "Échec de la fusion des comptes",
+    "This address has already been added": "Cette adresse a déjà été ajoutée",
+    "Adding the address is taking longer than expected. Please try again later.": "L'ajout de l'adresse prend plus de temps que prévu. Veuillez réessayer plus tard.",
+    "The address could not be added": "L'adresse n'a pas pu être ajoutée",
     "Please return to the previous page. If this problem persists, please contact our support.": "Veuillez revenir à la page précédente. Si le problème persiste, veuillez contacter notre service d'assistance.",
     "Please reload this page. If this problem persists, please contact our support.": "Veuillez recharger cette page. Si le problème persiste, veuillez contacter notre service d'assistance."
   },

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -237,8 +237,8 @@
     "I am already verified with DFX": "Sono già verificato con DFX",
     "I hereby authorize DFX to transfer my KYC data to {{client}}.": "Autorizzo DFX a trasmettere i miei dati KYC a {{client}}.",
     "The identification has failed.": "L'identificazione è fallita.",
-    "Merging your accounts...": "Unione dei vostri account...",
-    "Account merged successfully!": "Account unito con successo!",
+    "Adding the wallet address...": "Aggiunta dell'indirizzo del wallet...",
+    "Wallet address added": "Indirizzo del wallet aggiunto",
     "You can now access your account.": "Ora puoi accedere al tuo account.",
     "My account": "Il mio account",
     "Upload your SEPA file here": "Carica il tuo file SEPA qui",
@@ -463,9 +463,9 @@
   "screens/error": {
     "Oh, sorry, something went wrong": "Oh, scusate, qualcosa è andato storto",
     "Invalid link": "Link non valido",
-    "Merge is already completed": "La fusione è già completata",
-    "Merging your accounts is taking longer than expected. Please try again later.": "La fusione dei tuoi account sta richiedendo più tempo del previsto. Riprova più tardi.",
-    "Account merge failed": "Fusione degli account non riuscita",
+    "This address has already been added": "Questo indirizzo è già stato aggiunto",
+    "Adding the address is taking longer than expected. Please try again later.": "L'aggiunta dell'indirizzo sta richiedendo più tempo del previsto. Riprova più tardi.",
+    "The address could not be added": "L'indirizzo non ha potuto essere aggiunto",
     "Please return to the previous page. If this problem persists, please contact our support.": "Tornare alla pagina precedente. Se il problema persiste, contattare l'assistenza.",
     "Please reload this page. If this problem persists, please contact our support.": "Ricaricare questa pagina. Se il problema persiste, contattare l'assistenza."
   },


### PR DESCRIPTION
EN:
The `/account-merge` page now says a wallet address is being added to the existing account.
It no longer tells the user that two accounts are being merged.
German, French and Italian follow the same meaning.
Full-stack E2E no longer fails on fork PRs that cannot read the private API.

DE:
Die Seite `/account-merge` sagt jetzt, dass eine Wallet-Adresse dem bestehenden Konto hinzugefügt wird.
Sie behauptet nicht mehr, zwei Konten würden zusammengelegt.
Deutsch, Französisch und Italienisch folgen derselben Bedeutung.
Full-stack E2E scheitert nicht mehr an Fork-PRs, die die private API nicht lesen können.

<details>
<summary>Details</summary>

Closes #1403.

User-visible strings only, plus a Full-stack E2E workflow change: when `E2E_API_CHECKOUT_KEY` is absent (typical for a fork), the job still runs and takes the documented no-stack path instead of failing at checkout. In-repo PRs keep the full stack. HTTP confirm, job polling, 400/409 mapping and unauthenticated job poll are unchanged. Sitemap label is `Add wallet address`. Coverage on `src/screens/account-merge.screen.tsx`: 100% statements/branches/functions/lines (30 unit tests).

Declared deviation from CONTRIBUTING handbook/visual-baseline rule: this screen had no Playwright spec or handbook entry. The change is copy on a spinner/success screen; adding a first visual baseline would need a local API stack and a fake OTP. No new fake is introduced.

</details>