### PR TITLE
01a010cb - Set account email before the support form

### DIFF
--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -116,6 +116,11 @@ run does not prove for each one; the taxonomy and cross-repository entries live 
   `CollectionAccountInvoicePersonalIbanMissing` error token, so a green run proves that the screen
   displays that token, not that the API emits it for this request. A unit test against the message
   mapping pins the token contract instead.
+- **The support-issue receiver-IBAN spec pins KYC level and account mail on GET /v2/user.**
+  `e2e/support-issue-receiver-iban.spec.ts` rewrites that response so `kyc.level` is high enough for
+  the screen guard and `mail` is present if the cached wallet session has none. A green visual run
+  therefore does not prove the mail-first redirect, nor that the account actually has mail or a
+  completed KYC level.
 
 ## Known gaps
 

--- a/e2e/support-issue-receiver-iban.spec.ts
+++ b/e2e/support-issue-receiver-iban.spec.ts
@@ -17,13 +17,13 @@ import { getCachedAuth } from './helpers/auth-cache';
  * Two endpoints are MOCKED with synthetic or rewritten responses via page.route(...):
  * PUT bank/receiveIban (full URL /v1/bank/receiveIban after useApi) is intercepted with synthetic
  * status responses so each of the tested check states is reproducible on demand; GET /v2/user is
- * intercepted as a second, side-effect-free exception that pins kyc.level in the response body
- * to a fixed value so the screen-level KYC guard passes (see KYC note below). Everything else
- * (auth/user/settings/…) is passed through via route.continue() to the local running stack.
+ * intercepted as a second, side-effect-free exception that pins kyc.level and, if missing, mail
+ * so the KYC guard and the mail-first gate both let the form render (see KYC note below). Everything
+ * else (auth/user/settings/…) is passed through via route.continue() to the local running stack.
  *
  * Intercepted endpoints:
  *   - PUT bank/receiveIban (base `/v1/` is prepended by useApi)   body { iban }; success body { status: ReceiveIbanStatus }
- *   - GET /v2/user   response rewritten to pin kyc.level to a fixed value so the screen's KYC guard passes
+ *   - GET /v2/user   response rewritten to pin kyc.level and, if absent, mail so the KYC guard and mail gate pass
  *
  * Synthetic fixtures: fixed example IBAN string.
  *
@@ -111,7 +111,7 @@ async function installReceiveIbanRoutes(
 
     await route.fulfill({
       response,
-      json: { ...user, kyc: { ...user.kyc, level: GUARD_KYC_LEVEL } },
+      json: { ...user, kyc: { ...user.kyc, level: GUARD_KYC_LEVEL }, mail: user.mail || 'visual-e2e@example.com' },
     });
   });
 }

--- a/scripts/handbook/metadata.json
+++ b/scripts/handbook/metadata.json
@@ -143,6 +143,10 @@
     "title": "Trading-Flows",
     "description": "Trading-bezogene End-to-End-Flows."
   },
+  "support-issue-receiver-iban": {
+    "title": "Support-Ticket Formular",
+    "description": "Kunden-Supportformular: Empfänger-IBAN-Check; Ticket erst nach gesetzter Konto-Mail."
+  },
   "support-dashboard": {
     "title": "Support-Dashboard",
     "description": "Support-Dashboard: Übersicht und Detailansichten."

--- a/src/__tests__/edit-mail-return.test.tsx
+++ b/src/__tests__/edit-mail-return.test.tsx
@@ -1,0 +1,243 @@
+// Component-level: EditMailScreen captures redirectPath into session store, consumes it on
+// capture, and abandons it on Cancel / Merge-OK so a remount cannot rehydrate a stale origin.
+
+const mockUpdateMail = jest.fn();
+const mockVerifyMail = jest.fn();
+const mockRedirectPath = jest.fn();
+const mockSetRedirectPath = jest.fn();
+const mockNavigate = jest.fn();
+const mockHandleMergedError = jest.fn(() => false);
+
+jest.mock('@dfx.swiss/react', () => ({
+  Utils: { createRules: () => ({}) },
+  Validations: { Required: undefined, Mail: undefined },
+  TfaLevel: { BASIC: 'Basic' },
+  useUserContext: () => ({
+    user: { mail: 'old@example.com' },
+    updateMail: mockUpdateMail,
+    verifyMail: mockVerifyMail,
+  }),
+  useKyc: () => ({ check2fa: () => Promise.resolve() }),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  Form: ({ children }: any) => <div>{children}</div>,
+  StyledButton: ({ label, onClick, type }: any) => (
+    <button type={type || 'button'} onClick={onClick}>
+      {label}
+    </button>
+  ),
+  StyledButtonWidth: { MIN: 'min' },
+  StyledInput: () => null,
+  StyledVerticalStack: ({ children }: any) => <div>{children}</div>,
+  StyledLoadingSpinner: () => null,
+  SpinnerSize: { LG: 'lg' },
+}));
+
+jest.mock('src/contexts/app-handling.context', () => ({
+  useAppHandlingContext: () => ({
+    redirectPath: mockRedirectPath(),
+    setRedirectPath: mockSetRedirectPath,
+  }),
+}));
+
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({
+    translate: (_ns: string, key: string) => key,
+    translateError: (key: string) => key,
+  }),
+}));
+
+jest.mock('src/hooks/layout-config.hook', () => ({
+  useLayoutOptions: () => undefined,
+}));
+
+jest.mock('src/hooks/navigation.hook', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('src/hooks/merged-account.hook', () => ({
+  useMergedAccount: () => ({ handleMergedError: mockHandleMergedError }),
+}));
+
+jest.mock('src/components/overlay/edit-overlay', () => ({
+  EditOverlay: ({ onCancel, onEdit }: any) => (
+    <div>
+      <button type="button" onClick={onCancel}>
+        Cancel
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void onEdit('new@example.com');
+        }}
+      >
+        Save
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('src/components/error-hint', () => ({
+  ErrorHint: ({ message }: { message: string }) => <div data-testid="error-hint">{message}</div>,
+}));
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import EditMailScreen from 'src/screens/edit-mail.screen';
+
+const STORE_KEY = 'dfx.editMailReturn';
+
+describe('EditMailScreen return path', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    mockRedirectPath.mockReturnValue(undefined);
+    mockUpdateMail.mockResolvedValue(undefined);
+    mockVerifyMail.mockResolvedValue(undefined);
+    mockHandleMergedError.mockReturnValue(false);
+  });
+
+  it('writes a valid redirectPath into the session store and consumes it', async () => {
+    mockRedirectPath.mockReturnValue('/support/issue');
+
+    render(<EditMailScreen />);
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem(STORE_KEY)).toBe('/support/issue');
+    });
+    expect(mockSetRedirectPath).toHaveBeenCalledWith(undefined);
+  });
+
+  it('does not write redirectPath when it is /account/mail', async () => {
+    mockRedirectPath.mockReturnValue('/account/mail');
+
+    render(<EditMailScreen />);
+
+    await screen.findByRole('button', { name: 'Cancel' });
+    expect(sessionStorage.getItem(STORE_KEY)).toBeNull();
+    expect(mockSetRedirectPath).not.toHaveBeenCalled();
+  });
+
+  it('clears store and redirectPath on Cancel and navigates to /account', async () => {
+    mockRedirectPath.mockReturnValue('/support/issue');
+
+    render(<EditMailScreen />);
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem(STORE_KEY)).toBe('/support/issue');
+    });
+
+    await act(async () => {
+      (await screen.findByRole('button', { name: 'Cancel' })).click();
+    });
+
+    expect(sessionStorage.getItem(STORE_KEY)).toBeNull();
+    expect(mockSetRedirectPath).toHaveBeenCalledWith(undefined);
+    expect(mockNavigate).toHaveBeenCalledWith('/account');
+  });
+
+  it('navigates to the stored path after successful verify and clears the store', async () => {
+    sessionStorage.setItem(STORE_KEY, '/support/issue');
+    mockUpdateMail.mockResolvedValue(undefined);
+    mockVerifyMail.mockResolvedValue(undefined);
+
+    render(<EditMailScreen />);
+    const save = await screen.findByRole('button', { name: 'Save' });
+
+    await act(async () => {
+      save.click();
+    });
+
+    await act(async () => {
+      (await screen.findByRole('button', { name: 'Next' })).click();
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/support/issue');
+    });
+    expect(sessionStorage.getItem(STORE_KEY)).toBeNull();
+  });
+
+  it('clears store and redirectPath when updateMail is a handled merge-401', async () => {
+    sessionStorage.setItem(STORE_KEY, '/support/issue');
+    mockHandleMergedError.mockReturnValue(true);
+    mockUpdateMail.mockRejectedValue({ statusCode: 401, message: 'unauthorized' });
+
+    render(<EditMailScreen />);
+    const save = await screen.findByRole('button', { name: 'Save' });
+
+    await act(async () => {
+      save.click();
+    });
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem(STORE_KEY)).toBeNull();
+    });
+    expect(mockSetRedirectPath).toHaveBeenCalledWith(undefined);
+    expect(mockNavigate).not.toHaveBeenCalledWith('/account');
+  });
+
+  it('clears store and redirectPath when verifyMail is a handled merge-401', async () => {
+    sessionStorage.setItem(STORE_KEY, '/support/issue');
+    mockVerifyMail.mockRejectedValue({ statusCode: 401, message: 'unauthorized' });
+
+    render(<EditMailScreen />);
+    const save = await screen.findByRole('button', { name: 'Save' });
+
+    await act(async () => {
+      save.click();
+    });
+
+    mockHandleMergedError.mockReturnValue(true);
+
+    await act(async () => {
+      (await screen.findByRole('button', { name: 'Next' })).click();
+    });
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem(STORE_KEY)).toBeNull();
+    });
+    expect(mockSetRedirectPath).toHaveBeenCalledWith(undefined);
+  });
+
+  it('navigates to /account after verify when no return path is stored', async () => {
+    mockUpdateMail.mockResolvedValue(undefined);
+    mockVerifyMail.mockResolvedValue(undefined);
+
+    render(<EditMailScreen />);
+    const save = await screen.findByRole('button', { name: 'Save' });
+
+    await act(async () => {
+      save.click();
+    });
+
+    await act(async () => {
+      (await screen.findByRole('button', { name: 'Next' })).click();
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/account');
+    });
+    expect(sessionStorage.getItem(STORE_KEY)).toBeNull();
+  });
+
+  it('clears store and redirectPath on Merge-OK and navigates to /account', async () => {
+    sessionStorage.setItem(STORE_KEY, '/support/issue');
+    mockUpdateMail.mockRejectedValue({ statusCode: 409, message: 'exists merge' });
+
+    render(<EditMailScreen />);
+    const save = await screen.findByRole('button', { name: 'Save' });
+
+    await act(async () => {
+      save.click();
+    });
+
+    await act(async () => {
+      (await screen.findByRole('button', { name: 'OK' })).click();
+    });
+
+    expect(sessionStorage.getItem(STORE_KEY)).toBeNull();
+    expect(mockSetRedirectPath).toHaveBeenCalledWith(undefined);
+    expect(mockNavigate).toHaveBeenCalledWith('/account');
+  });
+});

--- a/src/__tests__/session-store.test.tsx
+++ b/src/__tests__/session-store.test.tsx
@@ -1,0 +1,153 @@
+import { renderHook, act } from '@testing-library/react';
+import { useSessionStore } from '../hooks/session-store.hook';
+
+// Mock sessionStorage
+const sessionStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock });
+
+describe('useSessionStore', () => {
+  beforeEach(() => {
+    sessionStorageMock.clear();
+  });
+
+  describe('supportIssueUid', () => {
+    it('should return undefined when not set', () => {
+      const { result } = renderHook(() => useSessionStore());
+      expect(result.current.supportIssueUid.get()).toBeUndefined();
+    });
+
+    it('should set and get supportIssueUid', () => {
+      const { result } = renderHook(() => useSessionStore());
+
+      act(() => {
+        result.current.supportIssueUid.set('issue-uid-123');
+      });
+
+      expect(result.current.supportIssueUid.get()).toBe('issue-uid-123');
+    });
+
+    it('should remove supportIssueUid', () => {
+      const { result } = renderHook(() => useSessionStore());
+
+      act(() => {
+        result.current.supportIssueUid.set('issue-uid-123');
+        result.current.supportIssueUid.remove();
+      });
+
+      expect(result.current.supportIssueUid.get()).toBeUndefined();
+    });
+  });
+
+  describe('paymentLinkApiUrlStore', () => {
+    it('should return undefined when not set', () => {
+      const { result } = renderHook(() => useSessionStore());
+      expect(result.current.paymentLinkApiUrlStore.get()).toBeUndefined();
+    });
+
+    it('should set and get paymentLinkApiUrlStore', () => {
+      const { result } = renderHook(() => useSessionStore());
+
+      act(() => {
+        result.current.paymentLinkApiUrlStore.set('https://api.example.com/payment');
+      });
+
+      expect(result.current.paymentLinkApiUrlStore.get()).toBe('https://api.example.com/payment');
+    });
+
+    it('should remove paymentLinkApiUrlStore', () => {
+      const { result } = renderHook(() => useSessionStore());
+
+      act(() => {
+        result.current.paymentLinkApiUrlStore.set('https://api.example.com/payment');
+        result.current.paymentLinkApiUrlStore.remove();
+      });
+
+      expect(result.current.paymentLinkApiUrlStore.get()).toBeUndefined();
+    });
+  });
+
+  describe('editMailReturn', () => {
+    it('should return undefined when not set', () => {
+      const { result } = renderHook(() => useSessionStore());
+      expect(result.current.editMailReturn.get()).toBeUndefined();
+    });
+
+    it('should set and get editMailReturn', () => {
+      const { result } = renderHook(() => useSessionStore());
+
+      act(() => {
+        result.current.editMailReturn.set('/account');
+      });
+
+      expect(result.current.editMailReturn.get()).toBe('/account');
+    });
+
+    it('should remove editMailReturn', () => {
+      const { result } = renderHook(() => useSessionStore());
+
+      act(() => {
+        result.current.editMailReturn.set('/account');
+        result.current.editMailReturn.remove();
+      });
+
+      expect(result.current.editMailReturn.get()).toBeUndefined();
+    });
+  });
+
+  describe('isolation', () => {
+    it('should not leak values between keys', () => {
+      const { result } = renderHook(() => useSessionStore());
+
+      act(() => {
+        result.current.supportIssueUid.set('uid-only');
+        result.current.paymentLinkApiUrlStore.set('https://api.example.com');
+        result.current.editMailReturn.set('/settings');
+      });
+
+      expect(result.current.supportIssueUid.get()).toBe('uid-only');
+      expect(result.current.paymentLinkApiUrlStore.get()).toBe('https://api.example.com');
+      expect(result.current.editMailReturn.get()).toBe('/settings');
+
+      act(() => {
+        result.current.paymentLinkApiUrlStore.remove();
+      });
+
+      expect(result.current.supportIssueUid.get()).toBe('uid-only');
+      expect(result.current.paymentLinkApiUrlStore.get()).toBeUndefined();
+      expect(result.current.editMailReturn.get()).toBe('/settings');
+    });
+  });
+
+  describe('persistence', () => {
+    it('should persist data across hook instances', () => {
+      const { result: result1 } = renderHook(() => useSessionStore());
+
+      act(() => {
+        result1.current.supportIssueUid.set('persisted-uid');
+        result1.current.paymentLinkApiUrlStore.set('https://persisted.example.com');
+        result1.current.editMailReturn.set('/persisted-path');
+      });
+
+      const { result: result2 } = renderHook(() => useSessionStore());
+
+      expect(result2.current.supportIssueUid.get()).toBe('persisted-uid');
+      expect(result2.current.paymentLinkApiUrlStore.get()).toBe('https://persisted.example.com');
+      expect(result2.current.editMailReturn.get()).toBe('/persisted-path');
+    });
+  });
+});

--- a/src/__tests__/support-issue-receiver-iban.test.tsx
+++ b/src/__tests__/support-issue-receiver-iban.test.tsx
@@ -13,6 +13,14 @@ const mockCreateSupportIssue = jest.fn();
 const mockNavigate = jest.fn();
 const mockClearParams = jest.fn();
 const mockTranslate = jest.fn((_ns: string, key: string) => key);
+const mockUseUserContext = jest.fn(() => ({
+  user: undefined as { mail?: string; kyc?: { level: number } } | undefined,
+  isUserLoading: false,
+}));
+const mockUseSessionContext = jest.fn(() => ({
+  isLoggedIn: false,
+  logout: jest.fn(),
+}));
 
 jest.mock('@dfx.swiss/react', () => {
   const SupportIssueType = {
@@ -70,7 +78,7 @@ jest.mock('@dfx.swiss/react', () => {
     formatIban: (iban: string) => iban,
   };
 
-  // Mirrors the screen's only three calls into the real Validations: Required returns a react-hook-form
+  // Mirrors the screen's calls into the real Validations: Required returns a react-hook-form
   // "required" rule with message 'required'; Custom wraps an arbitrary validator function as a
   // react-hook-form "validate" rule (the validator itself decides pass/fail per field); Iban fails
   // with a sentinel so that if the receiver field ever gained Validations.Iban, submission tests
@@ -102,14 +110,14 @@ jest.mock('@dfx.swiss/react', () => {
     Validations,
     useBank: () => ({ checkReceiveIban: mockCheckReceiveIban }),
     useBankAccountContext: () => ({ bankAccounts: undefined }),
-    useSessionContext: () => ({ isLoggedIn: false, logout: jest.fn() }),
+    useSessionContext: () => mockUseSessionContext(),
     useSupportChatContext: () => ({
       createSupportIssue: mockCreateSupportIssue,
-      loadSupportIssue: jest.fn(),
+      loadSupportIssue: jest.fn().mockResolvedValue(undefined),
       isLoading: false,
       supportIssue: undefined,
     }),
-    useUserContext: () => ({ user: undefined }),
+    useUserContext: () => mockUseUserContext(),
   };
 });
 
@@ -353,7 +361,7 @@ function renderScreen(search = MISSING_PATH) {
   const router = createMemoryRouter([{ path: '/support/issue', element: <SupportIssueScreen /> }], {
     initialEntries: [`/support/issue${search}`],
   });
-  return render(<RouterProvider router={router} />);
+  return { ...render(<RouterProvider router={router} />), router };
 }
 
 /**
@@ -438,6 +446,8 @@ describe('SupportIssueScreen receiver IBAN check', () => {
     jest.useFakeTimers();
     jest.clearAllMocks();
     mockTranslate.mockImplementation((_ns: string, key: string) => key);
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: false, logout: jest.fn() });
+    mockUseUserContext.mockReturnValue({ user: undefined });
     mockCheckReceiveIban.mockReset();
     mockCreateSupportIssue.mockReset();
     mockCreateSupportIssue.mockResolvedValue('issue-uid-1');
@@ -1011,5 +1021,113 @@ describe('SupportIssueScreen receiver IBAN check', () => {
     expect(screen.queryByText(HINTS[ReceiveIbanStatus.DFX_IBAN])).not.toBeInTheDocument();
     // Reason change only clears state; it must not start another check.
     expect(mockCheckReceiveIban).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SupportIssueScreen mail gate', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockTranslate.mockImplementation((_ns: string, key: string) => key);
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: false, logout: jest.fn() });
+    mockUseUserContext.mockReturnValue({ user: undefined });
+    mockCheckReceiveIban.mockReset();
+    mockCreateSupportIssue.mockReset();
+    mockCreateSupportIssue.mockResolvedValue('issue-uid-1');
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    jest.useRealTimers();
+  });
+
+  it('redirects logged-in users without mail to /account/mail and hides the form', () => {
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: true, logout: jest.fn() });
+    mockUseUserContext.mockReturnValue({ user: { mail: undefined, kyc: { level: 50 } }, isUserLoading: false });
+    renderScreen('');
+
+    expect(mockNavigate).toHaveBeenCalledWith('/account/mail', { setRedirect: true });
+    expect(screen.queryByText('Email address', { selector: 'label' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Next$/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('Issue type', { selector: 'label' })).not.toBeInTheDocument();
+    expect(mockCreateSupportIssue).not.toHaveBeenCalled();
+  });
+
+  it('keeps the form hidden and does not redirect while a logged-in user is still loading', () => {
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: true, logout: jest.fn() });
+    mockUseUserContext.mockReturnValue({ user: undefined, isUserLoading: true });
+    renderScreen('');
+
+    expect(mockNavigate).not.toHaveBeenCalledWith('/account/mail', expect.anything());
+    expect(screen.queryByText('Issue type', { selector: 'label' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Next$/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the form for logged-in users with mail and does not send mail on create', async () => {
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: true, logout: jest.fn() });
+    mockUseUserContext.mockReturnValue({ user: { mail: 'a@b.c', kyc: { level: 50 } }, isUserLoading: false });
+    mockCheckReceiveIban.mockResolvedValue({ status: ReceiveIbanStatus.DFX_IBAN });
+    renderScreen('');
+
+    expect(mockNavigate).not.toHaveBeenCalledWith('/account/mail', expect.anything());
+    expect(screen.queryByText('Email address', { selector: 'label' })).not.toBeInTheDocument();
+
+    selectTransactionMissingViaUi();
+    fillTransactionMissingForm(VALID_FORMATTED);
+    await advanceDebounce();
+    fireEvent.blur(getReceiverIbanInput());
+
+    expect(getNextButton()).not.toBeDisabled();
+    await act(async () => {
+      fireEvent.click(getNextButton());
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockCreateSupportIssue).toHaveBeenCalled();
+    const request = mockCreateSupportIssue.mock.calls[0][0];
+    expect(request.mail).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(request, 'mail')).toBe(false);
+  });
+
+  it('shows the form for logged-out users without redirect or email field', () => {
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: false, logout: jest.fn() });
+    mockUseUserContext.mockReturnValue({ user: undefined });
+    renderScreen('');
+
+    expect(mockNavigate).not.toHaveBeenCalledWith('/account/mail', expect.anything());
+    expect(screen.queryByText('Email address', { selector: 'label' })).not.toBeInTheDocument();
+    expect(screen.getByText('Issue type', { selector: 'label' })).toBeInTheDocument();
+  });
+
+  it('does not redirect logged-in users without mail to /account/mail on the guest/quote path', () => {
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: true, logout: jest.fn() });
+    mockUseUserContext.mockReturnValue({ user: { mail: undefined, kyc: { level: 50 } }, isUserLoading: false });
+    renderScreen('?quote=Qtest');
+
+    expect(mockNavigate).not.toHaveBeenCalledWith('/account/mail', expect.anything());
+    expect(screen.getByText('Issue type', { selector: 'label' })).toBeInTheDocument();
+  });
+
+  it('keeps the quote-path latch after the URL quote param is cleared on the same instance', async () => {
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: true, logout: jest.fn() });
+    mockUseUserContext.mockReturnValue({ user: { mail: undefined, kyc: { level: 50 } }, isUserLoading: false });
+    const { router } = renderScreen('?quote=Qtest');
+
+    expect(mockNavigate).not.toHaveBeenCalledWith('/account/mail', expect.anything());
+    expect(screen.getByText('Issue type', { selector: 'label' })).toBeInTheDocument();
+
+    await act(async () => {
+      await router.navigate('/support/issue');
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalledWith('/account/mail', expect.anything());
+    expect(screen.getByText('Issue type', { selector: 'label' })).toBeInTheDocument();
   });
 });

--- a/src/hooks/session-store.hook.ts
+++ b/src/hooks/session-store.hook.ts
@@ -7,11 +7,13 @@ export interface SessionStoreItem<T> {
 export interface SessionStoreInterface {
   supportIssueUid: SessionStoreItem<string>;
   paymentLinkApiUrlStore: SessionStoreItem<string>;
+  editMailReturn: SessionStoreItem<string>;
 }
 
 enum SessionStoreKey {
   SUPPORT_ISSUE_UID = 'dfx.supportIssueUid',
   PAYMENT_LINK_API_URL = 'dfx.paymentLinkApiUrl',
+  EDIT_MAIL_RETURN = 'dfx.editMailReturn',
 }
 
 export function useSessionStore(): SessionStoreInterface {
@@ -37,6 +39,11 @@ export function useSessionStore(): SessionStoreInterface {
       get: () => get(SessionStoreKey.PAYMENT_LINK_API_URL),
       set: (value: string) => set(SessionStoreKey.PAYMENT_LINK_API_URL, value),
       remove: () => remove(SessionStoreKey.PAYMENT_LINK_API_URL),
+    },
+    editMailReturn: {
+      get: () => get(SessionStoreKey.EDIT_MAIL_RETURN),
+      set: (value: string) => set(SessionStoreKey.EDIT_MAIL_RETURN, value),
+      remove: () => remove(SessionStoreKey.EDIT_MAIL_RETURN),
     },
   };
 }

--- a/src/screens/edit-mail.screen.tsx
+++ b/src/screens/edit-mail.screen.tsx
@@ -12,10 +12,12 @@ import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { ErrorHint } from 'src/components/error-hint';
 import { EditOverlay } from 'src/components/overlay/edit-overlay';
+import { useAppHandlingContext } from 'src/contexts/app-handling.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useMergedAccount } from 'src/hooks/merged-account.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
+import { useSessionStore } from 'src/hooks/session-store.hook';
 
 export default function EditMailScreen(): JSX.Element {
   const { translate, translateError } = useSettingsContext();
@@ -24,6 +26,8 @@ export default function EditMailScreen(): JSX.Element {
   const { handleMergedError } = useMergedAccount();
   const { user } = useUserContext();
   const { check2fa } = useKyc();
+  const { redirectPath, setRedirectPath } = useAppHandlingContext();
+  const { editMailReturn } = useSessionStore();
 
   const [checking2fa, setChecking2fa] = useState(true);
   const [mailVerificationStep, setMailVerificationStep] = useState(false);
@@ -38,6 +42,18 @@ export default function EditMailScreen(): JSX.Element {
       .finally(() => setChecking2fa(false));
   }, []);
 
+  function abandonMailReturn() {
+    editMailReturn.remove();
+    setRedirectPath(undefined);
+  }
+
+  useEffect(() => {
+    if (redirectPath && redirectPath !== '/account/mail') {
+      editMailReturn.set(redirectPath);
+      setRedirectPath(undefined);
+    }
+  }, [redirectPath]);
+
   const {
     control,
     handleSubmit,
@@ -51,7 +67,10 @@ export default function EditMailScreen(): JSX.Element {
     return updateMail(newEmail)
       .then(() => setMailVerificationStep(true))
       .catch((e: ApiError) => {
-        if (handleMergedError(e)) return;
+        if (handleMergedError(e)) {
+          abandonMailReturn();
+          return;
+        }
 
         if (e.statusCode === 409 && e.message?.includes('exists')) {
           if (e.message.includes('merge')) {
@@ -71,18 +90,29 @@ export default function EditMailScreen(): JSX.Element {
     setIsSubmitting(true);
 
     verifyMail(data.token)
-      .then(() => navigate('/account'))
-      .catch((e: ApiError) =>
-        handleMergedError(e)
-          ? undefined
-          : e.statusCode === 403
-          ? setTokenInvalid(true)
-          : e.statusCode === 409 && e.message?.includes('exists')
-          ? e.message.includes('merge')
-            ? setShowLinkHint(true)
-            : setError(e.message ?? 'Unknown error')
-          : setError(e.message ?? 'Unknown error'),
-      )
+      .then(() => {
+        const stored = editMailReturn.get();
+        editMailReturn.remove();
+        navigate(stored ?? '/account');
+      })
+      .catch((e: ApiError) => {
+        if (handleMergedError(e)) {
+          abandonMailReturn();
+          return;
+        }
+
+        if (e.statusCode === 403) {
+          setTokenInvalid(true);
+        } else if (e.statusCode === 409 && e.message?.includes('exists')) {
+          if (e.message.includes('merge')) {
+            setShowLinkHint(true);
+          } else {
+            setError(e.message ?? 'Unknown error');
+          }
+        } else {
+          setError(e.message ?? 'Unknown error');
+        }
+      })
       .finally(() => setIsSubmitting(false));
   }
 
@@ -106,7 +136,10 @@ export default function EditMailScreen(): JSX.Element {
           <StyledButton
             width={StyledButtonWidth.MIN}
             label={translate('general/actions', 'OK')}
-            onClick={() => navigate('/account')}
+            onClick={() => {
+              abandonMailReturn();
+              navigate('/account');
+            }}
           />
         </StyledVerticalStack>
       ) : checking2fa ? (
@@ -118,7 +151,10 @@ export default function EditMailScreen(): JSX.Element {
           prefill={user?.mail}
           placeholder={translate('screens/kyc', 'Email address')}
           validation={Validations.Mail}
-          onCancel={() => navigate('/account')}
+          onCancel={() => {
+            abandonMailReturn();
+            navigate('/account');
+          }}
           onEdit={onSubmit}
         />
       ) : (

--- a/src/screens/support-issue.screen.tsx
+++ b/src/screens/support-issue.screen.tsx
@@ -131,7 +131,7 @@ export default function SupportIssueScreen(): JSX.Element {
   const { navigate, clearParams } = useNavigation();
   const { rootRef } = useLayoutContext();
   const { translate, translateError, allowedCountries } = useSettingsContext();
-  const { user } = useUserContext();
+  const { user, isUserLoading } = useUserContext();
   const { isLoggedIn, logout } = useSessionContext();
   const { checkReceiveIban } = useBank();
   const { bankAccounts } = useBankAccountContext();
@@ -175,6 +175,9 @@ export default function SupportIssueScreen(): JSX.Element {
   const isRequestOnly = selectedTxState === TransactionState.WAITING_FOR_PAYMENT;
 
   const orderParam = urlParams.get('quote') ?? urlParams.get('order');
+  // Latch the guest/quote path on first render. clearParams drops quote/order from the URL
+  // before logout finishes, which would otherwise trip the mail gate mid-transition.
+  const isQuotePath = useRef(Boolean(orderParam)).current;
   const issueTypeParam = urlParams.get('issue-type');
   const reasonParam = urlParams.get('reason');
 
@@ -217,6 +220,12 @@ export default function SupportIssueScreen(): JSX.Element {
 
     setIsKycComplete(kycCompleted);
   }, [user, selectedType]);
+
+  useEffect(() => {
+    if (!isQuotePath && isLoggedIn && !isUserLoading && user && !user.mail) {
+      navigate('/account/mail', { setRedirect: true });
+    }
+  }, [isLoggedIn, isUserLoading, user, navigate, isQuotePath]);
 
   useEffect(() => {
     if (orderParam) {
@@ -419,7 +428,9 @@ export default function SupportIssueScreen(): JSX.Element {
 
   return (
     <>
-      {(selectedType === SupportIssueType.LIMIT_REQUEST && isKycComplete === undefined) || isIssueLoading ? (
+      {(selectedType === SupportIssueType.LIMIT_REQUEST && isKycComplete === undefined) ||
+      isIssueLoading ||
+      (!isQuotePath && isLoggedIn && (isUserLoading || !user || !user.mail)) ? (
         <StyledLoadingSpinner size={SpinnerSize.LG} />
       ) : selectTransaction ? (
         <>


### PR DESCRIPTION
EN:
A logged-in customer without account email is sent to the official mail screen before the support form. The ticket form no longer collects email. Cancel and merge-OK on the mail screen drop the stored return path so it cannot come back on a later visit. This replacement takes over DFXswiss/services#1397 onto current develop.

DE:
Ein eingeloggter Kunde ohne Konto-Mail wird vor dem Support-Formular auf die offizielle Mail-Seite geleitet. Das Ticket-Formular fragt keine Mail mehr ab. Abbruch und Merge-OK auf der Mail-Seite löschen den gespeicherten Rückweg, damit er bei einem späteren Besuch nicht wiederkehrt. Dieser Ersatz übernimmt DFXswiss/services#1397 auf den aktuellen develop.

<details>
<summary>Details</summary>

Takes over the still-draft in-repo PR #1397 (no write on the org branch). Head is rebased onto develop `6e2cc5b` (#1404) with no file overlap.

Logged-in users without `user.mail` are redirected to `/account/mail` with `setRedirect: true`. The origin is copied into session storage and `redirectPath` is consumed. After `verifyMail` the stored destination is restored. Cancel, merge-OK and a handled merge-401 clear both the store and `redirectPath`. The quote/order guest path is latched on first render so URL cleanup cannot trip the mail gate.

Declared deviations from CONTRIBUTING:
- Whole-file 100% coverage is not claimed for the pre-existing screens `src/screens/support-issue.screen.tsx` and `src/screens/edit-mail.screen.tsx`. New branches are covered by `src/__tests__/support-issue-receiver-iban.test.tsx`, `src/__tests__/edit-mail-return.test.tsx` and `src/__tests__/session-store.test.tsx`.
- No new Playwright baselines. The support-issue receiver-IBAN handbook screenshots already exist. The visual spec pins `user.mail` so the mail gate does not hide the form. The visible form for a user who already has mail is unchanged.
- No new full-stack e2e case for the mail-first redirect. Existing `e2e-stack/specs/support.spec.ts` still uses factory users that already have mail, so the create-ticket path stays green. The new gate is covered by unit tests.

Supersedes #1397.

</details>