### PR TITLE
da8cdc19 - Fix hardcoded services.dfx.swiss link in test mock

### DIFF
--- a/src/__tests__/open-crypto-pay.test.ts
+++ b/src/__tests__/open-crypto-pay.test.ts
@@ -15,7 +15,7 @@ jest.mock('../util/utils', () => {
   const originalModule = jest.requireActual('../util/utils');
   return {
     ...originalModule,
-    url: ({ base = 'https://services.dfx.swiss', path = '', params }: { base?: string; path?: string; params?: URLSearchParams }) => {
+    url: ({ base = 'https://app.dfx.swiss', path = '', params }: { base?: string; path?: string; params?: URLSearchParams }) => {
       const normalizedBase = base?.replace(/\/+$/, '') + '/';
       const normalizedPath = path.replace(/^\/+/, '');
       const absoluteUrl = new URL(normalizedPath, normalizedBase);


### PR DESCRIPTION
EN:
Part of DFXswiss/api#5021: replace hardcoded `services.dfx.swiss` links with `app.dfx.swiss` across the frontend repos. A full-repo search of this repo found exactly one hardcoded occurrence; it is fixed here.

DE:
Teil von DFXswiss/api#5021: hartcodierte `services.dfx.swiss`-Links durch `app.dfx.swiss` ersetzen. Eine vollständige Repo-Suche ergab genau einen Treffer; er ist hiermit behoben.

<details>
<summary>Details</summary>

## Search

Searched the full repository (all text files, excluding `node_modules`/`dist`/`build`/`.next`) for `services.dfx.swiss`, `services-dev.`, and `dev.services.` (and case-insensitive variants). Exactly one hit:

- `src/__tests__/open-crypto-pay.test.ts:18` — a Jest mock of the `url` utility used a stale default `base` value of `'https://services.dfx.swiss'`.

No other occurrences exist in this repo. All other matches for the substring `services` are the `dfx-services` product/component name (the widget custom element, Docker image tags, the `x-client` header value) — not this domain, and out of scope for this issue.

## Fix

Changed the default value to `'https://app.dfx.swiss'`. `app.dfx.swiss` (not the `dev.` variant) is correct here: this mock has no environment awareness (it exists "to avoid env dependency", per the comment above it), matching how other unit tests in this repo reference the prod placeholder domain; `dev.app.dfx.swiss` only appears in this repo's E2E specs and dev build scripts, where an actual environment target is meant.

This default *is* exercised at runtime — `OpenCryptoPayUtils.getOcpUrlByUniqueId` builds the inner API URL with an explicit `base`, but the outer LNURL-wrapping step (`Lnurl.prependLnurl` → `url({ path: 'pl', params })`) calls the same mocked `url` without a `base`, so the changed default does land in the returned string on every test run. None of the assertions in the file's 5 tests pin that specific host value, so the change doesn't alter what the tests check — but the default is not dead code, and no test breaks either way.

Coverage: `src/__tests__/open-crypto-pay.test.ts` is a test file, not part of the code under test, so Jest doesn't produce statement/branch coverage for it — running `--collectCoverageFrom` scoped to this file confirms Jest emits no coverage entries for it at all. There's no per-file number to report for a file this rule doesn't apply to.

## Out of scope

Per the issue, `Config.frontend.services` / the `SERVICES_URL` env var (API-side) is a deploy/config concern, not duplicated here. `DFXswiss/app` does not exist as a repo, so it is not covered by this PR or by DFXswiss/packages (searched separately — no hardcoded occurrences found there, no PR needed).

## Local verification

- `CI=true npm test -- --watchAll=false --testPathPattern=open-crypto-pay` — 5/5 passed
- `npm run lint` — clean
- `npm run build:dev` — succeeded
- `npm run widget:dev` — succeeded
- `npm run format:md:check` — clean

</details>

