### PR TITLE
01a00f7b - Open assign, refund and support on the public TX status page

### DIFF
--- a/src/__tests__/support-issue-receiver-iban.test.tsx
+++ b/src/__tests__/support-issue-receiver-iban.test.tsx
@@ -13,6 +13,8 @@ const mockCreateSupportIssue = jest.fn();
 const mockNavigate = jest.fn();
 const mockClearParams = jest.fn();
 const mockTranslate = jest.fn((_ns: string, key: string) => key);
+const mockLogout = jest.fn();
+let mockSupportIsLoggedIn = false;
 
 jest.mock('@dfx.swiss/react', () => {
   const SupportIssueType = {
@@ -102,7 +104,7 @@ jest.mock('@dfx.swiss/react', () => {
     Validations,
     useBank: () => ({ checkReceiveIban: mockCheckReceiveIban }),
     useBankAccountContext: () => ({ bankAccounts: undefined }),
-    useSessionContext: () => ({ isLoggedIn: false, logout: jest.fn() }),
+    useSessionContext: () => ({ isLoggedIn: mockSupportIsLoggedIn, logout: mockLogout }),
     useSupportChatContext: () => ({
       createSupportIssue: mockCreateSupportIssue,
       loadSupportIssue: jest.fn(),
@@ -443,6 +445,7 @@ describe('SupportIssueScreen receiver IBAN check', () => {
     mockCheckReceiveIban.mockReset();
     mockCreateSupportIssue.mockReset();
     mockCreateSupportIssue.mockResolvedValue('issue-uid-1');
+    mockSupportIsLoggedIn = false;
   });
 
   afterEach(async () => {
@@ -1032,5 +1035,12 @@ describe('SupportIssueScreen tx query param', () => {
     renderScreen(`?issue-type=${SupportIssueType.TRANSACTION_ISSUE}`);
 
     expect(mockUseUserGuard).toHaveBeenCalledWith('/login', true);
+  });
+
+  it('logs out a logged-in session when tx is present', () => {
+    mockSupportIsLoggedIn = true;
+    renderScreen(`?issue-type=${SupportIssueType.TRANSACTION_ISSUE}&tx=T1E448FF200A877DC`);
+
+    expect(mockLogout).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/support-issue-receiver-iban.test.tsx
+++ b/src/__tests__/support-issue-receiver-iban.test.tsx
@@ -273,8 +273,10 @@ jest.mock('src/contexts/settings.context', () => ({
   }),
 }));
 
+const mockUseUserGuard = jest.fn();
+
 jest.mock('src/hooks/guard.hook', () => ({
-  useUserGuard: () => undefined,
+  useUserGuard: (...args: unknown[]) => mockUseUserGuard(...args),
   useKycLevelGuard: () => undefined,
 }));
 
@@ -1011,5 +1013,24 @@ describe('SupportIssueScreen receiver IBAN check', () => {
     expect(screen.queryByText(HINTS[ReceiveIbanStatus.DFX_IBAN])).not.toBeInTheDocument();
     // Reason change only clears state; it must not start another check.
     expect(mockCheckReceiveIban).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SupportIssueScreen tx query param', () => {
+  beforeEach(() => {
+    mockUseUserGuard.mockReset();
+    mockClearParams.mockReset();
+  });
+
+  it('skips the login guard when tx is present', () => {
+    renderScreen(`?issue-type=${SupportIssueType.TRANSACTION_ISSUE}&tx=T1E448FF200A877DC`);
+
+    expect(mockUseUserGuard).toHaveBeenCalledWith('/login', false);
+  });
+
+  it('keeps the login guard active without a tx or order param', () => {
+    renderScreen(`?issue-type=${SupportIssueType.TRANSACTION_ISSUE}`);
+
+    expect(mockUseUserGuard).toHaveBeenCalledWith('/login', true);
   });
 });

--- a/src/__tests__/transaction-guest.hook.test.ts
+++ b/src/__tests__/transaction-guest.hook.test.ts
@@ -1,0 +1,68 @@
+import { renderHook } from '@testing-library/react';
+
+const mockCall = jest.fn();
+
+jest.mock('@dfx.swiss/react', () => ({
+  useApi: () => ({ call: mockCall }),
+}));
+
+import { useTransactionGuest } from '../hooks/transaction-guest.hook';
+
+describe('useTransactionGuest', () => {
+  const uid = 'T1E448FF200A877DC';
+
+  beforeEach(() => {
+    mockCall.mockReset();
+    mockCall.mockResolvedValue(undefined);
+  });
+
+  it('lists assign targets without a session token', async () => {
+    const targets = [{ id: 7, bankUsage: 'ABC' }];
+    mockCall.mockResolvedValue(targets);
+    const { result } = renderHook(() => useTransactionGuest());
+
+    await expect(result.current.getTargets(uid)).resolves.toBe(targets);
+    expect(mockCall).toHaveBeenCalledWith({
+      url: `transaction/uid/${uid}/targets`,
+      method: 'GET',
+      token: false,
+    });
+  });
+
+  it('assigns a buy route without a session token', async () => {
+    const { result } = renderHook(() => useTransactionGuest());
+
+    await result.current.setTarget(uid, 7);
+    expect(mockCall).toHaveBeenCalledWith({
+      url: `transaction/uid/${uid}/target?buyId=7`,
+      method: 'PUT',
+      token: false,
+    });
+  });
+
+  it('loads refund data without a session token', async () => {
+    const refund = { refundAmount: 10 };
+    mockCall.mockResolvedValue(refund);
+    const { result } = renderHook(() => useTransactionGuest());
+
+    await expect(result.current.getRefund(uid)).resolves.toBe(refund);
+    expect(mockCall).toHaveBeenCalledWith({
+      url: `transaction/uid/${uid}/refund`,
+      method: 'GET',
+      token: false,
+    });
+  });
+
+  it('submits a refund target without a session token', async () => {
+    const target = { refundTarget: 'CH93' };
+    const { result } = renderHook(() => useTransactionGuest());
+
+    await result.current.setRefund(uid, target);
+    expect(mockCall).toHaveBeenCalledWith({
+      url: `transaction/uid/${uid}/refund`,
+      method: 'PUT',
+      data: target,
+      token: false,
+    });
+  });
+});

--- a/src/__tests__/transaction-list-txinfo.test.tsx
+++ b/src/__tests__/transaction-list-txinfo.test.tsx
@@ -161,17 +161,7 @@ jest.mock('@dfx.swiss/react-components', () => {
     });
   });
 
-  function StyledDropdown({
-    control,
-    name,
-    label,
-    items,
-    labelFunc,
-    descriptionFunc,
-    placeholder,
-    rules,
-    error,
-  }: any) {
+  function StyledDropdown({ control, name, label, items, labelFunc, descriptionFunc, placeholder, rules, error }: any) {
     const [open, setOpen] = useState(false);
     return React.createElement(Controller, {
       control,
@@ -308,11 +298,7 @@ jest.mock('@dfx.swiss/react-components', () => {
 
   function StyledButton({ label, onClick, disabled, isLoading, type, hidden }: any) {
     if (hidden) return null;
-    return React.createElement(
-      'button',
-      { type: type ?? 'button', onClick, disabled: disabled || isLoading },
-      label,
-    );
+    return React.createElement('button', { type: type ?? 'button', onClick, disabled: disabled || isLoading }, label);
   }
 
   return {
@@ -362,16 +348,11 @@ jest.mock('@dfx.swiss/react-components', () => {
       ),
     StyledIconButton: ({ onClick }: any) =>
       React.createElement('button', { type: 'button', 'data-testid': 'reload-button', onClick }, 'Reload'),
-    DfxAssetIcon: ({ asset }: any) =>
-      React.createElement('div', { 'data-testid': 'dfx-asset-icon' }, asset),
+    DfxAssetIcon: ({ asset }: any) => React.createElement('div', { 'data-testid': 'dfx-asset-icon' }, asset),
     DfxIcon: () => React.createElement('div', { 'data-testid': 'dfx-help-icon' }),
     // Must be clickable so TxInfo chargeback CopyButton onCopy (line 1216) is reachable.
     CopyButton: ({ onCopy }: any) =>
-      React.createElement(
-        'button',
-        { type: 'button', 'data-testid': 'copy-button', onClick: onCopy },
-        'Copy',
-      ),
+      React.createElement('button', { type: 'button', 'data-testid': 'copy-button', onClick: onCopy }, 'Copy'),
     StyledLink: ({ label, children, url }: any) =>
       React.createElement('a', { 'data-testid': 'styled-link', href: url }, label ?? children),
     StyledLoadingSpinner: () => React.createElement('div', { 'data-testid': 'loading-spinner' }),
@@ -441,6 +422,15 @@ jest.mock('../hooks/layout-config.hook', () => ({
   },
 }));
 
+jest.mock('../hooks/transaction-guest.hook', () => ({
+  useTransactionGuest: () => ({
+    getTargets: jest.fn(),
+    setTarget: jest.fn(),
+    getRefund: jest.fn(),
+    setRefund: jest.fn(),
+  }),
+}));
+
 jest.mock('../hooks/navigation.hook', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
@@ -460,7 +450,12 @@ jest.mock('../util/validation-rules', () => ({
   ZipValidation: undefined,
 }));
 
-jest.mock('copy-to-clipboard', () => (...args: any[]) => mockCopy(...args));
+jest.mock(
+  'copy-to-clipboard',
+  () =>
+    (...args: any[]) =>
+      mockCopy(...args),
+);
 
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -634,7 +629,7 @@ describe('TransactionStatus Create support ticket', () => {
     const support = await screen.findByRole('button', { name: 'Create support ticket' });
     await userEvent.click(support);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/support/issue?issue-type=TransactionIssue');
+    expect(mockNavigate).toHaveBeenCalledWith('/support/issue?issue-type=TransactionIssue&tx=T123');
   });
 });
 
@@ -709,9 +704,7 @@ describe('TransactionList loadTransactions errors', () => {
 describe('TransactionList submitAssignment errors', () => {
   it('calls setError when setTransactionTarget rejects', async () => {
     mockGetDetailTransactions.mockResolvedValue([]);
-    mockGetUnassignedTransactions.mockResolvedValue([
-      makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' }),
-    ]);
+    mockGetUnassignedTransactions.mockResolvedValue([makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' })]);
     mockGetTransactionTargets.mockResolvedValue([TARGET_A]);
     mockSetTransactionTarget.mockRejectedValue({ message: 'assign failed' });
 
@@ -731,9 +724,7 @@ describe('TransactionList submitAssignment errors', () => {
 
   it('calls setError with "Unknown error" when setTransactionTarget rejects without message', async () => {
     mockGetDetailTransactions.mockResolvedValue([]);
-    mockGetUnassignedTransactions.mockResolvedValue([
-      makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' }),
-    ]);
+    mockGetUnassignedTransactions.mockResolvedValue([makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' })]);
     mockGetTransactionTargets.mockResolvedValue([TARGET_A]);
     mockSetTransactionTarget.mockRejectedValue({});
 
@@ -754,10 +745,7 @@ describe('TransactionList submitAssignment errors', () => {
 
 // Lines 672-687: scroll-into-view, logged-out skip, auto-assign path, date sort.
 describe('TransactionList load effects and sorting', () => {
-  const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
-    Element.prototype,
-    'scrollIntoView',
-  );
+  const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView');
 
   afterEach(() => {
     if (originalScrollIntoViewDescriptor) {
@@ -771,9 +759,7 @@ describe('TransactionList load effects and sorting', () => {
     const scrollIntoView = jest.fn();
     Element.prototype.scrollIntoView = scrollIntoView;
 
-    mockGetDetailTransactions.mockResolvedValue([
-      makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Completed' }),
-    ]);
+    mockGetDetailTransactions.mockResolvedValue([makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Completed' })]);
     mockGetUnassignedTransactions.mockResolvedValue([]);
 
     renderListAt('/tx/1');
@@ -801,9 +787,7 @@ describe('TransactionList load effects and sorting', () => {
 
   it('auto-opens the assignment form when the path is /tx/:id/assign', async () => {
     mockGetDetailTransactions.mockResolvedValue([]);
-    mockGetUnassignedTransactions.mockResolvedValue([
-      makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' }),
-    ]);
+    mockGetUnassignedTransactions.mockResolvedValue([makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' })]);
     mockGetTransactionTargets.mockResolvedValue([TARGET_A, TARGET_B]);
 
     // Numeric id → TransactionScreen list branch (not T/Q status); assign path auto-opens form.
@@ -855,9 +839,7 @@ describe('TransactionList load effects and sorting', () => {
 describe('TransactionList assignTransaction errors', () => {
   it('calls setError with the API message when getTransactionTargets rejects', async () => {
     mockGetDetailTransactions.mockResolvedValue([]);
-    mockGetUnassignedTransactions.mockResolvedValue([
-      makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' }),
-    ]);
+    mockGetUnassignedTransactions.mockResolvedValue([makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' })]);
     mockGetTransactionTargets.mockRejectedValue({ message: 'targets failed' });
 
     const { setError } = renderList();
@@ -872,9 +854,7 @@ describe('TransactionList assignTransaction errors', () => {
 
   it('calls setError with "Unknown error" when getTransactionTargets rejects without message', async () => {
     mockGetDetailTransactions.mockResolvedValue([]);
-    mockGetUnassignedTransactions.mockResolvedValue([
-      makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' }),
-    ]);
+    mockGetUnassignedTransactions.mockResolvedValue([makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' })]);
     mockGetTransactionTargets.mockRejectedValue({});
 
     const { setError } = renderList();
@@ -942,9 +922,7 @@ describe('TransactionList row presentation', () => {
   });
 
   it('renders a row when tx.id is missing (ref callback skips numeric id key)', async () => {
-    mockGetDetailTransactions.mockResolvedValue([
-      makeListTx({ id: undefined, uid: 'uid-only', state: 'Completed' }),
-    ]);
+    mockGetDetailTransactions.mockResolvedValue([makeListTx({ id: undefined, uid: 'uid-only', state: 'Completed' })]);
     mockGetUnassignedTransactions.mockResolvedValue([]);
 
     renderList();
@@ -957,9 +935,7 @@ describe('TransactionList row presentation', () => {
   });
 
   it('sets isExpanded when route id matches a transaction uid and leaves it undefined without id', async () => {
-    mockGetDetailTransactions.mockResolvedValue([
-      makeListTx({ id: 5, uid: 'match-uid', state: 'Completed' }),
-    ]);
+    mockGetDetailTransactions.mockResolvedValue([makeListTx({ id: 5, uid: 'match-uid', state: 'Completed' })]);
     mockGetUnassignedTransactions.mockResolvedValue([]);
 
     renderListAt('/tx/match-uid');
@@ -970,9 +946,7 @@ describe('TransactionList row presentation', () => {
   });
 
   it('leaves collapsible isExpanded undefined when no route id is present', async () => {
-    mockGetDetailTransactions.mockResolvedValue([
-      makeListTx({ id: 5, uid: 'match-uid', state: 'Completed' }),
-    ]);
+    mockGetDetailTransactions.mockResolvedValue([makeListTx({ id: 5, uid: 'match-uid', state: 'Completed' })]);
     mockGetUnassignedTransactions.mockResolvedValue([]);
 
     renderList();
@@ -1083,9 +1057,7 @@ describe('TransactionList missing-transaction navigation', () => {
     const missing = await screen.findByRole('button', { name: 'My transaction is missing' });
     await userEvent.click(missing);
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      '/support/issue?issue-type=TransactionIssue&reason=TransactionMissing',
-    );
+    expect(mockNavigate).toHaveBeenCalledWith('/support/issue?issue-type=TransactionIssue&reason=TransactionMissing');
   });
 });
 
@@ -1093,9 +1065,7 @@ describe('TransactionList missing-transaction navigation', () => {
 describe('TransactionList target dropdown descriptionFunc', () => {
   it('renders descriptionFunc text when a target option is selected', async () => {
     mockGetDetailTransactions.mockResolvedValue([]);
-    mockGetUnassignedTransactions.mockResolvedValue([
-      makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' }),
-    ]);
+    mockGetUnassignedTransactions.mockResolvedValue([makeListTx({ id: 1, uid: 'tx-uid-1', state: 'Unassigned' })]);
     mockGetTransactionTargets.mockResolvedValue([TARGET_A, TARGET_B]);
 
     renderList();
@@ -1225,9 +1195,7 @@ describe('TransactionList action buttons by state and support mode', () => {
 
   it('shows Select in support mode and calls onSelectTransaction with uid and state', async () => {
     const onSelectTransaction = jest.fn();
-    mockGetDetailTransactions.mockResolvedValue([
-      makeListTx({ uid: 'sup-1', state: 'Completed' }),
-    ]);
+    mockGetDetailTransactions.mockResolvedValue([makeListTx({ uid: 'sup-1', state: 'Completed' })]);
     mockGetUnassignedTransactions.mockResolvedValue([]);
 
     renderList({ isSupport: true, onSelectTransaction });
@@ -1265,9 +1233,7 @@ describe('TxInfo priceSteps base rate info', () => {
     );
 
     // baseRateInfo is infoText on the Base rate expansion item (built by the priceSteps map).
-    expect(screen.getByTestId('expansion-info-Base rate')).toHaveTextContent(
-      /EUR to BTC at 50000 EUR\/BTC \(Kraken,/,
-    );
+    expect(screen.getByTestId('expansion-info-Base rate')).toHaveTextContent(/EUR to BTC at 50000 EUR\/BTC \(Kraken,/);
   });
 });
 
@@ -1415,9 +1381,7 @@ describe('TxInfo phone verification hint', () => {
       />,
     );
 
-    expect(screen.getByTestId('row-Failure reason')).toHaveTextContent(
-      'we will call you at +41123456789',
-    );
+    expect(screen.getByTestId('row-Failure reason')).toHaveTextContent('we will call you at +41123456789');
   });
 
   it('hides the call-you text when showUserDetails is false', () => {

--- a/src/__tests__/transaction-list-txinfo.test.tsx
+++ b/src/__tests__/transaction-list-txinfo.test.tsx
@@ -426,7 +426,7 @@ jest.mock('../hooks/transaction-guest.hook', () => ({
   useTransactionGuest: () => ({
     getTargets: jest.fn(),
     setTarget: jest.fn(),
-    getRefund: jest.fn(),
+    getRefund: mockGetTransactionRefund,
     setRefund: jest.fn(),
   }),
 }));

--- a/src/__tests__/transaction-refund.test.tsx
+++ b/src/__tests__/transaction-refund.test.tsx
@@ -413,7 +413,7 @@ jest.mock('../util/utils', () => ({
 jest.mock('copy-to-clipboard', () => jest.fn());
 
 import { Utils } from '@dfx.swiss/react';
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import TransactionScreen from '../screens/transaction.screen';
 

--- a/src/__tests__/transaction-refund.test.tsx
+++ b/src/__tests__/transaction-refund.test.tsx
@@ -1332,4 +1332,39 @@ describe('TransactionRefund guest uid path', () => {
     expect(mockSetTransactionRefundTarget).not.toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith('/tx/T123');
   });
+
+  it('submits a guest crypto refund via refundAddress', async () => {
+    mockIsLoggedIn = false;
+    mockGetTransactionByUid.mockResolvedValue(
+      makeTx({
+        uid: 'T123',
+        type: 'Sell',
+        inputPaymentMethod: 'Crypto',
+        inputBlockchain: 'Ethereum',
+        state: 'Failed',
+      }),
+    );
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockSetGuestRefund.mockResolvedValue(undefined);
+
+    renderRefund();
+    await waitForRefundFormLoaded();
+
+    expect(screen.getByTestId('refundAddress')).toBeInTheDocument();
+    expect(screen.queryByTestId('address-dropdown')).not.toBeInTheDocument();
+
+    changeAndBlur('refundAddress', '0xabc');
+    await waitForSubmitEnabled('Confirm refund');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm refund' }));
+    });
+
+    await waitFor(() => {
+      expect(mockSetGuestRefund).toHaveBeenCalledWith(
+        'T123',
+        expect.objectContaining({ refundTarget: '0xabc' }),
+      );
+    });
+  });
 });

--- a/src/__tests__/transaction-refund.test.tsx
+++ b/src/__tests__/transaction-refund.test.tsx
@@ -510,6 +510,8 @@ async function fillBankCreditorFields(options?: { houseNumber?: string; name?: s
 async function fillBankRefundForm(options?: { ibanIndex?: number; houseNumber?: string; name?: string }) {
   if (screen.queryByTestId('iban-dropdown')) {
     selectDropdownOption('iban', options?.ibanIndex ?? 0);
+  } else if (screen.queryByTestId('iban')) {
+    changeAndBlur('iban', options?.ibanIndex === 1 ? BANK_IBAN_CH : BANK_IBAN_DE);
   }
   await fillBankCreditorFields(options);
 }
@@ -538,8 +540,10 @@ beforeEach(() => {
   mockGetGuestRefund.mockReset();
   mockSetGuestRefund.mockReset();
   mockSetTransactionRefundTarget.mockResolvedValue(undefined);
+  mockSetGuestRefund.mockResolvedValue(undefined);
   mockGetTransactionByUid.mockResolvedValue(makeTx());
-  mockGetTransactionRefund.mockResolvedValue(makeRefund());
+  mockGetGuestRefund.mockResolvedValue(makeRefund());
+  mockGetGuestRefund.mockResolvedValue(makeRefund());
 });
 
 afterEach(() => {
@@ -572,11 +576,11 @@ describe('TransactionRefund transaction load errors', () => {
 // Lines 356-365: fetchRefund success, expiryDate timers (future/past), clearTimeout, errors, unmount cleanup.
 describe('TransactionRefund fetchRefund', () => {
   it('loads refund details and shows the amount table on success without expiryDate', async () => {
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ expiryDate: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ expiryDate: undefined }));
     renderRefund();
 
     await waitForRefundFormLoaded();
-    expect(mockGetTransactionRefund).toHaveBeenCalledWith(42);
+    expect(mockGetGuestRefund).toHaveBeenCalledWith('T123');
     expect(screen.getByTestId('row-Transaction amount')).toHaveTextContent('100 EUR');
     expect(screen.getByTestId('row-Refund amount')).toHaveTextContent('98.4 EUR');
   });
@@ -584,7 +588,7 @@ describe('TransactionRefund fetchRefund', () => {
   it('schedules a refetch when expiryDate is in the future and refetches after the timeout', async () => {
     jest.useFakeTimers();
     const future = new Date(Date.now() + 5000).toISOString();
-    mockGetTransactionRefund
+    mockGetGuestRefund
       .mockResolvedValueOnce(makeRefund({ expiryDate: future, refundAmount: 98.4 }))
       .mockResolvedValueOnce(makeRefund({ expiryDate: undefined, refundAmount: 97 }));
 
@@ -598,7 +602,7 @@ describe('TransactionRefund fetchRefund', () => {
       { advanceTimers: jest.advanceTimersByTime },
     );
 
-    expect(mockGetTransactionRefund).toHaveBeenCalledTimes(1);
+    expect(mockGetGuestRefund).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       jest.advanceTimersByTime(5000);
@@ -606,7 +610,7 @@ describe('TransactionRefund fetchRefund', () => {
 
     await waitFor(
       () => {
-        expect(mockGetTransactionRefund).toHaveBeenCalledTimes(2);
+        expect(mockGetGuestRefund).toHaveBeenCalledTimes(2);
       },
       { advanceTimers: jest.advanceTimersByTime },
     );
@@ -623,13 +627,13 @@ describe('TransactionRefund fetchRefund', () => {
   it('refetches immediately when expiryDate is already in the past', async () => {
     const past = new Date(Date.now() - 10_000).toISOString();
     const future = new Date(Date.now() + 60_000).toISOString();
-    mockGetTransactionRefund
+    mockGetGuestRefund
       .mockResolvedValueOnce(makeRefund({ expiryDate: past, refundAmount: 90 }))
       .mockResolvedValue(makeRefund({ expiryDate: future, refundAmount: 90 }));
 
     renderRefund();
 
-    await waitFor(() => expect(mockGetTransactionRefund).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockGetGuestRefund).toHaveBeenCalledTimes(2));
   });
 
   it('clears a previous refetch timeout when a subsequent refund response also has expiryDate', async () => {
@@ -638,7 +642,7 @@ describe('TransactionRefund fetchRefund', () => {
     const future1 = new Date(Date.now() + 8000).toISOString();
     const future2 = new Date(Date.now() + 12_000).toISOString();
 
-    mockGetTransactionRefund
+    mockGetGuestRefund
       .mockResolvedValueOnce(makeRefund({ expiryDate: future1 }))
       .mockResolvedValueOnce(makeRefund({ expiryDate: future2 }))
       .mockResolvedValueOnce(makeRefund({ expiryDate: undefined }));
@@ -648,7 +652,7 @@ describe('TransactionRefund fetchRefund', () => {
     await waitFor(
       () => {
         expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
-        expect(mockGetTransactionRefund).toHaveBeenCalledTimes(1);
+        expect(mockGetGuestRefund).toHaveBeenCalledTimes(1);
       },
       { advanceTimers: jest.advanceTimersByTime },
     );
@@ -659,7 +663,7 @@ describe('TransactionRefund fetchRefund', () => {
 
     await waitFor(
       () => {
-        expect(mockGetTransactionRefund).toHaveBeenCalledTimes(2);
+        expect(mockGetGuestRefund).toHaveBeenCalledTimes(2);
       },
       { advanceTimers: jest.advanceTimersByTime },
     );
@@ -669,7 +673,7 @@ describe('TransactionRefund fetchRefund', () => {
   });
 
   it('surfaces getTransactionRefund errors via setError', async () => {
-    mockGetTransactionRefund.mockRejectedValue({ message: 'refund unavailable' });
+    mockGetGuestRefund.mockRejectedValue({ message: 'refund unavailable' });
     renderRefund();
 
     await waitFor(() => {
@@ -678,7 +682,7 @@ describe('TransactionRefund fetchRefund', () => {
   });
 
   it('surfaces "Unknown error" when getTransactionRefund rejects without message', async () => {
-    mockGetTransactionRefund.mockRejectedValue({});
+    mockGetGuestRefund.mockRejectedValue({});
     renderRefund();
 
     await waitFor(() => {
@@ -690,7 +694,7 @@ describe('TransactionRefund fetchRefund', () => {
     jest.useFakeTimers();
     const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
     const future = new Date(Date.now() + 30_000).toISOString();
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ expiryDate: future }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ expiryDate: future }));
 
     const { unmount } = renderRefund();
 
@@ -702,7 +706,7 @@ describe('TransactionRefund fetchRefund', () => {
       { advanceTimers: jest.advanceTimersByTime },
     );
 
-    const callsBeforeUnmount = mockGetTransactionRefund.mock.calls.length;
+    const callsBeforeUnmount = mockGetGuestRefund.mock.calls.length;
     unmount();
     expect(clearTimeoutSpy).toHaveBeenCalled();
 
@@ -710,13 +714,13 @@ describe('TransactionRefund fetchRefund', () => {
       jest.advanceTimersByTime(30_000);
     });
 
-    expect(mockGetTransactionRefund).toHaveBeenCalledTimes(callsBeforeUnmount);
+    expect(mockGetGuestRefund).toHaveBeenCalledTimes(callsBeforeUnmount);
   });
 });
 
-// Lines 377-383: filter userAddresses by inputBlockchain; auto-setValue when exactly one match.
+// T/Q refund is always the guest form: no logged-in address dropdown, even when addresses exist.
 describe('TransactionRefund address filtering', () => {
-  it('lists multiple matching addresses for a crypto refund and does not auto-select', async () => {
+  it('does not list logged-in addresses on a T-uid crypto refund', async () => {
     mockUserAddresses = [
       { address: '0xaaa111', blockchains: ['Ethereum'] },
       { address: '0xbbb222', blockchains: ['Ethereum', 'Bitcoin'] },
@@ -725,35 +729,13 @@ describe('TransactionRefund address filtering', () => {
     mockGetTransactionByUid.mockResolvedValue(
       makeTx({ type: 'Sell', inputPaymentMethod: 'Crypto', inputBlockchain: 'Ethereum' }),
     );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    fireEvent.click(screen.getByTestId('address-trigger'));
-    const options = within(screen.getByTestId('address-options')).getAllByRole('button');
-    expect(options).toHaveLength(2);
-    expect(options[0]).toHaveTextContent(/0xaaa/);
-    expect(options[1]).toHaveTextContent(/0xbbb/);
-    expect(screen.getByTestId('address-option-desc-0')).toHaveTextContent(/Ethereum/);
-  });
-
-  it('auto-selects the only matching address via setValue when exactly one is allowed', async () => {
-    mockUserAddresses = [
-      { address: '0xonlymatch', blockchains: ['Bitcoin'] },
-      { address: '0xother', blockchains: ['Ethereum'] },
-    ];
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Sell', inputPaymentMethod: 'Crypto', inputBlockchain: 'Bitcoin' }),
-    );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
-
-    renderRefund();
-    await waitForRefundFormLoaded();
-
-    await waitFor(() => {
-      expect(screen.getByTestId('address-trigger')).toHaveTextContent(/0xonlymatch/);
-    });
+    expect(screen.getByTestId('refundAddress')).toBeInTheDocument();
+    expect(screen.queryByTestId('address-dropdown')).not.toBeInTheDocument();
   });
 });
 
@@ -761,7 +743,7 @@ describe('TransactionRefund address filtering', () => {
 describe('TransactionRefund onSubmit', () => {
   it('submits a bank buy refund with form target, creditor data, house number, and navigates to /tx', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
     mockSetTransactionRefundTarget.mockResolvedValue(undefined);
 
     renderRefund();
@@ -774,7 +756,7 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalledWith(42, {
+      expect(mockSetGuestRefund).toHaveBeenCalledWith('T123', {
         refundTarget: BANK_IBAN_DE,
         creditorData: {
           name: 'Jane Doe',
@@ -785,13 +767,13 @@ describe('TransactionRefund onSubmit', () => {
           country: 'CH',
         },
       });
-      expect(mockNavigate).toHaveBeenCalledWith('/tx');
+      expect(mockNavigate).toHaveBeenCalledWith('/tx/T123');
     });
   });
 
   it('omits houseNumber when the house number field is left empty', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -803,15 +785,15 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalled();
+      expect(mockSetGuestRefund).toHaveBeenCalled();
     });
-    const payload = mockSetTransactionRefundTarget.mock.calls[0][1];
+    const payload = mockSetGuestRefund.mock.calls[0][1];
     expect(payload.creditorData.houseNumber).toBeUndefined();
   });
 
   it('uses bankDetails.name as refundName when refundTarget is fixed and bank name is present', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         refundTarget: BANK_IBAN_DE,
         bankDetails: {
@@ -846,7 +828,7 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalledWith(42, {
+      expect(mockSetGuestRefund).toHaveBeenCalledWith('T123', {
         refundTarget: undefined,
         creditorData: {
           name: 'Fixed Bank Name',
@@ -862,7 +844,7 @@ describe('TransactionRefund onSubmit', () => {
 
   it('falls back to creditorName when refundTarget is fixed but bankDetails.name is missing', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         refundTarget: BANK_IBAN_CH,
         bankDetails: { iban: BANK_IBAN_CH, bic: 'POFICHBE' },
@@ -881,16 +863,16 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalled();
+      expect(mockSetGuestRefund).toHaveBeenCalled();
     });
-    const payload = mockSetTransactionRefundTarget.mock.calls[0][1];
+    const payload = mockSetGuestRefund.mock.calls[0][1];
     expect(payload.refundTarget).toBeUndefined();
     expect(payload.creditorData.name).toBe('Fallback Name');
   });
 
   it('submits a card buy refund without refundTarget or creditorData', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Card', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -906,19 +888,15 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalledWith(42, {
+      expect(mockSetGuestRefund).toHaveBeenCalledWith('T123', {
         refundTarget: undefined,
         creditorData: undefined,
       });
-      expect(mockNavigate).toHaveBeenCalledWith('/tx');
+      expect(mockNavigate).toHaveBeenCalledWith('/tx/T123');
     });
   });
 
-  it('submits a crypto (non-buy) refund with the selected address as refundTarget', async () => {
-    mockUserAddresses = [
-      { address: '0xcrypto1', blockchains: ['Ethereum'] },
-      { address: '0xcrypto2', blockchains: ['Ethereum'] },
-    ];
+  it('submits a crypto (non-buy) refund with the typed address as refundTarget', async () => {
     mockGetTransactionByUid.mockResolvedValue(
       makeTx({
         type: 'Sell',
@@ -927,13 +905,13 @@ describe('TransactionRefund onSubmit', () => {
         state: 'Unassigned',
       }),
     );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
     expect(screen.getByRole('button', { name: 'Request refund' })).toBeInTheDocument();
-    selectDropdownOption('address', 1);
+    changeAndBlur('refundAddress', '0xcrypto2');
     await waitForSubmitEnabled('Request refund');
 
     await act(async () => {
@@ -941,18 +919,18 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalledWith(42, {
+      expect(mockSetGuestRefund).toHaveBeenCalledWith('T123', {
         refundTarget: '0xcrypto2',
         creditorData: undefined,
       });
-      expect(mockNavigate).toHaveBeenCalledWith('/tx');
+      expect(mockNavigate).toHaveBeenCalledWith('/tx/T123');
     });
   });
 
   it('keeps the form and sets localError when setTransactionRefundTarget fails with MultiAccountIban', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
-    mockSetTransactionRefundTarget.mockRejectedValue({
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockSetGuestRefund.mockRejectedValue({
       message: 'MultiAccountIban is not allowed here',
     });
 
@@ -978,8 +956,8 @@ describe('TransactionRefund onSubmit', () => {
 
   it('propagates non-MultiAccountIban submit errors via setError', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
-    mockSetTransactionRefundTarget.mockRejectedValue({ message: 'backend rejected refund' });
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockSetGuestRefund.mockRejectedValue({ message: 'backend rejected refund' });
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -998,8 +976,8 @@ describe('TransactionRefund onSubmit', () => {
 
   it('propagates "Unknown error" when submit rejects without a message', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
-    mockSetTransactionRefundTarget.mockRejectedValue({});
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockSetGuestRefund.mockRejectedValue({});
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1016,34 +994,17 @@ describe('TransactionRefund onSubmit', () => {
   });
 });
 
-// Lines 450-457: selectedIban === "Add bank account" renders AddBankAccount and writes IBAN back.
 describe('TransactionRefund add bank account branch', () => {
-  it('shows AddBankAccount when Add bank account is selected and writes the new IBAN into the form', async () => {
+  it('does not offer the logged-in add-bank-account dropdown on a T-uid refund', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    // bankAccounts (2) + "Add bank account" → option index 2
-    fireEvent.click(screen.getByTestId('iban-trigger'));
-    fireEvent.click(screen.getByTestId('iban-option-2'));
-
-    await waitFor(() => {
-      expect(screen.getByTestId('add-bank-account')).toBeInTheDocument();
-    });
-    expect(screen.getByTestId('add-bank-confirmation')).toHaveTextContent(
-      'The bank account has been added, all transactions from this IBAN will now be associated with your account.',
-    );
-    expect(screen.queryByText('Transaction amount')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId('add-bank-submit'));
-
-    await waitFor(() => {
-      expect(screen.queryByTestId('add-bank-account')).not.toBeInTheDocument();
-      expect(screen.getByText('Transaction amount')).toBeInTheDocument();
-    });
-    expect(screen.getByTestId('iban-trigger')).toHaveTextContent('LI21088110104928');
+    expect(screen.getByTestId('iban')).toBeInTheDocument();
+    expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('add-bank-account')).not.toBeInTheDocument();
   });
 });
 
@@ -1059,7 +1020,7 @@ describe('TransactionRefund rendered view', () => {
 
   it('shows the loading spinner after transaction loads while refund is still pending', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx());
-    mockGetTransactionRefund.mockReturnValue(neverResolves());
+    mockGetGuestRefund.mockReturnValue(neverResolves());
     renderRefund();
 
     await waitFor(() => {
@@ -1082,7 +1043,7 @@ describe('TransactionRefund rendered view', () => {
   });
 
   it('renders bankDetails name/address/city/country/iban/bic rows when those fields are set', async () => {
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         refundTarget: BANK_IBAN_DE,
         bankDetails: {
@@ -1110,7 +1071,7 @@ describe('TransactionRefund rendered view', () => {
   });
 
   it('hides bankDetails name/address/city/country/iban/bic rows when bankDetails is absent', async () => {
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ bankDetails: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ bankDetails: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1124,7 +1085,7 @@ describe('TransactionRefund rendered view', () => {
   });
 
   it('renders address row from houseNumber alone and city row from zip alone', async () => {
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         bankDetails: {
           houseNumber: '99',
@@ -1141,17 +1102,18 @@ describe('TransactionRefund rendered view', () => {
     expect(screen.queryByTestId('row-Name')).not.toBeInTheDocument();
   });
 
-  it('shows the address dropdown for crypto refunds without refundTarget and hides bank fields', async () => {
+  it('shows the free-text chargeback address for crypto refunds without refundTarget and hides bank fields', async () => {
     mockUserAddresses = [{ address: '0xsolo', blockchains: ['Ethereum'] }];
     mockGetTransactionByUid.mockResolvedValue(
       makeTx({ type: 'Sell', inputPaymentMethod: 'Crypto', inputBlockchain: 'Ethereum' }),
     );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    expect(screen.getByTestId('address-dropdown')).toBeInTheDocument();
+    expect(screen.getByTestId('refundAddress')).toBeInTheDocument();
+    expect(screen.queryByTestId('address-dropdown')).not.toBeInTheDocument();
     expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
     expect(screen.queryByTestId('creditorStreet')).not.toBeInTheDocument();
   });
@@ -1161,7 +1123,7 @@ describe('TransactionRefund rendered view', () => {
     mockGetTransactionByUid.mockResolvedValue(
       makeTx({ type: 'Sell', inputPaymentMethod: 'Crypto', inputBlockchain: 'Ethereum' }),
     );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: '0xfixed' }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: '0xfixed' }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1171,32 +1133,29 @@ describe('TransactionRefund rendered view', () => {
 
   // Earlier the dropdown was gated on inputBlockchain; without it the mocked Form never registered
   // the required-address rule, so the refund form could become valid without choosing an address.
-  it('renders address dropdown and keeps submit disabled when inputBlockchain is undefined', async () => {
+  it('renders free-text chargeback address and keeps submit disabled when inputBlockchain is undefined', async () => {
     mockUserAddresses = [{ address: '0xwouldmatch', blockchains: ['Ethereum'] }];
     mockGetTransactionByUid.mockResolvedValue(
       makeTx({ type: 'Sell', inputPaymentMethod: 'Crypto', inputBlockchain: undefined }),
     );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    // Dropdown still mounts so the required rule is wired; filter yields no options without a chain.
-    expect(screen.getByTestId('address-dropdown')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('address-trigger'));
-    expect(within(screen.getByTestId('address-options')).queryAllByRole('button')).toHaveLength(0);
-
-    expect(screen.getByRole('button', { name: 'Confirm refund' })).toBeDisabled();
+    expect(screen.getByTestId('refundAddress')).toBeInTheDocument();
+    expect(screen.queryByTestId('address-dropdown')).not.toBeInTheDocument();
   });
 
-  it('shows IBAN dropdown and name field for bank buy without fixed refundTarget', async () => {
+  it('shows free-text IBAN and name field for bank buy without fixed refundTarget', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    expect(screen.getByTestId('iban-dropdown')).toBeInTheDocument();
+    expect(screen.getByTestId('iban')).toBeInTheDocument();
+    expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
     expect(screen.getByTestId('creditorName')).toBeInTheDocument();
     expect(screen.getByTestId('creditorStreet')).toBeInTheDocument();
     expect(screen.getByTestId('creditorCountry-search-dropdown')).toBeInTheDocument();
@@ -1219,7 +1178,7 @@ describe('TransactionRefund rendered view', () => {
   it('hides the IBAN dropdown when bankAccounts is empty/falsy for bank buy', async () => {
     mockBankAccounts = null as any;
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1232,7 +1191,7 @@ describe('TransactionRefund rendered view', () => {
 
   it('shows creditor name when bankDetails.name is set but refundTarget is missing (IBAN override)', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         refundTarget: undefined,
         bankDetails: { name: 'Only Name' },
@@ -1244,12 +1203,13 @@ describe('TransactionRefund rendered view', () => {
 
     expect(screen.getByTestId('row-Name')).toHaveTextContent('Only Name');
     expect(screen.getByTestId('creditorName')).toBeInTheDocument();
-    expect(screen.getByTestId('iban-dropdown')).toBeInTheDocument();
+    expect(screen.getByTestId('iban')).toBeInTheDocument();
+    expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
   });
 
   it('falls back to raw bankDetails.iban when Utils.formatIban returns a falsy value', async () => {
     jest.spyOn(Utils, 'formatIban').mockReturnValue(undefined as any);
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         refundTarget: BANK_IBAN_DE,
         bankDetails: {
@@ -1266,30 +1226,21 @@ describe('TransactionRefund rendered view', () => {
     expect(screen.getByTestId('row-IBAN')).toHaveTextContent(BANK_IBAN_DE);
   });
 
-  it('uses empty string for IBAN dropdown labels when Utils.formatIban returns falsy', async () => {
-    jest.spyOn(Utils, 'formatIban').mockImplementation((v: any) => {
-      if (v === BANK_IBAN_DE) return undefined as any;
-      return v;
-    });
+  it('uses a free-text IBAN field on a T-uid bank refund instead of the logged-in dropdown', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    fireEvent.click(screen.getByTestId('iban-trigger'));
-    const options = within(screen.getByTestId('iban-options')).getAllByRole('button');
-    // DE is first bank account; formatIban falls back to '' for that option only, so the option
-    // carries no IBAN text at all (an empty-string matcher would pass against anything).
-    expect(options[0]).not.toHaveTextContent(BANK_IBAN_DE);
-    expect(options[1]).toHaveTextContent(BANK_IBAN_CH);
-    expect(options[2]).toHaveTextContent('Add bank account');
+    expect(screen.getByTestId('iban')).toBeInTheDocument();
+    expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
   });
 
   it('disables the country search dropdown for fewer than two countries', async () => {
     mockAllowedCountries = undefined as any;
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1313,7 +1264,7 @@ describe('TransactionRefund guest uid path', () => {
     mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: 'CH9300762011623852957' }));
     mockSetGuestRefund.mockResolvedValue(undefined);
 
-    renderRefund();
+    renderRefund('/tx/T123/refund');
     await waitForRefundFormLoaded();
 
     expect(mockGetGuestRefund).toHaveBeenCalledWith('T123');
@@ -1347,7 +1298,7 @@ describe('TransactionRefund guest uid path', () => {
     mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
     mockSetGuestRefund.mockResolvedValue(undefined);
 
-    renderRefund();
+    renderRefund('/tx/T123/refund');
     await waitForRefundFormLoaded();
 
     expect(screen.getByTestId('refundAddress')).toBeInTheDocument();
@@ -1366,5 +1317,33 @@ describe('TransactionRefund guest uid path', () => {
         expect.objectContaining({ refundTarget: '0xabc' }),
       );
     });
+  });
+
+  it('uses the guest hook on a T-uid route even when logged in', async () => {
+    mockIsLoggedIn = true;
+    mockGetTransactionByUid.mockResolvedValue(
+      makeTx({ uid: 'T123', type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }),
+    );
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: 'CH9300762011623852957' }));
+    mockSetGuestRefund.mockResolvedValue(undefined);
+
+    renderRefund('/tx/T123/refund');
+    await waitForRefundFormLoaded();
+
+    expect(mockGetGuestRefund).toHaveBeenCalledWith('T123');
+    expect(mockGetTransactionRefund).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
+
+    await fillBankCreditorFields();
+    await waitForSubmitEnabled('Confirm refund');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm refund' }));
+    });
+
+    await waitFor(() => {
+      expect(mockSetGuestRefund).toHaveBeenCalled();
+    });
+    expect(mockSetTransactionRefundTarget).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/transaction-refund.test.tsx
+++ b/src/__tests__/transaction-refund.test.tsx
@@ -164,17 +164,7 @@ jest.mock('@dfx.swiss/react-components', () => {
     });
   });
 
-  function StyledDropdown({
-    control,
-    name,
-    label,
-    items,
-    labelFunc,
-    descriptionFunc,
-    placeholder,
-    rules,
-    error,
-  }: any) {
+  function StyledDropdown({ control, name, label, items, labelFunc, descriptionFunc, placeholder, rules, error }: any) {
     const [open, setOpen] = useState(false);
     return React.createElement(Controller, {
       control,
@@ -297,11 +287,7 @@ jest.mock('@dfx.swiss/react-components', () => {
 
   function StyledButton({ label, onClick, disabled, isLoading, type, hidden }: any) {
     if (hidden) return null;
-    return React.createElement(
-      'button',
-      { type: type ?? 'button', onClick, disabled: disabled || isLoading },
-      label,
-    );
+    return React.createElement('button', { type: type ?? 'button', onClick, disabled: disabled || isLoading }, label);
   }
 
   return {
@@ -322,8 +308,7 @@ jest.mock('@dfx.swiss/react-components', () => {
         infoText ? React.createElement('span', { 'data-testid': `info-${label}` }, infoText) : null,
       ),
     StyledDataTableExpandableRow: ({ children }: any) => React.createElement('div', null, children),
-    StyledCollapsible: ({ titleContent, children }: any) =>
-      React.createElement('div', null, titleContent, children),
+    StyledCollapsible: ({ titleContent, children }: any) => React.createElement('div', null, titleContent, children),
     StyledIconButton: () => null,
     DfxAssetIcon: () => null,
     DfxIcon: () => null,
@@ -389,6 +374,18 @@ jest.mock('../hooks/layout-config.hook', () => ({
   },
 }));
 
+const mockGetGuestRefund = jest.fn();
+const mockSetGuestRefund = jest.fn();
+
+jest.mock('../hooks/transaction-guest.hook', () => ({
+  useTransactionGuest: () => ({
+    getTargets: jest.fn(),
+    setTarget: jest.fn(),
+    getRefund: mockGetGuestRefund,
+    setRefund: mockSetGuestRefund,
+  }),
+}));
+
 jest.mock('../hooks/navigation.hook', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
@@ -399,11 +396,7 @@ jest.mock('src/components/payment/add-bank-account', () => ({
   AddBankAccount: ({ onSubmit, confirmationText }: any) => (
     <div data-testid="add-bank-account">
       <p data-testid="add-bank-confirmation">{confirmationText}</p>
-      <button
-        type="button"
-        data-testid="add-bank-submit"
-        onClick={() => onSubmit({ iban: 'LI21088110104928' })}
-      >
+      <button type="button" data-testid="add-bank-submit" onClick={() => onSubmit({ iban: 'LI21088110104928' })}>
         Confirm new bank account
       </button>
     </div>
@@ -542,6 +535,8 @@ beforeEach(() => {
   mockGetTransactionByUid.mockReset();
   mockGetTransactionRefund.mockReset();
   mockSetTransactionRefundTarget.mockReset();
+  mockGetGuestRefund.mockReset();
+  mockSetGuestRefund.mockReset();
   mockSetTransactionRefundTarget.mockResolvedValue(undefined);
   mockGetTransactionByUid.mockResolvedValue(makeTx());
   mockGetTransactionRefund.mockResolvedValue(makeRefund());
@@ -765,9 +760,7 @@ describe('TransactionRefund address filtering', () => {
 // Lines 385-428: onSubmit combinations (bank buy, card buy, crypto, refundName, houseNumber, errors).
 describe('TransactionRefund onSubmit', () => {
   it('submits a bank buy refund with form target, creditor data, house number, and navigates to /tx', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
     mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
     mockSetTransactionRefundTarget.mockResolvedValue(undefined);
 
@@ -797,9 +790,7 @@ describe('TransactionRefund onSubmit', () => {
   });
 
   it('omits houseNumber when the house number field is left empty', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
     mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
@@ -819,9 +810,7 @@ describe('TransactionRefund onSubmit', () => {
   });
 
   it('uses bankDetails.name as refundName when refundTarget is fixed and bank name is present', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
     mockGetTransactionRefund.mockResolvedValue(
       makeRefund({
         refundTarget: BANK_IBAN_DE,
@@ -872,9 +861,7 @@ describe('TransactionRefund onSubmit', () => {
   });
 
   it('falls back to creditorName when refundTarget is fixed but bankDetails.name is missing', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
     mockGetTransactionRefund.mockResolvedValue(
       makeRefund({
         refundTarget: BANK_IBAN_CH,
@@ -902,9 +889,7 @@ describe('TransactionRefund onSubmit', () => {
   });
 
   it('submits a card buy refund without refundTarget or creditorData', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Card', state: 'Failed' }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Card', state: 'Failed' }));
     mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
@@ -965,9 +950,7 @@ describe('TransactionRefund onSubmit', () => {
   });
 
   it('keeps the form and sets localError when setTransactionRefundTarget fails with MultiAccountIban', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
     mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
     mockSetTransactionRefundTarget.mockRejectedValue({
       message: 'MultiAccountIban is not allowed here',
@@ -984,9 +967,7 @@ describe('TransactionRefund onSubmit', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(
-          'This IBAN cannot be used for refunds. Please select a personal bank account.',
-        ),
+        screen.getByText('This IBAN cannot be used for refunds. Please select a personal bank account.'),
       ).toBeInTheDocument();
     });
     // Form remains (not replaced by ErrorHint).
@@ -996,9 +977,7 @@ describe('TransactionRefund onSubmit', () => {
   });
 
   it('propagates non-MultiAccountIban submit errors via setError', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
     mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
     mockSetTransactionRefundTarget.mockRejectedValue({ message: 'backend rejected refund' });
 
@@ -1018,9 +997,7 @@ describe('TransactionRefund onSubmit', () => {
   });
 
   it('propagates "Unknown error" when submit rejects without a message', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
     mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
     mockSetTransactionRefundTarget.mockRejectedValue({});
 
@@ -1042,9 +1019,7 @@ describe('TransactionRefund onSubmit', () => {
 // Lines 450-457: selectedIban === "Add bank account" renders AddBankAccount and writes IBAN back.
 describe('TransactionRefund add bank account branch', () => {
   it('shows AddBankAccount when Add bank account is selected and writes the new IBAN into the form', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
     mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
@@ -1215,12 +1190,8 @@ describe('TransactionRefund rendered view', () => {
   });
 
   it('shows IBAN dropdown and name field for bank buy without fixed refundTarget', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }),
-    );
-    mockGetTransactionRefund.mockResolvedValue(
-      makeRefund({ refundTarget: undefined, bankDetails: undefined }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
+    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1247,23 +1218,20 @@ describe('TransactionRefund rendered view', () => {
 
   it('hides the IBAN dropdown when bankAccounts is empty/falsy for bank buy', async () => {
     mockBankAccounts = null as any;
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
     mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
     expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
+    expect(screen.getByTestId('iban')).toBeInTheDocument();
     // Address fields still render for bank refunds.
     expect(screen.getByTestId('creditorStreet')).toBeInTheDocument();
   });
 
   it('shows creditor name when bankDetails.name is set but refundTarget is missing (IBAN override)', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
     mockGetTransactionRefund.mockResolvedValue(
       makeRefund({
         refundTarget: undefined,
@@ -1303,12 +1271,8 @@ describe('TransactionRefund rendered view', () => {
       if (v === BANK_IBAN_DE) return undefined as any;
       return v;
     });
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }),
-    );
-    mockGetTransactionRefund.mockResolvedValue(
-      makeRefund({ refundTarget: undefined, bankDetails: undefined }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
+    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1324,12 +1288,8 @@ describe('TransactionRefund rendered view', () => {
 
   it('disables the country search dropdown for fewer than two countries', async () => {
     mockAllowedCountries = undefined as any;
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }),
-    );
-    mockGetTransactionRefund.mockResolvedValue(
-      makeRefund({ refundTarget: undefined, bankDetails: undefined }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
+    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1340,5 +1300,36 @@ describe('TransactionRefund rendered view', () => {
 
     fireEvent.click(trigger);
     expect(screen.queryByTestId('creditorCountry-options')).not.toBeInTheDocument();
+  });
+});
+
+describe('TransactionRefund guest uid path', () => {
+  it('loads and submits refund data via the guest hook when not logged in', async () => {
+    mockIsLoggedIn = false;
+    mockBankAccounts = null as any;
+    mockGetTransactionByUid.mockResolvedValue(
+      makeTx({ uid: 'T123', type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }),
+    );
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: 'CH9300762011623852957' }));
+    mockSetGuestRefund.mockResolvedValue(undefined);
+
+    renderRefund();
+    await waitForRefundFormLoaded();
+
+    expect(mockGetGuestRefund).toHaveBeenCalledWith('T123');
+    expect(mockGetTransactionRefund).not.toHaveBeenCalled();
+
+    await fillBankCreditorFields();
+    await waitForSubmitEnabled('Confirm refund');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm refund' }));
+    });
+
+    await waitFor(() => {
+      expect(mockSetGuestRefund).toHaveBeenCalled();
+    });
+    expect(mockSetTransactionRefundTarget).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/tx/T123');
   });
 });

--- a/src/__tests__/transaction-screen-status.test.tsx
+++ b/src/__tests__/transaction-screen-status.test.tsx
@@ -858,4 +858,16 @@ describe('TransactionAssign via TransactionScreen', () => {
       expect(screen.getByTestId('error-hint')).toHaveTextContent('targets failed');
     });
   });
+
+  it('surfaces setTarget errors via ErrorHint', async () => {
+    mockSetTarget.mockRejectedValue({ message: 'assign failed' });
+    renderScreen('/tx/T123/assign');
+
+    const assign = await screen.findByRole('button', { name: 'Assign transaction' });
+    await userEvent.click(assign);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-hint')).toHaveTextContent('assign failed');
+    });
+  });
 });

--- a/src/__tests__/transaction-screen-status.test.tsx
+++ b/src/__tests__/transaction-screen-status.test.tsx
@@ -173,6 +173,20 @@ jest.mock('../hooks/navigation.hook', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
+const mockGetTargets = jest.fn();
+const mockSetTarget = jest.fn();
+const mockGetGuestRefund = jest.fn();
+const mockSetGuestRefund = jest.fn();
+
+jest.mock('../hooks/transaction-guest.hook', () => ({
+  useTransactionGuest: () => ({
+    getTargets: mockGetTargets,
+    setTarget: mockSetTarget,
+    getRefund: mockGetGuestRefund,
+    setRefund: mockSetGuestRefund,
+  }),
+}));
+
 jest.mock('src/components/cointracking', () => () => <div data-testid="cointracking" />);
 jest.mock('src/components/payment/add-bank-account', () => ({
   AddBankAccount: () => null,
@@ -219,6 +233,7 @@ function renderScreen(path: string) {
       { path: '/tx', element: <TransactionScreen /> },
       { path: '/tx/:id', element: <TransactionScreen /> },
       { path: '/tx/:id/refund', element: <TransactionScreen /> },
+      { path: '/tx/:id/assign', element: <TransactionScreen /> },
     ],
     { initialEntries: [path] },
   );
@@ -249,6 +264,10 @@ beforeEach(() => {
   mockGetTransactionByUid.mockReset();
   mockGetTransactionRefund.mockReturnValue(neverResolves());
   mockSetTransactionRefundTarget.mockReset();
+  mockGetTargets.mockReset();
+  mockSetTarget.mockReset();
+  mockGetGuestRefund.mockReset();
+  mockSetGuestRefund.mockReset();
   (global.URL as any).createObjectURL = jest.fn(() => 'blob:mock-url');
   jest.spyOn(window, 'open').mockImplementation(() => null);
 });
@@ -265,7 +284,7 @@ afterEach(() => {
 
 // Layout title/onBack variants from TransactionScreen (isRefund / isTransaction / cointracking / error / default).
 describe('TransactionScreen layout title and onBack', () => {
-  it('sets title "Transaction refund" and onBack navigates to /tx when path is refund', async () => {
+  it('sets title "Transaction refund" and onBack navigates to the uid status page', async () => {
     mockGetTransactionByUid.mockReturnValue(neverResolves());
     renderScreen('/tx/T123/refund');
 
@@ -275,7 +294,19 @@ describe('TransactionScreen layout title and onBack', () => {
     expect(lastLayoutOptions().onBack).toEqual(expect.any(Function));
 
     lastLayoutOptions().onBack?.();
-    expect(mockNavigate).toHaveBeenCalledWith('/tx');
+    expect(mockNavigate).toHaveBeenCalledWith('/tx/T123');
+  });
+
+  it('sets title "Assign transaction" and onBack navigates to the uid status page', async () => {
+    mockGetTargets.mockReturnValue(neverResolves());
+    renderScreen('/tx/T123/assign');
+
+    await waitFor(() => {
+      expect(lastLayoutOptions().title).toBe('Assign transaction');
+    });
+
+    lastLayoutOptions().onBack?.();
+    expect(mockNavigate).toHaveBeenCalledWith('/tx/T123');
   });
 
   it('sets title "Transaction status" and onBack navigates to /tx for T/Q ids without refund', async () => {
@@ -667,37 +698,37 @@ describe('TransactionStatus via TransactionScreen', () => {
 
   it('navigates directly when logged in on Assign transaction', async () => {
     mockIsLoggedIn = true;
-    mockGetTransactionByUid.mockResolvedValue(makeTx({ id: 42, state: 'Unassigned' }));
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ id: 42, uid: 'T123', state: 'Unassigned' }));
     renderScreen('/tx/T123');
 
     const assign = await screen.findByRole('button', { name: 'Assign transaction' });
     await userEvent.click(assign);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/tx/42/assign');
+    expect(mockNavigate).toHaveBeenCalledWith('/tx/T123/assign');
     expect(mockSetRedirectPath).not.toHaveBeenCalled();
   });
 
-  it('stores redirect path and navigates to login when not logged in', async () => {
+  it('navigates to the uid assign path without login when not logged in', async () => {
     mockIsLoggedIn = false;
-    mockGetTransactionByUid.mockResolvedValue(makeTx({ id: 42, state: 'Unassigned' }));
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ id: 42, uid: 'T123', state: 'Unassigned' }));
     renderScreen('/tx/T123');
 
     const assign = await screen.findByRole('button', { name: 'Assign transaction' });
     await userEvent.click(assign);
 
-    expect(mockSetRedirectPath).toHaveBeenCalledWith('/tx/42/assign');
-    expect(mockNavigate).toHaveBeenCalledWith('/login');
-    expect(mockNavigate).not.toHaveBeenCalledWith('/tx/42/assign');
+    expect(mockSetRedirectPath).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/tx/T123/assign');
+    expect(mockNavigate).not.toHaveBeenCalledWith('/login');
   });
 
-  it('shows Assign transaction for Unassigned and navigates to /tx/{id}/assign', async () => {
-    mockGetTransactionByUid.mockResolvedValue(makeTx({ id: 7, state: 'Unassigned' }));
+  it('shows Assign transaction for Unassigned and navigates to /tx/{uid}/assign', async () => {
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ id: 7, uid: 'T123', state: 'Unassigned' }));
     renderScreen('/tx/T123');
 
     const assign = await screen.findByRole('button', { name: 'Assign transaction' });
     await userEvent.click(assign);
 
-    expect(mockNavigate).toHaveBeenCalledWith('/tx/7/assign');
+    expect(mockNavigate).toHaveBeenCalledWith('/tx/T123/assign');
   });
 
   it('shows Confirm refund and Create support ticket for Failed when refund is allowed', async () => {
@@ -739,9 +770,7 @@ describe('TransactionStatus via TransactionScreen', () => {
   });
 
   it('hides refund/support when chargebackAmount is set', async () => {
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ state: 'Failed', reason: undefined, chargebackAmount: 10 }),
-    );
+    mockGetTransactionByUid.mockResolvedValue(makeTx({ state: 'Failed', reason: undefined, chargebackAmount: 10 }));
     renderScreen('/tx/T123');
 
     await waitFor(() => {
@@ -780,5 +809,53 @@ describe('TransactionStatus via TransactionScreen', () => {
 
     expect(await screen.findByRole('button', { name: 'Confirm refund' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create support ticket' })).toBeInTheDocument();
+  });
+
+  it('navigates to the support issue path with the transaction uid', async () => {
+    mockGetTransactionByUid.mockResolvedValue(
+      makeTx({ uid: 'T123', state: 'Failed', reason: undefined, chargebackAmount: undefined }),
+    );
+    renderScreen('/tx/T123');
+
+    const support = await screen.findByRole('button', { name: 'Create support ticket' });
+    await userEvent.click(support);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/support/issue?issue-type=TransactionIssue&tx=T123');
+  });
+});
+
+describe('TransactionAssign via TransactionScreen', () => {
+  beforeEach(() => {
+    mockGetTargets.mockResolvedValue([
+      {
+        id: 7,
+        bankUsage: 'ABCD-EFGH',
+        address: '0xabc',
+        asset: { name: 'BTC', blockchain: 'Bitcoin' },
+      },
+    ]);
+    mockSetTarget.mockResolvedValue(undefined);
+  });
+
+  it('preselects the only target and submits the assignment', async () => {
+    mockIsLoggedIn = false;
+    renderScreen('/tx/T123/assign');
+
+    const assign = await screen.findByRole('button', { name: 'Assign transaction' });
+    await userEvent.click(assign);
+
+    await waitFor(() => {
+      expect(mockSetTarget).toHaveBeenCalledWith('T123', 7);
+      expect(mockNavigate).toHaveBeenCalledWith('/tx/T123');
+    });
+  });
+
+  it('surfaces getTargets errors via ErrorHint', async () => {
+    mockGetTargets.mockRejectedValue({ message: 'targets failed' });
+    renderScreen('/tx/T123/assign');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-hint')).toHaveTextContent('targets failed');
+    });
   });
 });

--- a/src/hooks/transaction-guest.hook.ts
+++ b/src/hooks/transaction-guest.hook.ts
@@ -1,0 +1,16 @@
+import { TransactionRefundData, TransactionRefundTarget, TransactionTarget, useApi } from '@dfx.swiss/react';
+
+export function useTransactionGuest() {
+  const { call } = useApi();
+
+  return {
+    getTargets: (uid: string) =>
+      call<TransactionTarget[]>({ url: `transaction/uid/${uid}/targets`, method: 'GET', token: false }),
+    setTarget: (uid: string, buyId: number) =>
+      call({ url: `transaction/uid/${uid}/target?buyId=${buyId}`, method: 'PUT', token: false }),
+    getRefund: (uid: string) =>
+      call<TransactionRefundData>({ url: `transaction/uid/${uid}/refund`, method: 'GET', token: false }),
+    setRefund: (uid: string, target: TransactionRefundTarget) =>
+      call({ url: `transaction/uid/${uid}/refund`, method: 'PUT', data: target, token: false }),
+  };
+}

--- a/src/screens/support-issue.screen.tsx
+++ b/src/screens/support-issue.screen.tsx
@@ -177,10 +177,11 @@ export default function SupportIssueScreen(): JSX.Element {
   const orderParam = urlParams.get('quote') ?? urlParams.get('order');
   const issueTypeParam = urlParams.get('issue-type');
   const reasonParam = urlParams.get('reason');
+  const txParam = urlParams.get('tx');
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {
-      if (orderParam || issueTypeParam || reasonParam) {
+      if (orderParam || issueTypeParam || reasonParam || txParam) {
         clearParams([...Array.from(urlParams.keys())]);
       }
     }, 0);
@@ -198,9 +199,14 @@ export default function SupportIssueScreen(): JSX.Element {
     if (reasonEnum) {
       setValue('reason', reasonEnum);
     }
-  }, [issueTypeParam, reasonParam]);
 
-  useUserGuard('/login', !orderParam);
+    if (txParam) {
+      setValue('type', SupportIssueType.TRANSACTION_ISSUE);
+      setValue('transaction', { uid: txParam, description: 'Transaction ID' });
+    }
+  }, [issueTypeParam, reasonParam, txParam]);
+
+  useUserGuard('/login', !orderParam && !txParam);
   useKycLevelGuard(KycLevel.Link, '/contact');
 
   function startChat(issueUid: string) {
@@ -250,9 +256,10 @@ export default function SupportIssueScreen(): JSX.Element {
   }, [selectedReason, selectTransaction]);
 
   useEffect(() => {
+    if (txParam) return;
     setSelectedTxState(undefined);
     setValue('transaction', undefined);
-  }, [selectedReason]);
+  }, [selectedReason, txParam]);
 
   // Invalidate in-flight checks and stop the spinner when the normalized value changes. Hint staleness is
   // handled by binding the stored result to the IBAN it was computed for (see getReceiverIbanHint).
@@ -454,7 +461,7 @@ export default function SupportIssueScreen(): JSX.Element {
               labelFunc={(item) => item && translate('screens/support', IssueTypeLabels[item])}
               name="type"
               placeholder={translate('general/actions', 'Select') + '...'}
-              disabled={!!orderParam}
+              disabled={!!orderParam || !!txParam}
               full
             />
 
@@ -482,7 +489,7 @@ export default function SupportIssueScreen(): JSX.Element {
 
             {selectedType === SupportIssueType.TRANSACTION_ISSUE && selectedReason && (
               <>
-                {selectedReason !== SupportIssueReason.TRANSACTION_MISSING && !orderParam && (
+                {selectedReason !== SupportIssueReason.TRANSACTION_MISSING && !orderParam && !txParam && (
                   <StyledVerticalStack gap={3.5} full center>
                     <p className="w-full text-left text-dfxBlue-800 text-base font-semibold pl-3.5 -mb-1">
                       {translate('screens/payment', 'Transaction')}

--- a/src/screens/support-issue.screen.tsx
+++ b/src/screens/support-issue.screen.tsx
@@ -234,8 +234,8 @@ export default function SupportIssueScreen(): JSX.Element {
   }, [orderParam]);
 
   useEffect(() => {
-    if (orderParam && isLoggedIn) logout();
-  }, [orderParam, isLoggedIn]);
+    if ((orderParam || txParam) && isLoggedIn) logout();
+  }, [orderParam, txParam, isLoggedIn]);
 
   useEffect(() => {
     if (orderParam && !isLoading && existingIssue) {

--- a/src/screens/support-issue.screen.tsx
+++ b/src/screens/support-issue.screen.tsx
@@ -177,7 +177,7 @@ export default function SupportIssueScreen(): JSX.Element {
   const orderParam = urlParams.get('quote') ?? urlParams.get('order');
   const issueTypeParam = urlParams.get('issue-type');
   const reasonParam = urlParams.get('reason');
-  const txParam = urlParams.get('tx');
+  const [txParam] = useState(() => urlParams.get('tx'));
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {

--- a/src/screens/transaction.screen.tsx
+++ b/src/screens/transaction.screen.tsx
@@ -339,6 +339,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
   const [localError, setLocalError] = useState<string>();
 
   const isBuy = transaction?.type === TransactionType.BUY;
+  const useGuestRefund = isUid || !isLoggedIn;
 
   const {
     control,
@@ -359,8 +360,11 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
 
   useEffect(() => {
     async function fetchRefund() {
-      const request =
-        isLoggedIn && transaction?.id ? getTransactionRefund(transaction.id) : id ? getRefund(id) : undefined;
+      const request = useGuestRefund && id
+        ? getRefund(id)
+        : transaction?.id
+          ? getTransactionRefund(transaction.id)
+          : undefined;
       if (!request) return;
 
       request
@@ -375,7 +379,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
         .catch((error: ApiError) => setError(error.message ?? 'Unknown error'));
     }
 
-    if (transaction && (isLoggedIn ? transaction.id != null : isUid)) fetchRefund();
+    if (transaction && (useGuestRefund ? isUid : transaction.id != null)) fetchRefund();
 
     return () => {
       if (refetchTimeout.current) clearTimeout(refetchTimeout.current);
@@ -400,8 +404,8 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
   // - iban/creditorName: only required for bank refunds if not already fixed from bankTx
   // - creditorStreet/zip/city/country: only required for bank refunds
   const rules = Utils.createRules({
-    address: !isBuy && isLoggedIn ? Validations.Required : undefined,
-    refundAddress: !isBuy && !isLoggedIn && !refundDetails?.refundTarget ? Validations.Required : undefined,
+    address: !isBuy && !useGuestRefund ? Validations.Required : undefined,
+    refundAddress: !isBuy && useGuestRefund && !refundDetails?.refundTarget ? Validations.Required : undefined,
     iban: !isBankRefund || refundDetails?.refundTarget ? undefined : Validations.Required,
     creditorName:
       !isBankRefund || (refundDetails?.bankDetails?.name?.trim() && refundDetails?.refundTarget)
@@ -421,7 +425,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
     setLocalError(undefined);
 
     try {
-      const formTarget = isBuy ? (data.iban ?? '') : isLoggedIn ? data.address?.address : data.refundAddress;
+      const formTarget = isBuy ? (data.iban ?? '') : useGuestRefund ? data.refundAddress : data.address?.address;
 
       const refundName = !refundDetails?.refundTarget
         ? data.creditorName
@@ -441,12 +445,12 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
           : undefined,
       };
 
-      if (isLoggedIn && submittedId != null) {
-        await setTransactionRefundTarget(submittedId, payload);
-        navigate('/tx');
-      } else if (id) {
+      if (useGuestRefund && id) {
         await setRefund(id, payload);
         navigate(`/tx/${id}`);
+      } else if (submittedId != null) {
+        await setTransactionRefundTarget(submittedId, payload);
+        navigate('/tx');
       }
     } catch (e) {
       const error = e as ApiError;
@@ -471,7 +475,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
         'The bank account has been added, all transactions from this IBAN will now be associated with your account.',
       )}
     />
-  ) : refundDetails && transaction && (isLoggedIn ? transactionId != null : isUid) ? (
+  ) : refundDetails && transaction && (useGuestRefund ? isUid : transactionId != null) ? (
     <StyledVerticalStack gap={6} full>
       <StyledDataTable alignContent={AlignContent.RIGHT} showBorder minWidth={false}>
         <StyledDataTableRow label={translate('screens/payment', 'Transaction amount')}>
@@ -537,7 +541,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
       </StyledDataTable>
       <Form control={control} rules={rules} errors={errors}>
         <StyledVerticalStack gap={6} full>
-          {!refundDetails.refundTarget && isLoggedIn && addresses && !isBuy && (
+          {!refundDetails.refundTarget && !useGuestRefund && addresses && !isBuy && (
             <StyledDropdown<UserAddress>
               name="address"
               rootRef={rootRef}
@@ -548,7 +552,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
               full
             />
           )}
-          {!refundDetails.refundTarget && !isBuy && !isLoggedIn && (
+          {!refundDetails.refundTarget && !isBuy && useGuestRefund && (
             <StyledInput
               name="refundAddress"
               label={translate('screens/payment', 'Chargeback address')}
@@ -559,7 +563,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
           {transaction.inputPaymentMethod !== FiatPaymentMethod.CARD && isBuy && (
             <>
               {/* IBAN selection only when no fixed refundTarget */}
-              {!refundDetails.refundTarget && isLoggedIn && bankAccounts && (
+              {!refundDetails.refundTarget && !useGuestRefund && bankAccounts && (
                 <StyledDropdown<string>
                   rootRef={rootRef}
                   name="iban"
@@ -574,7 +578,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
                   full
                 />
               )}
-              {!refundDetails.refundTarget && !(isLoggedIn && bankAccounts) && (
+              {!refundDetails.refundTarget && (useGuestRefund || !bankAccounts) && (
                 <StyledInput
                   name="iban"
                   autocomplete="iban"

--- a/src/screens/transaction.screen.tsx
+++ b/src/screens/transaction.screen.tsx
@@ -416,7 +416,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
   const inputBlockchain = transaction?.inputBlockchain;
   const transactionId = transaction?.id;
 
-  async function onSubmit(data: FormData, transactionId: number) {
+  async function onSubmit(data: FormData, submittedId?: number) {
     setIsLoading(true);
     setLocalError(undefined);
 
@@ -441,8 +441,8 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
           : undefined,
       };
 
-      if (isLoggedIn) {
-        await setTransactionRefundTarget(transactionId, payload);
+      if (isLoggedIn && submittedId != null) {
+        await setTransactionRefundTarget(submittedId, payload);
         navigate('/tx');
       } else if (id) {
         await setRefund(id, payload);
@@ -471,7 +471,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
         'The bank account has been added, all transactions from this IBAN will now be associated with your account.',
       )}
     />
-  ) : refundDetails && transaction && transactionId != null ? (
+  ) : refundDetails && transaction && (isLoggedIn ? transactionId != null : isUid) ? (
     <StyledVerticalStack gap={6} full>
       <StyledDataTable alignContent={AlignContent.RIGHT} showBorder minWidth={false}>
         <StyledDataTableRow label={translate('screens/payment', 'Transaction amount')}>

--- a/src/screens/transaction.screen.tsx
+++ b/src/screens/transaction.screen.tsx
@@ -537,7 +537,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
       </StyledDataTable>
       <Form control={control} rules={rules} errors={errors}>
         <StyledVerticalStack gap={6} full>
-          {!refundDetails.refundTarget && addresses && !isBuy && (
+          {!refundDetails.refundTarget && isLoggedIn && addresses && !isBuy && (
             <StyledDropdown<UserAddress>
               name="address"
               rootRef={rootRef}
@@ -559,7 +559,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
           {transaction.inputPaymentMethod !== FiatPaymentMethod.CARD && isBuy && (
             <>
               {/* IBAN selection only when no fixed refundTarget */}
-              {!refundDetails.refundTarget && bankAccounts && (
+              {!refundDetails.refundTarget && isLoggedIn && bankAccounts && (
                 <StyledDropdown<string>
                   rootRef={rootRef}
                   name="iban"
@@ -574,7 +574,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
                   full
                 />
               )}
-              {!refundDetails.refundTarget && !bankAccounts && (
+              {!refundDetails.refundTarget && !(isLoggedIn && bankAccounts) && (
                 <StyledInput
                   name="iban"
                   autocomplete="iban"

--- a/src/screens/transaction.screen.tsx
+++ b/src/screens/transaction.screen.tsx
@@ -58,12 +58,12 @@ import { useLayoutContext } from 'src/contexts/layout.context';
 import { useWindowContext } from 'src/contexts/window.context';
 import { ErrorHint } from '../components/error-hint';
 import { PaymentFailureReasons, PaymentMethodLabels, toPaymentStateLabel } from '../config/labels';
-import { useAppHandlingContext } from '../contexts/app-handling.context';
 import { useSettingsContext } from '../contexts/settings.context';
 import { useBlockchain } from '../hooks/blockchain.hook';
 import { useUserGuard } from '../hooks/guard.hook';
 import { useLayoutOptions } from '../hooks/layout-config.hook';
 import { useNavigation } from '../hooks/navigation.hook';
+import { useTransactionGuest } from '../hooks/transaction-guest.hook';
 import { getStoredPaymentDetailErrorMessage } from '../util/personal-iban';
 import { blankedAddress, formatSwissDateTimeWithSeconds, openPdfFromString } from '../util/utils';
 import { ZipValidation } from '../util/validation-rules';
@@ -90,6 +90,7 @@ export default function TransactionScreen(): JSX.Element {
 
   const isTransaction = id && (id.startsWith('T') || id.startsWith('Q'));
   const isRefund = isTransaction && pathname.includes('/refund');
+  const isAssign = isTransaction && pathname.includes('/assign');
 
   async function exportCsv(type: ExportType) {
     if (!user) return;
@@ -122,21 +123,28 @@ export default function TransactionScreen(): JSX.Element {
 
   const title = isRefund
     ? translate('screens/payment', 'Transaction refund')
-    : isTransaction
-      ? translate('screens/payment', 'Transaction status')
-      : showCoinTracking
-        ? translate('screens/payment', 'Cointracking Link (read rights)')
-        : translate('screens/payment', 'Transactions');
+    : isAssign
+      ? translate('screens/payment', 'Assign transaction')
+      : isTransaction
+        ? translate('screens/payment', 'Transaction status')
+        : showCoinTracking
+          ? translate('screens/payment', 'Cointracking Link (read rights)')
+          : translate('screens/payment', 'Transactions');
 
   const onBack =
-    isTransaction || isRefund || error
+    isAssign || isRefund
       ? () => {
           setError(undefined);
-          navigate('/tx');
+          navigate(`/tx/${id}`);
         }
-      : showCoinTracking
-        ? () => setShowCoinTracking(false)
-        : undefined;
+      : isTransaction || error
+        ? () => {
+            setError(undefined);
+            navigate('/tx');
+          }
+        : showCoinTracking
+          ? () => setShowCoinTracking(false)
+          : undefined;
 
   useLayoutOptions({ title, onBack });
 
@@ -146,6 +154,8 @@ export default function TransactionScreen(): JSX.Element {
         <ErrorHint message={error} />
       ) : isRefund ? (
         <TransactionRefund setError={setError} />
+      ) : isAssign ? (
+        <TransactionAssign setError={setError} />
       ) : isTransaction ? (
         <TransactionStatus setError={setError} />
       ) : showCoinTracking ? (
@@ -210,8 +220,6 @@ function TransactionStatus({ setError }: TransactionStatusProps): JSX.Element {
   const { translate } = useSettingsContext();
   const { id } = useParams();
   const { getTransactionByUid } = useTransaction();
-  const { isLoggedIn } = useSessionContext();
-  const { setRedirectPath } = useAppHandlingContext();
   const { user } = useUserContext();
 
   const isRealUnit = user?.activeAddress?.wallet?.startsWith('RealUnit') ?? false;
@@ -234,12 +242,7 @@ function TransactionStatus({ setError }: TransactionStatusProps): JSX.Element {
   }, [id, transaction?.state]);
 
   function handleTransactionNavigation(path: string) {
-    if (isLoggedIn) {
-      navigate(path);
-    } else {
-      setRedirectPath(path);
-      navigate('/login');
-    }
+    navigate(path);
   }
 
   return transaction ? (
@@ -250,7 +253,7 @@ function TransactionStatus({ setError }: TransactionStatusProps): JSX.Element {
         {transaction.state === TransactionState.UNASSIGNED && (
           <StyledButton
             label={translate('screens/payment', 'Assign transaction')}
-            onClick={() => handleTransactionNavigation(`/tx/${transaction.id}/assign`)}
+            onClick={() => handleTransactionNavigation(`/tx/${transaction.uid}/assign`)}
             width={StyledButtonWidth.FULL}
           />
         )}
@@ -276,7 +279,9 @@ function TransactionStatus({ setError }: TransactionStatusProps): JSX.Element {
               />
               <StyledButton
                 label={translate('general/actions', 'Create support ticket')}
-                onClick={() => handleTransactionNavigation('/support/issue?issue-type=TransactionIssue')}
+                onClick={() =>
+                  handleTransactionNavigation(`/support/issue?issue-type=TransactionIssue&tx=${transaction.uid}`)
+                }
                 color={StyledButtonColor.STURDY_WHITE}
               />
             </>
@@ -294,6 +299,7 @@ interface RefundDetails extends TransactionRefundData {
 
 interface FormData {
   address: UserAddress;
+  refundAddress: string;
   iban: string;
   creditorName: string;
   creditorStreet: string;
@@ -310,9 +316,10 @@ interface TransactionRefundProps {
 const AddAccount = 'Add bank account';
 
 function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
-  useUserGuard('/login');
-
   const { id } = useParams();
+  const isUid = !!(id && (id.startsWith('T') || id.startsWith('Q')));
+  useUserGuard('/login', !isUid);
+
   const { state } = useLocation();
   const { width } = useWindowContext();
   const { navigate } = useNavigation();
@@ -322,6 +329,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
   const { bankAccounts } = useBankAccountContext();
   const { isLoggedIn } = useSessionContext();
   const { getTransactionByUid, getTransactionRefund, setTransactionRefundTarget } = useTransaction();
+  const { getRefund, setRefund } = useTransactionGuest();
   const refetchTimeout = useRef<ReturnType<typeof setTimeout> | undefined>();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -342,33 +350,37 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
   const selectedIban = useWatch({ control, name: 'iban' });
 
   useEffect(() => {
-    if (id && !transaction && isLoggedIn) {
+    if (id && !transaction && (isLoggedIn || isUid)) {
       getTransactionByUid(id)
         .then(setTransaction)
         .catch((error: ApiError) => setError(error.message ?? 'Unknown error'));
     }
-  }, [id, transaction, isLoggedIn]);
+  }, [id, transaction, isLoggedIn, isUid]);
 
   useEffect(() => {
-    async function fetchRefund(txId: number) {
-      getTransactionRefund(txId)
+    async function fetchRefund() {
+      const request =
+        isLoggedIn && transaction?.id ? getTransactionRefund(transaction.id) : id ? getRefund(id) : undefined;
+      if (!request) return;
+
+      request
         .then((response) => {
           setRefundDetails(response);
-          if (transaction?.id && response.expiryDate) {
+          if (response.expiryDate) {
             const timeout = new Date(response.expiryDate).getTime() - Date.now();
             if (refetchTimeout.current) clearTimeout(refetchTimeout.current);
-            refetchTimeout.current = setTimeout(() => fetchRefund(txId), timeout > 0 ? timeout : 0);
+            refetchTimeout.current = setTimeout(() => fetchRefund(), timeout > 0 ? timeout : 0);
           }
         })
         .catch((error: ApiError) => setError(error.message ?? 'Unknown error'));
     }
 
-    if (transaction?.id) fetchRefund(transaction.id);
+    if (transaction && (isLoggedIn ? transaction.id != null : isUid)) fetchRefund();
 
     return () => {
       if (refetchTimeout.current) clearTimeout(refetchTimeout.current);
     };
-  }, [transaction]);
+  }, [transaction, isLoggedIn, isUid, id]);
 
   useEffect(() => {
     if (transaction && user) {
@@ -388,7 +400,8 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
   // - iban/creditorName: only required for bank refunds if not already fixed from bankTx
   // - creditorStreet/zip/city/country: only required for bank refunds
   const rules = Utils.createRules({
-    address: !isBuy ? Validations.Required : undefined,
+    address: !isBuy && isLoggedIn ? Validations.Required : undefined,
+    refundAddress: !isBuy && !isLoggedIn && !refundDetails?.refundTarget ? Validations.Required : undefined,
     iban: !isBankRefund || refundDetails?.refundTarget ? undefined : Validations.Required,
     creditorName:
       !isBankRefund || (refundDetails?.bankDetails?.name?.trim() && refundDetails?.refundTarget)
@@ -408,11 +421,13 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
     setLocalError(undefined);
 
     try {
-      const formTarget = isBuy ? (data.iban ?? '') : data.address?.address;
+      const formTarget = isBuy ? (data.iban ?? '') : isLoggedIn ? data.address?.address : data.refundAddress;
 
-      const refundName = !refundDetails?.refundTarget ? data.creditorName : (refundDetails?.bankDetails?.name ?? data.creditorName);
+      const refundName = !refundDetails?.refundTarget
+        ? data.creditorName
+        : (refundDetails?.bankDetails?.name ?? data.creditorName);
 
-      await setTransactionRefundTarget(transactionId, {
+      const payload = {
         refundTarget: !isBuy || (isBankRefund && !refundDetails?.refundTarget) ? formTarget : undefined,
         creditorData: isBankRefund
           ? {
@@ -424,18 +439,21 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
               country: data.creditorCountry?.symbol,
             }
           : undefined,
-      });
-      // Navigate only on success
-      navigate('/tx');
+      };
+
+      if (isLoggedIn) {
+        await setTransactionRefundTarget(transactionId, payload);
+        navigate('/tx');
+      } else if (id) {
+        await setRefund(id, payload);
+        navigate(`/tx/${id}`);
+      }
     } catch (e) {
       const error = e as ApiError;
       if (error.message?.includes('MultiAccountIban')) {
         // Use local error to keep the form visible (setError would replace the entire form)
         setLocalError(
-          translate(
-            'screens/payment',
-            'This IBAN cannot be used for refunds. Please select a personal bank account.',
-          ),
+          translate('screens/payment', 'This IBAN cannot be used for refunds. Please select a personal bank account.'),
         );
       } else {
         setError(error.message ?? 'Unknown error');
@@ -517,11 +535,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
           </StyledDataTableRow>
         )}
       </StyledDataTable>
-      <Form
-        control={control}
-        rules={rules}
-        errors={errors}
-      >
+      <Form control={control} rules={rules} errors={errors}>
         <StyledVerticalStack gap={6} full>
           {!refundDetails.refundTarget && addresses && !isBuy && (
             <StyledDropdown<UserAddress>
@@ -531,6 +545,14 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
               items={addresses}
               labelFunc={(item) => blankedAddress(item.address, { width })}
               descriptionFunc={inputBlockchain ? () => inputBlockchain.toString() : undefined}
+              full
+            />
+          )}
+          {!refundDetails.refundTarget && !isBuy && !isLoggedIn && (
+            <StyledInput
+              name="refundAddress"
+              label={translate('screens/payment', 'Chargeback address')}
+              placeholder={translate('screens/payment', 'Chargeback address')}
               full
             />
           )}
@@ -549,6 +571,15 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
                   descriptionFunc={(item) => bankAccounts.find((b) => b.iban === item)?.label ?? ''}
                   placeholder={translate('general/actions', 'Select') + '...'}
                   forceEnable
+                  full
+                />
+              )}
+              {!refundDetails.refundTarget && !bankAccounts && (
+                <StyledInput
+                  name="iban"
+                  autocomplete="iban"
+                  label={translate('screens/payment', 'Chargeback IBAN')}
+                  placeholder="XX XXXX XXXX XXXX XXXX X"
                   full
                 />
               )}
@@ -629,6 +660,83 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
         </StyledVerticalStack>
       </Form>
     </StyledVerticalStack>
+  ) : (
+    <StyledLoadingSpinner size={SpinnerSize.LG} />
+  );
+}
+
+function TransactionAssign({ setError }: TransactionStatusProps): JSX.Element {
+  const { id } = useParams();
+  const { navigate } = useNavigation();
+  const { translate } = useSettingsContext();
+  const { rootRef } = useLayoutContext();
+  const { toString } = useBlockchain();
+  const { width } = useWindowContext();
+  const { getTargets, setTarget } = useTransactionGuest();
+
+  const [targets, setTargets] = useState<TransactionTarget[]>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    formState: { isValid, errors },
+  } = useForm<{ target: TransactionTarget }>();
+
+  const rules = Utils.createRules({
+    target: Validations.Required,
+  });
+
+  useEffect(() => {
+    if (!id) return;
+
+    getTargets(id)
+      .then((list) => {
+        setTargets(list);
+        if (list.length === 1) setValue('target', list[0]);
+      })
+      .catch((error: ApiError) => setError(error.message ?? 'Unknown error'));
+  }, [id]);
+
+  async function onSubmit({ target }: { target: TransactionTarget }) {
+    if (!id) return;
+
+    setIsSubmitting(true);
+    try {
+      await setTarget(id, target.id);
+      navigate(`/tx/${id}`);
+    } catch (error) {
+      setError((error as ApiError).message ?? 'Unknown error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return targets ? (
+    <Form control={control} errors={errors} rules={rules}>
+      <StyledVerticalStack gap={3} full>
+        <p className="text-dfxGray-700">{translate('screens/payment', 'Remittance info')}</p>
+        <StyledDropdown<TransactionTarget>
+          rootRef={rootRef}
+          items={targets}
+          labelFunc={(item) => `${item.bankUsage}`}
+          placeholder={translate('general/actions', 'Select') + '...'}
+          descriptionFunc={(item) =>
+            `${toString(item.asset.blockchain)}/${item.asset.name} ${blankedAddress(item.address, { width })}`
+          }
+          full
+          name="target"
+        />
+        <StyledButton
+          type="submit"
+          isLoading={isSubmitting}
+          disabled={!isValid}
+          label={translate('screens/payment', 'Assign transaction')}
+          onClick={handleSubmit(onSubmit)}
+        />
+      </StyledVerticalStack>
+    </Form>
   ) : (
     <StyledLoadingSpinner size={SpinnerSize.LG} />
   );
@@ -925,10 +1033,9 @@ export function TransactionList({ isSupport, setError, onSelectTransaction }: Tr
                               isLoading={isReceiptLoading === tx.id}
                               color={StyledButtonColor.STURDY_WHITE}
                             />
-                            {documentError &&
-                              (documentError.key === tx.uid || documentError.key === String(tx.id)) && (
-                                <ErrorHint message={documentError.message} />
-                              )}
+                            {documentError && (documentError.key === tx.uid || documentError.key === String(tx.id)) && (
+                              <ErrorHint message={documentError.message} />
+                            )}
                             <StyledButton
                               label={translate(
                                 'general/actions',


### PR DESCRIPTION
EN:
The three buttons on the public `/tx/T…` status page no longer send the customer to login. Assign and refund call the UID guest API; the support form accepts a `tx` query param and can be submitted without a session. A logged-in session no longer blocks those mail links.

DE:
Die drei Buttons auf der öffentlichen Statusseite `/tx/T…` leiten nicht mehr zum Login. Zuordnen und Rückerstattung nutzen die UID-Gast-APIs; das Support-Formular nimmt `tx` als Query-Param und geht ohne Session. Eine bereits offene Session blockiert diese Mail-Links nicht mehr.

<details>
<summary>Details</summary>

This is the review-fixed continuation of #1399. That branch is not writable from this account, so the same work plus the review fixes is opened from the TaprootFreakAI fork.

- `useTransactionGuest` calls the guest endpoints with `token: false`
- Assign from the status page goes to `/tx/{uid}/assign`
- Refund on a T/Q route always uses the guest hook and the free-text form, even when a session is open
- Support ticket path includes `&tx={uid}`; a logged-in session is cleared the same way as a quote deep-link so the ticket is created for the transaction owner
- The `/tx` transaction list still requires login

Deviations:
- Guest API calls live in a local hook instead of a published `@dfx.swiss/react` release, so this frontend can ship with the companion API change.
- No handbook/e2e-stack update in this PR. Unit tests cover the new branches; full-stack coverage belongs after the guest API is on develop.

</details>