### PR TITLE
01a00f7b - Review fixes for public TX guest actions

### DIFF
--- a/src/__tests__/support-issue-receiver-iban.test.tsx
+++ b/src/__tests__/support-issue-receiver-iban.test.tsx
@@ -13,6 +13,8 @@ const mockCreateSupportIssue = jest.fn();
 const mockNavigate = jest.fn();
 const mockClearParams = jest.fn();
 const mockTranslate = jest.fn((_ns: string, key: string) => key);
+const mockLogout = jest.fn();
+let mockSupportIsLoggedIn = false;
 
 jest.mock('@dfx.swiss/react', () => {
   const SupportIssueType = {
@@ -102,7 +104,7 @@ jest.mock('@dfx.swiss/react', () => {
     Validations,
     useBank: () => ({ checkReceiveIban: mockCheckReceiveIban }),
     useBankAccountContext: () => ({ bankAccounts: undefined }),
-    useSessionContext: () => ({ isLoggedIn: false, logout: jest.fn() }),
+    useSessionContext: () => ({ isLoggedIn: mockSupportIsLoggedIn, logout: mockLogout }),
     useSupportChatContext: () => ({
       createSupportIssue: mockCreateSupportIssue,
       loadSupportIssue: jest.fn(),
@@ -443,6 +445,7 @@ describe('SupportIssueScreen receiver IBAN check', () => {
     mockCheckReceiveIban.mockReset();
     mockCreateSupportIssue.mockReset();
     mockCreateSupportIssue.mockResolvedValue('issue-uid-1');
+    mockSupportIsLoggedIn = false;
   });
 
   afterEach(async () => {
@@ -1032,5 +1035,12 @@ describe('SupportIssueScreen tx query param', () => {
     renderScreen(`?issue-type=${SupportIssueType.TRANSACTION_ISSUE}`);
 
     expect(mockUseUserGuard).toHaveBeenCalledWith('/login', true);
+  });
+
+  it('logs out a logged-in session when tx is present', () => {
+    mockSupportIsLoggedIn = true;
+    renderScreen(`?issue-type=${SupportIssueType.TRANSACTION_ISSUE}&tx=T1E448FF200A877DC`);
+
+    expect(mockLogout).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/transaction-list-txinfo.test.tsx
+++ b/src/__tests__/transaction-list-txinfo.test.tsx
@@ -426,7 +426,7 @@ jest.mock('../hooks/transaction-guest.hook', () => ({
   useTransactionGuest: () => ({
     getTargets: jest.fn(),
     setTarget: jest.fn(),
-    getRefund: jest.fn(),
+    getRefund: mockGetTransactionRefund,
     setRefund: jest.fn(),
   }),
 }));

--- a/src/__tests__/transaction-refund.test.tsx
+++ b/src/__tests__/transaction-refund.test.tsx
@@ -413,7 +413,7 @@ jest.mock('../util/utils', () => ({
 jest.mock('copy-to-clipboard', () => jest.fn());
 
 import { Utils } from '@dfx.swiss/react';
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import TransactionScreen from '../screens/transaction.screen';
 

--- a/src/__tests__/transaction-refund.test.tsx
+++ b/src/__tests__/transaction-refund.test.tsx
@@ -510,6 +510,8 @@ async function fillBankCreditorFields(options?: { houseNumber?: string; name?: s
 async function fillBankRefundForm(options?: { ibanIndex?: number; houseNumber?: string; name?: string }) {
   if (screen.queryByTestId('iban-dropdown')) {
     selectDropdownOption('iban', options?.ibanIndex ?? 0);
+  } else if (screen.queryByTestId('iban')) {
+    changeAndBlur('iban', options?.ibanIndex === 1 ? BANK_IBAN_CH : BANK_IBAN_DE);
   }
   await fillBankCreditorFields(options);
 }
@@ -538,8 +540,10 @@ beforeEach(() => {
   mockGetGuestRefund.mockReset();
   mockSetGuestRefund.mockReset();
   mockSetTransactionRefundTarget.mockResolvedValue(undefined);
+  mockSetGuestRefund.mockResolvedValue(undefined);
   mockGetTransactionByUid.mockResolvedValue(makeTx());
-  mockGetTransactionRefund.mockResolvedValue(makeRefund());
+  mockGetGuestRefund.mockResolvedValue(makeRefund());
+  mockGetGuestRefund.mockResolvedValue(makeRefund());
 });
 
 afterEach(() => {
@@ -572,11 +576,11 @@ describe('TransactionRefund transaction load errors', () => {
 // Lines 356-365: fetchRefund success, expiryDate timers (future/past), clearTimeout, errors, unmount cleanup.
 describe('TransactionRefund fetchRefund', () => {
   it('loads refund details and shows the amount table on success without expiryDate', async () => {
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ expiryDate: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ expiryDate: undefined }));
     renderRefund();
 
     await waitForRefundFormLoaded();
-    expect(mockGetTransactionRefund).toHaveBeenCalledWith(42);
+    expect(mockGetGuestRefund).toHaveBeenCalledWith('T123');
     expect(screen.getByTestId('row-Transaction amount')).toHaveTextContent('100 EUR');
     expect(screen.getByTestId('row-Refund amount')).toHaveTextContent('98.4 EUR');
   });
@@ -584,7 +588,7 @@ describe('TransactionRefund fetchRefund', () => {
   it('schedules a refetch when expiryDate is in the future and refetches after the timeout', async () => {
     jest.useFakeTimers();
     const future = new Date(Date.now() + 5000).toISOString();
-    mockGetTransactionRefund
+    mockGetGuestRefund
       .mockResolvedValueOnce(makeRefund({ expiryDate: future, refundAmount: 98.4 }))
       .mockResolvedValueOnce(makeRefund({ expiryDate: undefined, refundAmount: 97 }));
 
@@ -598,7 +602,7 @@ describe('TransactionRefund fetchRefund', () => {
       { advanceTimers: jest.advanceTimersByTime },
     );
 
-    expect(mockGetTransactionRefund).toHaveBeenCalledTimes(1);
+    expect(mockGetGuestRefund).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       jest.advanceTimersByTime(5000);
@@ -606,7 +610,7 @@ describe('TransactionRefund fetchRefund', () => {
 
     await waitFor(
       () => {
-        expect(mockGetTransactionRefund).toHaveBeenCalledTimes(2);
+        expect(mockGetGuestRefund).toHaveBeenCalledTimes(2);
       },
       { advanceTimers: jest.advanceTimersByTime },
     );
@@ -623,13 +627,13 @@ describe('TransactionRefund fetchRefund', () => {
   it('refetches immediately when expiryDate is already in the past', async () => {
     const past = new Date(Date.now() - 10_000).toISOString();
     const future = new Date(Date.now() + 60_000).toISOString();
-    mockGetTransactionRefund
+    mockGetGuestRefund
       .mockResolvedValueOnce(makeRefund({ expiryDate: past, refundAmount: 90 }))
       .mockResolvedValue(makeRefund({ expiryDate: future, refundAmount: 90 }));
 
     renderRefund();
 
-    await waitFor(() => expect(mockGetTransactionRefund).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockGetGuestRefund).toHaveBeenCalledTimes(2));
   });
 
   it('clears a previous refetch timeout when a subsequent refund response also has expiryDate', async () => {
@@ -638,7 +642,7 @@ describe('TransactionRefund fetchRefund', () => {
     const future1 = new Date(Date.now() + 8000).toISOString();
     const future2 = new Date(Date.now() + 12_000).toISOString();
 
-    mockGetTransactionRefund
+    mockGetGuestRefund
       .mockResolvedValueOnce(makeRefund({ expiryDate: future1 }))
       .mockResolvedValueOnce(makeRefund({ expiryDate: future2 }))
       .mockResolvedValueOnce(makeRefund({ expiryDate: undefined }));
@@ -648,7 +652,7 @@ describe('TransactionRefund fetchRefund', () => {
     await waitFor(
       () => {
         expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
-        expect(mockGetTransactionRefund).toHaveBeenCalledTimes(1);
+        expect(mockGetGuestRefund).toHaveBeenCalledTimes(1);
       },
       { advanceTimers: jest.advanceTimersByTime },
     );
@@ -659,7 +663,7 @@ describe('TransactionRefund fetchRefund', () => {
 
     await waitFor(
       () => {
-        expect(mockGetTransactionRefund).toHaveBeenCalledTimes(2);
+        expect(mockGetGuestRefund).toHaveBeenCalledTimes(2);
       },
       { advanceTimers: jest.advanceTimersByTime },
     );
@@ -669,7 +673,7 @@ describe('TransactionRefund fetchRefund', () => {
   });
 
   it('surfaces getTransactionRefund errors via setError', async () => {
-    mockGetTransactionRefund.mockRejectedValue({ message: 'refund unavailable' });
+    mockGetGuestRefund.mockRejectedValue({ message: 'refund unavailable' });
     renderRefund();
 
     await waitFor(() => {
@@ -678,7 +682,7 @@ describe('TransactionRefund fetchRefund', () => {
   });
 
   it('surfaces "Unknown error" when getTransactionRefund rejects without message', async () => {
-    mockGetTransactionRefund.mockRejectedValue({});
+    mockGetGuestRefund.mockRejectedValue({});
     renderRefund();
 
     await waitFor(() => {
@@ -690,7 +694,7 @@ describe('TransactionRefund fetchRefund', () => {
     jest.useFakeTimers();
     const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
     const future = new Date(Date.now() + 30_000).toISOString();
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ expiryDate: future }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ expiryDate: future }));
 
     const { unmount } = renderRefund();
 
@@ -702,7 +706,7 @@ describe('TransactionRefund fetchRefund', () => {
       { advanceTimers: jest.advanceTimersByTime },
     );
 
-    const callsBeforeUnmount = mockGetTransactionRefund.mock.calls.length;
+    const callsBeforeUnmount = mockGetGuestRefund.mock.calls.length;
     unmount();
     expect(clearTimeoutSpy).toHaveBeenCalled();
 
@@ -710,13 +714,13 @@ describe('TransactionRefund fetchRefund', () => {
       jest.advanceTimersByTime(30_000);
     });
 
-    expect(mockGetTransactionRefund).toHaveBeenCalledTimes(callsBeforeUnmount);
+    expect(mockGetGuestRefund).toHaveBeenCalledTimes(callsBeforeUnmount);
   });
 });
 
-// Lines 377-383: filter userAddresses by inputBlockchain; auto-setValue when exactly one match.
+// T/Q refund is always the guest form: no logged-in address dropdown, even when addresses exist.
 describe('TransactionRefund address filtering', () => {
-  it('lists multiple matching addresses for a crypto refund and does not auto-select', async () => {
+  it('does not list logged-in addresses on a T-uid crypto refund', async () => {
     mockUserAddresses = [
       { address: '0xaaa111', blockchains: ['Ethereum'] },
       { address: '0xbbb222', blockchains: ['Ethereum', 'Bitcoin'] },
@@ -725,35 +729,13 @@ describe('TransactionRefund address filtering', () => {
     mockGetTransactionByUid.mockResolvedValue(
       makeTx({ type: 'Sell', inputPaymentMethod: 'Crypto', inputBlockchain: 'Ethereum' }),
     );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    fireEvent.click(screen.getByTestId('address-trigger'));
-    const options = within(screen.getByTestId('address-options')).getAllByRole('button');
-    expect(options).toHaveLength(2);
-    expect(options[0]).toHaveTextContent(/0xaaa/);
-    expect(options[1]).toHaveTextContent(/0xbbb/);
-    expect(screen.getByTestId('address-option-desc-0')).toHaveTextContent(/Ethereum/);
-  });
-
-  it('auto-selects the only matching address via setValue when exactly one is allowed', async () => {
-    mockUserAddresses = [
-      { address: '0xonlymatch', blockchains: ['Bitcoin'] },
-      { address: '0xother', blockchains: ['Ethereum'] },
-    ];
-    mockGetTransactionByUid.mockResolvedValue(
-      makeTx({ type: 'Sell', inputPaymentMethod: 'Crypto', inputBlockchain: 'Bitcoin' }),
-    );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
-
-    renderRefund();
-    await waitForRefundFormLoaded();
-
-    await waitFor(() => {
-      expect(screen.getByTestId('address-trigger')).toHaveTextContent(/0xonlymatch/);
-    });
+    expect(screen.getByTestId('refundAddress')).toBeInTheDocument();
+    expect(screen.queryByTestId('address-dropdown')).not.toBeInTheDocument();
   });
 });
 
@@ -761,7 +743,7 @@ describe('TransactionRefund address filtering', () => {
 describe('TransactionRefund onSubmit', () => {
   it('submits a bank buy refund with form target, creditor data, house number, and navigates to /tx', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
     mockSetTransactionRefundTarget.mockResolvedValue(undefined);
 
     renderRefund();
@@ -774,7 +756,7 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalledWith(42, {
+      expect(mockSetGuestRefund).toHaveBeenCalledWith('T123', {
         refundTarget: BANK_IBAN_DE,
         creditorData: {
           name: 'Jane Doe',
@@ -785,13 +767,13 @@ describe('TransactionRefund onSubmit', () => {
           country: 'CH',
         },
       });
-      expect(mockNavigate).toHaveBeenCalledWith('/tx');
+      expect(mockNavigate).toHaveBeenCalledWith('/tx/T123');
     });
   });
 
   it('omits houseNumber when the house number field is left empty', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -803,15 +785,15 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalled();
+      expect(mockSetGuestRefund).toHaveBeenCalled();
     });
-    const payload = mockSetTransactionRefundTarget.mock.calls[0][1];
+    const payload = mockSetGuestRefund.mock.calls[0][1];
     expect(payload.creditorData.houseNumber).toBeUndefined();
   });
 
   it('uses bankDetails.name as refundName when refundTarget is fixed and bank name is present', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         refundTarget: BANK_IBAN_DE,
         bankDetails: {
@@ -846,7 +828,7 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalledWith(42, {
+      expect(mockSetGuestRefund).toHaveBeenCalledWith('T123', {
         refundTarget: undefined,
         creditorData: {
           name: 'Fixed Bank Name',
@@ -862,7 +844,7 @@ describe('TransactionRefund onSubmit', () => {
 
   it('falls back to creditorName when refundTarget is fixed but bankDetails.name is missing', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         refundTarget: BANK_IBAN_CH,
         bankDetails: { iban: BANK_IBAN_CH, bic: 'POFICHBE' },
@@ -881,16 +863,16 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalled();
+      expect(mockSetGuestRefund).toHaveBeenCalled();
     });
-    const payload = mockSetTransactionRefundTarget.mock.calls[0][1];
+    const payload = mockSetGuestRefund.mock.calls[0][1];
     expect(payload.refundTarget).toBeUndefined();
     expect(payload.creditorData.name).toBe('Fallback Name');
   });
 
   it('submits a card buy refund without refundTarget or creditorData', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Card', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -906,19 +888,15 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalledWith(42, {
+      expect(mockSetGuestRefund).toHaveBeenCalledWith('T123', {
         refundTarget: undefined,
         creditorData: undefined,
       });
-      expect(mockNavigate).toHaveBeenCalledWith('/tx');
+      expect(mockNavigate).toHaveBeenCalledWith('/tx/T123');
     });
   });
 
-  it('submits a crypto (non-buy) refund with the selected address as refundTarget', async () => {
-    mockUserAddresses = [
-      { address: '0xcrypto1', blockchains: ['Ethereum'] },
-      { address: '0xcrypto2', blockchains: ['Ethereum'] },
-    ];
+  it('submits a crypto (non-buy) refund with the typed address as refundTarget', async () => {
     mockGetTransactionByUid.mockResolvedValue(
       makeTx({
         type: 'Sell',
@@ -927,13 +905,13 @@ describe('TransactionRefund onSubmit', () => {
         state: 'Unassigned',
       }),
     );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
     expect(screen.getByRole('button', { name: 'Request refund' })).toBeInTheDocument();
-    selectDropdownOption('address', 1);
+    changeAndBlur('refundAddress', '0xcrypto2');
     await waitForSubmitEnabled('Request refund');
 
     await act(async () => {
@@ -941,18 +919,18 @@ describe('TransactionRefund onSubmit', () => {
     });
 
     await waitFor(() => {
-      expect(mockSetTransactionRefundTarget).toHaveBeenCalledWith(42, {
+      expect(mockSetGuestRefund).toHaveBeenCalledWith('T123', {
         refundTarget: '0xcrypto2',
         creditorData: undefined,
       });
-      expect(mockNavigate).toHaveBeenCalledWith('/tx');
+      expect(mockNavigate).toHaveBeenCalledWith('/tx/T123');
     });
   });
 
   it('keeps the form and sets localError when setTransactionRefundTarget fails with MultiAccountIban', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
-    mockSetTransactionRefundTarget.mockRejectedValue({
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockSetGuestRefund.mockRejectedValue({
       message: 'MultiAccountIban is not allowed here',
     });
 
@@ -978,8 +956,8 @@ describe('TransactionRefund onSubmit', () => {
 
   it('propagates non-MultiAccountIban submit errors via setError', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
-    mockSetTransactionRefundTarget.mockRejectedValue({ message: 'backend rejected refund' });
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockSetGuestRefund.mockRejectedValue({ message: 'backend rejected refund' });
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -998,8 +976,8 @@ describe('TransactionRefund onSubmit', () => {
 
   it('propagates "Unknown error" when submit rejects without a message', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
-    mockSetTransactionRefundTarget.mockRejectedValue({});
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockSetGuestRefund.mockRejectedValue({});
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1016,34 +994,17 @@ describe('TransactionRefund onSubmit', () => {
   });
 });
 
-// Lines 450-457: selectedIban === "Add bank account" renders AddBankAccount and writes IBAN back.
 describe('TransactionRefund add bank account branch', () => {
-  it('shows AddBankAccount when Add bank account is selected and writes the new IBAN into the form', async () => {
+  it('does not offer the logged-in add-bank-account dropdown on a T-uid refund', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    // bankAccounts (2) + "Add bank account" → option index 2
-    fireEvent.click(screen.getByTestId('iban-trigger'));
-    fireEvent.click(screen.getByTestId('iban-option-2'));
-
-    await waitFor(() => {
-      expect(screen.getByTestId('add-bank-account')).toBeInTheDocument();
-    });
-    expect(screen.getByTestId('add-bank-confirmation')).toHaveTextContent(
-      'The bank account has been added, all transactions from this IBAN will now be associated with your account.',
-    );
-    expect(screen.queryByText('Transaction amount')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId('add-bank-submit'));
-
-    await waitFor(() => {
-      expect(screen.queryByTestId('add-bank-account')).not.toBeInTheDocument();
-      expect(screen.getByText('Transaction amount')).toBeInTheDocument();
-    });
-    expect(screen.getByTestId('iban-trigger')).toHaveTextContent('LI21088110104928');
+    expect(screen.getByTestId('iban')).toBeInTheDocument();
+    expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('add-bank-account')).not.toBeInTheDocument();
   });
 });
 
@@ -1059,7 +1020,7 @@ describe('TransactionRefund rendered view', () => {
 
   it('shows the loading spinner after transaction loads while refund is still pending', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx());
-    mockGetTransactionRefund.mockReturnValue(neverResolves());
+    mockGetGuestRefund.mockReturnValue(neverResolves());
     renderRefund();
 
     await waitFor(() => {
@@ -1082,7 +1043,7 @@ describe('TransactionRefund rendered view', () => {
   });
 
   it('renders bankDetails name/address/city/country/iban/bic rows when those fields are set', async () => {
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         refundTarget: BANK_IBAN_DE,
         bankDetails: {
@@ -1110,7 +1071,7 @@ describe('TransactionRefund rendered view', () => {
   });
 
   it('hides bankDetails name/address/city/country/iban/bic rows when bankDetails is absent', async () => {
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ bankDetails: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ bankDetails: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1124,7 +1085,7 @@ describe('TransactionRefund rendered view', () => {
   });
 
   it('renders address row from houseNumber alone and city row from zip alone', async () => {
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         bankDetails: {
           houseNumber: '99',
@@ -1141,17 +1102,18 @@ describe('TransactionRefund rendered view', () => {
     expect(screen.queryByTestId('row-Name')).not.toBeInTheDocument();
   });
 
-  it('shows the address dropdown for crypto refunds without refundTarget and hides bank fields', async () => {
+  it('shows the free-text chargeback address for crypto refunds without refundTarget and hides bank fields', async () => {
     mockUserAddresses = [{ address: '0xsolo', blockchains: ['Ethereum'] }];
     mockGetTransactionByUid.mockResolvedValue(
       makeTx({ type: 'Sell', inputPaymentMethod: 'Crypto', inputBlockchain: 'Ethereum' }),
     );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    expect(screen.getByTestId('address-dropdown')).toBeInTheDocument();
+    expect(screen.getByTestId('refundAddress')).toBeInTheDocument();
+    expect(screen.queryByTestId('address-dropdown')).not.toBeInTheDocument();
     expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
     expect(screen.queryByTestId('creditorStreet')).not.toBeInTheDocument();
   });
@@ -1161,7 +1123,7 @@ describe('TransactionRefund rendered view', () => {
     mockGetTransactionByUid.mockResolvedValue(
       makeTx({ type: 'Sell', inputPaymentMethod: 'Crypto', inputBlockchain: 'Ethereum' }),
     );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: '0xfixed' }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: '0xfixed' }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1171,32 +1133,29 @@ describe('TransactionRefund rendered view', () => {
 
   // Earlier the dropdown was gated on inputBlockchain; without it the mocked Form never registered
   // the required-address rule, so the refund form could become valid without choosing an address.
-  it('renders address dropdown and keeps submit disabled when inputBlockchain is undefined', async () => {
+  it('renders free-text chargeback address and keeps submit disabled when inputBlockchain is undefined', async () => {
     mockUserAddresses = [{ address: '0xwouldmatch', blockchains: ['Ethereum'] }];
     mockGetTransactionByUid.mockResolvedValue(
       makeTx({ type: 'Sell', inputPaymentMethod: 'Crypto', inputBlockchain: undefined }),
     );
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    // Dropdown still mounts so the required rule is wired; filter yields no options without a chain.
-    expect(screen.getByTestId('address-dropdown')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('address-trigger'));
-    expect(within(screen.getByTestId('address-options')).queryAllByRole('button')).toHaveLength(0);
-
-    expect(screen.getByRole('button', { name: 'Confirm refund' })).toBeDisabled();
+    expect(screen.getByTestId('refundAddress')).toBeInTheDocument();
+    expect(screen.queryByTestId('address-dropdown')).not.toBeInTheDocument();
   });
 
-  it('shows IBAN dropdown and name field for bank buy without fixed refundTarget', async () => {
+  it('shows free-text IBAN and name field for bank buy without fixed refundTarget', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    expect(screen.getByTestId('iban-dropdown')).toBeInTheDocument();
+    expect(screen.getByTestId('iban')).toBeInTheDocument();
+    expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
     expect(screen.getByTestId('creditorName')).toBeInTheDocument();
     expect(screen.getByTestId('creditorStreet')).toBeInTheDocument();
     expect(screen.getByTestId('creditorCountry-search-dropdown')).toBeInTheDocument();
@@ -1219,7 +1178,7 @@ describe('TransactionRefund rendered view', () => {
   it('hides the IBAN dropdown when bankAccounts is empty/falsy for bank buy', async () => {
     mockBankAccounts = null as any;
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1232,7 +1191,7 @@ describe('TransactionRefund rendered view', () => {
 
   it('shows creditor name when bankDetails.name is set but refundTarget is missing (IBAN override)', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         refundTarget: undefined,
         bankDetails: { name: 'Only Name' },
@@ -1244,12 +1203,13 @@ describe('TransactionRefund rendered view', () => {
 
     expect(screen.getByTestId('row-Name')).toHaveTextContent('Only Name');
     expect(screen.getByTestId('creditorName')).toBeInTheDocument();
-    expect(screen.getByTestId('iban-dropdown')).toBeInTheDocument();
+    expect(screen.getByTestId('iban')).toBeInTheDocument();
+    expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
   });
 
   it('falls back to raw bankDetails.iban when Utils.formatIban returns a falsy value', async () => {
     jest.spyOn(Utils, 'formatIban').mockReturnValue(undefined as any);
-    mockGetTransactionRefund.mockResolvedValue(
+    mockGetGuestRefund.mockResolvedValue(
       makeRefund({
         refundTarget: BANK_IBAN_DE,
         bankDetails: {
@@ -1266,30 +1226,21 @@ describe('TransactionRefund rendered view', () => {
     expect(screen.getByTestId('row-IBAN')).toHaveTextContent(BANK_IBAN_DE);
   });
 
-  it('uses empty string for IBAN dropdown labels when Utils.formatIban returns falsy', async () => {
-    jest.spyOn(Utils, 'formatIban').mockImplementation((v: any) => {
-      if (v === BANK_IBAN_DE) return undefined as any;
-      return v;
-    });
+  it('uses a free-text IBAN field on a T-uid bank refund instead of the logged-in dropdown', async () => {
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
 
-    fireEvent.click(screen.getByTestId('iban-trigger'));
-    const options = within(screen.getByTestId('iban-options')).getAllByRole('button');
-    // DE is first bank account; formatIban falls back to '' for that option only, so the option
-    // carries no IBAN text at all (an empty-string matcher would pass against anything).
-    expect(options[0]).not.toHaveTextContent(BANK_IBAN_DE);
-    expect(options[1]).toHaveTextContent(BANK_IBAN_CH);
-    expect(options[2]).toHaveTextContent('Add bank account');
+    expect(screen.getByTestId('iban')).toBeInTheDocument();
+    expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
   });
 
   it('disables the country search dropdown for fewer than two countries', async () => {
     mockAllowedCountries = undefined as any;
     mockGetTransactionByUid.mockResolvedValue(makeTx({ type: 'Buy', inputPaymentMethod: 'Bank' }));
-    mockGetTransactionRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined, bankDetails: undefined }));
 
     renderRefund();
     await waitForRefundFormLoaded();
@@ -1313,7 +1264,7 @@ describe('TransactionRefund guest uid path', () => {
     mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: 'CH9300762011623852957' }));
     mockSetGuestRefund.mockResolvedValue(undefined);
 
-    renderRefund();
+    renderRefund('/tx/T123/refund');
     await waitForRefundFormLoaded();
 
     expect(mockGetGuestRefund).toHaveBeenCalledWith('T123');
@@ -1347,7 +1298,7 @@ describe('TransactionRefund guest uid path', () => {
     mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: undefined }));
     mockSetGuestRefund.mockResolvedValue(undefined);
 
-    renderRefund();
+    renderRefund('/tx/T123/refund');
     await waitForRefundFormLoaded();
 
     expect(screen.getByTestId('refundAddress')).toBeInTheDocument();
@@ -1366,5 +1317,33 @@ describe('TransactionRefund guest uid path', () => {
         expect.objectContaining({ refundTarget: '0xabc' }),
       );
     });
+  });
+
+  it('uses the guest hook on a T-uid route even when logged in', async () => {
+    mockIsLoggedIn = true;
+    mockGetTransactionByUid.mockResolvedValue(
+      makeTx({ uid: 'T123', type: 'Buy', inputPaymentMethod: 'Bank', state: 'Failed' }),
+    );
+    mockGetGuestRefund.mockResolvedValue(makeRefund({ refundTarget: 'CH9300762011623852957' }));
+    mockSetGuestRefund.mockResolvedValue(undefined);
+
+    renderRefund('/tx/T123/refund');
+    await waitForRefundFormLoaded();
+
+    expect(mockGetGuestRefund).toHaveBeenCalledWith('T123');
+    expect(mockGetTransactionRefund).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('iban-dropdown')).not.toBeInTheDocument();
+
+    await fillBankCreditorFields();
+    await waitForSubmitEnabled('Confirm refund');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm refund' }));
+    });
+
+    await waitFor(() => {
+      expect(mockSetGuestRefund).toHaveBeenCalled();
+    });
+    expect(mockSetTransactionRefundTarget).not.toHaveBeenCalled();
   });
 });

--- a/src/screens/support-issue.screen.tsx
+++ b/src/screens/support-issue.screen.tsx
@@ -234,8 +234,8 @@ export default function SupportIssueScreen(): JSX.Element {
   }, [orderParam]);
 
   useEffect(() => {
-    if (orderParam && isLoggedIn) logout();
-  }, [orderParam, isLoggedIn]);
+    if ((orderParam || txParam) && isLoggedIn) logout();
+  }, [orderParam, txParam, isLoggedIn]);
 
   useEffect(() => {
     if (orderParam && !isLoading && existingIssue) {

--- a/src/screens/transaction.screen.tsx
+++ b/src/screens/transaction.screen.tsx
@@ -339,6 +339,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
   const [localError, setLocalError] = useState<string>();
 
   const isBuy = transaction?.type === TransactionType.BUY;
+  const useGuestRefund = isUid || !isLoggedIn;
 
   const {
     control,
@@ -359,8 +360,11 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
 
   useEffect(() => {
     async function fetchRefund() {
-      const request =
-        isLoggedIn && transaction?.id ? getTransactionRefund(transaction.id) : id ? getRefund(id) : undefined;
+      const request = useGuestRefund && id
+        ? getRefund(id)
+        : transaction?.id
+          ? getTransactionRefund(transaction.id)
+          : undefined;
       if (!request) return;
 
       request
@@ -375,7 +379,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
         .catch((error: ApiError) => setError(error.message ?? 'Unknown error'));
     }
 
-    if (transaction && (isLoggedIn ? transaction.id != null : isUid)) fetchRefund();
+    if (transaction && (useGuestRefund ? isUid : transaction.id != null)) fetchRefund();
 
     return () => {
       if (refetchTimeout.current) clearTimeout(refetchTimeout.current);
@@ -400,8 +404,8 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
   // - iban/creditorName: only required for bank refunds if not already fixed from bankTx
   // - creditorStreet/zip/city/country: only required for bank refunds
   const rules = Utils.createRules({
-    address: !isBuy && isLoggedIn ? Validations.Required : undefined,
-    refundAddress: !isBuy && !isLoggedIn && !refundDetails?.refundTarget ? Validations.Required : undefined,
+    address: !isBuy && !useGuestRefund ? Validations.Required : undefined,
+    refundAddress: !isBuy && useGuestRefund && !refundDetails?.refundTarget ? Validations.Required : undefined,
     iban: !isBankRefund || refundDetails?.refundTarget ? undefined : Validations.Required,
     creditorName:
       !isBankRefund || (refundDetails?.bankDetails?.name?.trim() && refundDetails?.refundTarget)
@@ -421,7 +425,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
     setLocalError(undefined);
 
     try {
-      const formTarget = isBuy ? (data.iban ?? '') : isLoggedIn ? data.address?.address : data.refundAddress;
+      const formTarget = isBuy ? (data.iban ?? '') : useGuestRefund ? data.refundAddress : data.address?.address;
 
       const refundName = !refundDetails?.refundTarget
         ? data.creditorName
@@ -441,12 +445,12 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
           : undefined,
       };
 
-      if (isLoggedIn && submittedId != null) {
-        await setTransactionRefundTarget(submittedId, payload);
-        navigate('/tx');
-      } else if (id) {
+      if (useGuestRefund && id) {
         await setRefund(id, payload);
         navigate(`/tx/${id}`);
+      } else if (submittedId != null) {
+        await setTransactionRefundTarget(submittedId, payload);
+        navigate('/tx');
       }
     } catch (e) {
       const error = e as ApiError;
@@ -471,7 +475,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
         'The bank account has been added, all transactions from this IBAN will now be associated with your account.',
       )}
     />
-  ) : refundDetails && transaction && (isLoggedIn ? transactionId != null : isUid) ? (
+  ) : refundDetails && transaction && (useGuestRefund ? isUid : transactionId != null) ? (
     <StyledVerticalStack gap={6} full>
       <StyledDataTable alignContent={AlignContent.RIGHT} showBorder minWidth={false}>
         <StyledDataTableRow label={translate('screens/payment', 'Transaction amount')}>
@@ -537,7 +541,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
       </StyledDataTable>
       <Form control={control} rules={rules} errors={errors}>
         <StyledVerticalStack gap={6} full>
-          {!refundDetails.refundTarget && isLoggedIn && addresses && !isBuy && (
+          {!refundDetails.refundTarget && !useGuestRefund && addresses && !isBuy && (
             <StyledDropdown<UserAddress>
               name="address"
               rootRef={rootRef}
@@ -548,7 +552,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
               full
             />
           )}
-          {!refundDetails.refundTarget && !isBuy && !isLoggedIn && (
+          {!refundDetails.refundTarget && !isBuy && useGuestRefund && (
             <StyledInput
               name="refundAddress"
               label={translate('screens/payment', 'Chargeback address')}
@@ -559,7 +563,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
           {transaction.inputPaymentMethod !== FiatPaymentMethod.CARD && isBuy && (
             <>
               {/* IBAN selection only when no fixed refundTarget */}
-              {!refundDetails.refundTarget && isLoggedIn && bankAccounts && (
+              {!refundDetails.refundTarget && !useGuestRefund && bankAccounts && (
                 <StyledDropdown<string>
                   rootRef={rootRef}
                   name="iban"
@@ -574,7 +578,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
                   full
                 />
               )}
-              {!refundDetails.refundTarget && !(isLoggedIn && bankAccounts) && (
+              {!refundDetails.refundTarget && (useGuestRefund || !bankAccounts) && (
                 <StyledInput
                   name="iban"
                   autocomplete="iban"


### PR DESCRIPTION
EN:
Lands the review fixes onto the in-repo branch of #1399 so full-stack E2E can run there. After this is merged into that branch, #1399 is the PR to keep.

DE:
Bringt die Review-Fixes auf den In-Repo-Branch von #1399, damit Full-stack E2E dort laufen kann. Nach dem Merge in diesen Branch bleibt #1399 der PR.

<details>
<summary>Details</summary>

Changes:
- T/Q refund always uses the guest API and the free-text form, including when a session is already open
- Support `?tx=` clears a logged-in session the same way quote deep-links do
- Unit tests follow that guest path; unused lint and a spinner-stuck list suite are fixed

This pull request only exists because this account cannot push to `DFXswiss:fix/tx-uid-guest-actions`. Merge it into that branch (do not merge into develop).

</details>