### PR TITLE
01a010cd - Open invoice, receipt and buy-QR PDFs without a blocked popup

### DIFF
--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -121,10 +121,11 @@ run does not prove for each one; the taxonomy and cross-repository entries live 
   the screen guard and `mail` is present if the cached wallet session has none. A green visual run
   therefore does not prove the mail-first redirect, nor that the account actually has mail or a
   completed KYC level.
-- **The list Open-invoice tests fulfill the invoice PUT.** `e2e-stack/specs/transactions.spec.ts`
-  answers `PUT /v1/transaction/:uid/invoice` with a static PDF body or a `400` with a fixed message,
-  so a green run proves that the click reserves a tab and surfaces the error, not that the API can
-  build an invoice from SQL-seeded `buy_crypto`.
+- **The list Open-invoice and Open-receipt tests fulfill the document routes.**
+  `e2e-stack/specs/transactions.spec.ts` answers `PUT /v1/transaction/:uid/invoice` and
+  `/v1/transaction/:id/receipt` with a static PDF body or a `400` with a fixed message, so a green
+  run proves that the click reserves a tab and surfaces the error, not that the API can build an
+  invoice or receipt from SQL-seeded `buy_crypto`.
 
 ## Known gaps
 

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -121,6 +121,10 @@ run does not prove for each one; the taxonomy and cross-repository entries live 
   the screen guard and `mail` is present if the cached wallet session has none. A green visual run
   therefore does not prove the mail-first redirect, nor that the account actually has mail or a
   completed KYC level.
+- **The list Open-invoice tests fulfill the invoice PUT.** `e2e-stack/specs/transactions.spec.ts`
+  answers `PUT /v1/transaction/:uid/invoice` with a static PDF body or a `400` with a fixed message,
+  so a green run proves that the click reserves a tab and surfaces the error, not that the API can
+  build an invoice from SQL-seeded `buy_crypto`.
 
 ## Known gaps
 

--- a/e2e-stack/specs/transactions.spec.ts
+++ b/e2e-stack/specs/transactions.spec.ts
@@ -193,6 +193,12 @@ test('Open invoice is shown on a completed CHF buy and hidden on pending buy and
     amount: 701,
     inputAsset: 'CHF',
   });
+  const secondAsset = await queryOne<{ id: number }>(
+    `SELECT id FROM asset WHERE buyable = true AND blockchain != 'Ethereum' ORDER BY id ASC LIMIT 1`,
+  );
+  const secondBuy = await createBuy(user.jwt, {
+    assetId: required(secondAsset, 'seed must provide a buyable non-Ethereum asset').id,
+  });
   await createTransaction({
     state: 'pending_buy',
     tag: 'tx-inv-vis-pend',
@@ -201,6 +207,7 @@ test('Open invoice is shown on a completed CHF buy and hidden on pending buy and
     jwt: user.jwt,
     amount: 702,
     inputAsset: 'CHF',
+    buyId: secondBuy.buyId,
   });
   await createTransaction({
     state: 'pending_sell',

--- a/e2e-stack/specs/transactions.spec.ts
+++ b/e2e-stack/specs/transactions.spec.ts
@@ -173,6 +173,170 @@ test("transaction list does not show another user's transactions", async ({ page
   await expect(page.getByText('No transactions found', { exact: true })).toBeVisible();
 });
 
+// Minimal valid-looking PDF bytes as base64 for the fulfilled invoice PUT body.
+// The suite only needs the frontend to accept { pdfData }; it does not render the PDF.
+const MINIMAL_PDF_B64 = Buffer.from('%PDF-1.1\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF').toString('base64');
+
+test('Open invoice is shown on a completed CHF buy and hidden on pending buy and sell', async ({ page }) => {
+  const user = await createUser({
+    tag: 'tx-list-invoice-vis',
+    kycLevel: 30,
+    completePersonalData: true,
+  });
+
+  await createTransaction({
+    state: 'completed_buy',
+    tag: 'tx-inv-vis-done',
+    userId: user.userId,
+    userDataId: user.userDataId,
+    jwt: user.jwt,
+    amount: 701,
+    inputAsset: 'CHF',
+  });
+  await createTransaction({
+    state: 'pending_buy',
+    tag: 'tx-inv-vis-pend',
+    userId: user.userId,
+    userDataId: user.userDataId,
+    jwt: user.jwt,
+    amount: 702,
+    inputAsset: 'CHF',
+  });
+  await createTransaction({
+    state: 'pending_sell',
+    tag: 'tx-inv-vis-sell',
+    userId: user.userId,
+    userDataId: user.userDataId,
+    jwt: user.jwt,
+    amount: 703,
+  });
+
+  await openScreen(page, '/tx', user.jwt);
+
+  const completedRow = page
+    .locator('div.flex.flex-row.gap-2.items-center')
+    .filter({ hasText: '701' })
+    .filter({ hasText: 'CHF' })
+    .first();
+  const pendingBuyRow = page
+    .locator('div.flex.flex-row.gap-2.items-center')
+    .filter({ hasText: '702' })
+    .filter({ hasText: 'CHF' })
+    .first();
+  const sellRow = page
+    .locator('div.flex.flex-row.gap-2.items-center')
+    .filter({ hasText: '703' })
+    .filter({ hasText: 'ETH' })
+    .first();
+
+  // Expand completed buy → Open invoice must be available.
+  await completedRow.click();
+  await expect(page.getByRole('button', { name: 'Open invoice' })).toBeVisible();
+  // Collapse so pending/sell expanded content is the only place a button could appear.
+  await completedRow.click();
+
+  // Pending buy: no Open invoice.
+  await pendingBuyRow.click();
+  await expect(page.getByRole('button', { name: 'Open invoice' })).toHaveCount(0);
+  await pendingBuyRow.click();
+
+  // Sell: no Open invoice.
+  await sellRow.click();
+  await expect(page.getByRole('button', { name: 'Open invoice' })).toHaveCount(0);
+});
+
+test('Open invoice click opens a tab before the invoice PUT returns', async ({ page }) => {
+  const user = await createUser({
+    tag: 'tx-list-invoice-tab',
+    kycLevel: 30,
+    completePersonalData: true,
+  });
+  await createTransaction({
+    state: 'completed_buy',
+    tag: 'tx-inv-tab',
+    userId: user.userId,
+    userDataId: user.userDataId,
+    jwt: user.jwt,
+    amount: 711,
+    inputAsset: 'CHF',
+  });
+
+  await openScreen(page, '/tx', user.jwt);
+
+  // Delay the invoice PUT so a post-await window.open would miss the user gesture window.
+  // Old code (open after await) fails this 800ms popup wait against a 2000ms delayed response.
+  await page.route('**/v1/transaction/*/invoice', async (route) => {
+    await new Promise((r) => setTimeout(r, 2000));
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ pdfData: MINIMAL_PDF_B64 }),
+    });
+  });
+
+  const buyRow = page
+    .locator('div.flex.flex-row.gap-2.items-center')
+    .filter({ hasText: '711' })
+    .filter({ hasText: 'CHF' })
+    .first();
+  await buyRow.click();
+
+  const openInvoice = page.getByRole('button', { name: 'Open invoice' });
+  await expect(openInvoice).toBeVisible();
+
+  const popupPromise = page.waitForEvent('popup', { timeout: 800 });
+  await openInvoice.click();
+  const popup = await popupPromise;
+
+  expect(popup.url()).toMatch(/about:blank|blob:/);
+});
+
+test('Open invoice error closes the reserved tab and shows the API message', async ({ page }) => {
+  const user = await createUser({
+    tag: 'tx-list-invoice-err',
+    kycLevel: 30,
+    completePersonalData: true,
+  });
+  await createTransaction({
+    state: 'completed_buy',
+    tag: 'tx-inv-err',
+    userId: user.userId,
+    userDataId: user.userDataId,
+    jwt: user.jwt,
+    amount: 721,
+    inputAsset: 'CHF',
+  });
+
+  await openScreen(page, '/tx', user.jwt);
+
+  await page.route('**/v1/transaction/*/invoice', async (route) => {
+    await route.fulfill({
+      status: 400,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'Missing invoice information' }),
+    });
+  });
+
+  const buyRow = page
+    .locator('div.flex.flex-row.gap-2.items-center')
+    .filter({ hasText: '721' })
+    .filter({ hasText: 'CHF' })
+    .first();
+  await buyRow.click();
+
+  const openInvoice = page.getByRole('button', { name: 'Open invoice' });
+  await expect(openInvoice).toBeVisible();
+
+  const popupPromise = page.waitForEvent('popup');
+  await openInvoice.click();
+  const popup = await popupPromise;
+
+  // ErrorHint surfaces the API message (no data-testid on the real component).
+  await expect(page.getByText('Missing invoice information', { exact: true })).toBeVisible();
+  // Reserved tab is closed in the catch path (preview?.close()).
+  await expect.poll(() => popup.isClosed()).toBe(true);
+});
+
 // ---------------------------------------------------------------------------
 // /tx/:id — detail / status view (uid)
 // ---------------------------------------------------------------------------

--- a/e2e-stack/specs/transactions.spec.ts
+++ b/e2e-stack/specs/transactions.spec.ts
@@ -337,6 +337,96 @@ test('Open invoice error closes the reserved tab and shows the API message', asy
   await expect.poll(() => popup.isClosed()).toBe(true);
 });
 
+test('Open receipt click opens a tab before the receipt request returns', async ({ page }) => {
+  const user = await createUser({
+    tag: 'tx-list-receipt-tab',
+    kycLevel: 30,
+    completePersonalData: true,
+  });
+  await createTransaction({
+    state: 'completed_buy',
+    tag: 'tx-rcpt-tab',
+    userId: user.userId,
+    userDataId: user.userDataId,
+    jwt: user.jwt,
+    amount: 731,
+    inputAsset: 'CHF',
+  });
+
+  await openScreen(page, '/tx', user.jwt);
+
+  // Delay the receipt route so a post-await window.open would miss the user gesture window.
+  // Old code (open after await) fails this 800ms popup wait against a 2000ms delayed response.
+  await page.route('**/v1/transaction/*/receipt*', async (route) => {
+    await new Promise((r) => setTimeout(r, 2000));
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ pdfData: MINIMAL_PDF_B64 }),
+    });
+  });
+
+  const buyRow = page
+    .locator('div.flex.flex-row.gap-2.items-center')
+    .filter({ hasText: '731' })
+    .filter({ hasText: 'CHF' })
+    .first();
+  await buyRow.click();
+
+  const openReceipt = page.getByRole('button', { name: 'Open receipt' });
+  await expect(openReceipt).toBeVisible();
+
+  const popupPromise = page.waitForEvent('popup', { timeout: 800 });
+  await openReceipt.click();
+  const popup = await popupPromise;
+
+  expect(popup.url()).toMatch(/about:blank|blob:/);
+});
+
+test('Open receipt error closes the reserved tab and shows the API message', async ({ page }) => {
+  const user = await createUser({
+    tag: 'tx-list-receipt-err',
+    kycLevel: 30,
+    completePersonalData: true,
+  });
+  await createTransaction({
+    state: 'completed_buy',
+    tag: 'tx-rcpt-err',
+    userId: user.userId,
+    userDataId: user.userDataId,
+    jwt: user.jwt,
+    amount: 741,
+    inputAsset: 'CHF',
+  });
+
+  await openScreen(page, '/tx', user.jwt);
+
+  await page.route('**/v1/transaction/*/receipt*', async (route) => {
+    await route.fulfill({
+      status: 400,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'Missing receipt information' }),
+    });
+  });
+
+  const buyRow = page
+    .locator('div.flex.flex-row.gap-2.items-center')
+    .filter({ hasText: '741' })
+    .filter({ hasText: 'CHF' })
+    .first();
+  await buyRow.click();
+
+  const openReceipt = page.getByRole('button', { name: 'Open receipt' });
+  await expect(openReceipt).toBeVisible();
+
+  const popupPromise = page.waitForEvent('popup');
+  await openReceipt.click();
+  const popup = await popupPromise;
+
+  await expect(page.getByText('Missing receipt information', { exact: true })).toBeVisible();
+  await expect.poll(() => popup.isClosed()).toBe(true);
+});
+
 // ---------------------------------------------------------------------------
 // /tx/:id — detail / status view (uid)
 // ---------------------------------------------------------------------------

--- a/src/__tests__/payment-qr-code-error.test.tsx
+++ b/src/__tests__/payment-qr-code-error.test.tsx
@@ -297,6 +297,33 @@ describe('PaymentQrCode stale-response guard', () => {
     expect(button).toBeEnabled();
   });
 
+  it('closes the reserved preview and does not assign a PDF when the request goes stale', async () => {
+    const preview = { closed: false, close: jest.fn(), location: { href: '' } };
+    jest.spyOn(window, 'open').mockImplementation(() => preview as unknown as Window);
+    (global.URL as any).createObjectURL = jest.fn(() => 'blob:invoice');
+
+    const { rerender } = render(<PaymentQrCode value="BCD\n001" txId={42} collectionAccount />);
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: 'PDF Invoice' }));
+    });
+
+    await waitFor(() => {
+      expect(mockInvoiceFor).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(<PaymentQrCode value="BCD\n001" txId={42} />);
+
+    await act(async () => {
+      resolveInvoice({ pdfData: 'JVBERi0x' });
+    });
+
+    expect(preview.close).toHaveBeenCalled();
+    expect(preview.location.href).toBe('');
+    expect(mockOpenPdf).not.toHaveBeenCalled();
+    expect((global.URL as any).createObjectURL).not.toHaveBeenCalled();
+  });
+
   it('does not show an error when the collection mode changes while a failing request is in flight', async () => {
     let rejectInvoice: (reason: unknown) => void;
     mockInvoiceFor.mockImplementation(

--- a/src/__tests__/payment-qr-code-error.test.tsx
+++ b/src/__tests__/payment-qr-code-error.test.tsx
@@ -45,11 +45,23 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PaymentQrCode } from '../components/payment/payment-qr-code';
 
+const originalCreateObjectURL = (global.URL as any).createObjectURL;
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockInvoiceFor.mockResolvedValue({ pdfData: 'JVBERi0x' });
   mockUser = { accountId: 1, kyc: { dataComplete: true } };
   mockSession = { account: 1, user: 1 };
+  jest.spyOn(window, 'open').mockImplementation(() => null);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  if (originalCreateObjectURL) {
+    (global.URL as any).createObjectURL = originalCreateObjectURL;
+  } else {
+    delete (global.URL as any).createObjectURL;
+  }
 });
 
 const NO_COLLECTION_QR_HINT =
@@ -69,6 +81,7 @@ describe('PaymentQrCode incomplete KYC', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/profile', { setRedirect: true });
     expect(mockInvoiceFor).not.toHaveBeenCalled();
     expect(mockOpenPdf).not.toHaveBeenCalled();
+    expect(window.open).not.toHaveBeenCalled();
   });
 });
 
@@ -94,9 +107,10 @@ describe('PaymentQrCode missing value', () => {
     expect(mockInvoiceFor).toHaveBeenCalledWith(42, true);
 
     await waitFor(() => {
+      expect(window.open).toHaveBeenCalledWith('about:blank');
       expect(mockOpenPdf).toHaveBeenCalledTimes(1);
     });
-    expect(mockOpenPdf).toHaveBeenCalledWith('JVBERi0x');
+    expect(mockOpenPdf).toHaveBeenCalledWith('JVBERi0x', false);
   });
 });
 
@@ -129,6 +143,45 @@ describe('PaymentQrCode invoice errors', () => {
       expect(screen.getByText('Invoice service is unavailable')).toBeVisible();
     });
     expect(screen.queryByText('Unknown error')).not.toBeInTheDocument();
+  });
+
+  it('closes the reserved preview when invoice generation rejects', async () => {
+    const preview = { closed: false, close: jest.fn(), location: { href: '' } };
+    jest.spyOn(window, 'open').mockImplementation(() => preview as unknown as Window);
+    mockInvoiceFor.mockRejectedValue({ message: 'Invoice service is unavailable' });
+
+    render(<PaymentQrCode value="<svg>QR bill</svg>" txId={42} />);
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: 'PDF Invoice' }));
+    });
+
+    await waitFor(() => {
+      expect(preview.close).toHaveBeenCalled();
+      expect(screen.getByText('Invoice service is unavailable')).toBeVisible();
+    });
+    expect(mockOpenPdf).not.toHaveBeenCalled();
+  });
+});
+
+describe('PaymentQrCode reserved preview success', () => {
+  it('assigns the PDF via the reserved window when window.open returns a live preview', async () => {
+    const preview = { closed: false, close: jest.fn(), location: { href: '' } };
+    jest.spyOn(window, 'open').mockImplementation(() => preview as unknown as Window);
+    (global.URL as any).createObjectURL = jest.fn(() => 'blob:invoice');
+
+    render(<PaymentQrCode value="BCD\n001" txId={42} />);
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: 'PDF Invoice' }));
+    });
+
+    await waitFor(() => {
+      expect(window.open).toHaveBeenCalledWith('about:blank');
+      expect(preview.location.href).toBe('blob:invoice');
+      expect((global.URL as any).createObjectURL).toHaveBeenCalled();
+    });
+    expect(mockOpenPdf).not.toHaveBeenCalled();
   });
 });
 
@@ -339,9 +392,10 @@ describe('PaymentQrCode stale-response guard', () => {
     });
 
     await waitFor(() => {
+      expect(window.open).toHaveBeenCalledWith('about:blank');
       expect(mockOpenPdf).toHaveBeenCalledTimes(1);
     });
-    expect(mockOpenPdf).toHaveBeenCalledWith('JVBERi0x');
+    expect(mockOpenPdf).toHaveBeenCalledWith('JVBERi0x', false);
   });
 
   it('clears a shown error when the mode changes', async () => {
@@ -449,8 +503,9 @@ describe('PaymentQrCode stale-response guard', () => {
     });
 
     await waitFor(() => {
+      expect(window.open).toHaveBeenCalledWith('about:blank');
       expect(mockOpenPdf).toHaveBeenCalledTimes(1);
     });
-    expect(mockOpenPdf).toHaveBeenCalledWith('JVBERi0x');
+    expect(mockOpenPdf).toHaveBeenCalledWith('JVBERi0x', false);
   });
 });

--- a/src/__tests__/transaction-invoice.test.ts
+++ b/src/__tests__/transaction-invoice.test.ts
@@ -98,14 +98,20 @@ describe('canOpenInvoice', () => {
 
 describe('revealInvoicePdf', () => {
   const pdf = btoa('pdf');
+  const originalCreateObjectURL = (global.URL as any).createObjectURL;
 
   beforeEach(() => {
     mockOpenPdfFromString.mockClear();
-    jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:invoice');
+    (global.URL as any).createObjectURL = jest.fn(() => 'blob:invoice');
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    if (originalCreateObjectURL) {
+      (global.URL as any).createObjectURL = originalCreateObjectURL;
+    } else {
+      delete (global.URL as any).createObjectURL;
+    }
   });
 
   it('sets location.href to a blob URL for a live preview window and does not call openPdfFromString', () => {
@@ -118,7 +124,7 @@ describe('revealInvoicePdf', () => {
     revealInvoicePdf(pdf, preview as unknown as Window);
 
     expect(preview.location.href).toBe('blob:invoice');
-    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect((global.URL as any).createObjectURL).toHaveBeenCalled();
     expect(mockOpenPdfFromString).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/transaction-invoice.test.ts
+++ b/src/__tests__/transaction-invoice.test.ts
@@ -1,0 +1,143 @@
+jest.mock('@dfx.swiss/react', () => ({
+  TransactionState: {
+    COMPLETED: 'Completed',
+    FAILED: 'Failed',
+    UNASSIGNED: 'Unassigned',
+  },
+  TransactionType: {
+    BUY: 'Buy',
+    SELL: 'Sell',
+  },
+}));
+
+jest.mock('../util/utils', () => ({
+  openPdfFromString: jest.fn(),
+}));
+
+import { TransactionState, TransactionType } from '@dfx.swiss/react';
+import { canOpenInvoice, revealInvoicePdf } from '../util/transaction-invoice';
+import { openPdfFromString } from '../util/utils';
+
+const mockOpenPdfFromString = openPdfFromString as jest.Mock;
+
+describe('canOpenInvoice', () => {
+  it('returns true for Completed Buy CHF', () => {
+    expect(
+      canOpenInvoice({
+        type: TransactionType.BUY,
+        state: TransactionState.COMPLETED,
+        inputAsset: 'CHF',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for Completed Buy EUR', () => {
+    expect(
+      canOpenInvoice({
+        type: TransactionType.BUY,
+        state: TransactionState.COMPLETED,
+        inputAsset: 'EUR',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for Sell', () => {
+    expect(
+      canOpenInvoice({
+        type: TransactionType.SELL,
+        state: TransactionState.COMPLETED,
+        inputAsset: 'EUR',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for non-completed Buy', () => {
+    expect(
+      canOpenInvoice({
+        type: TransactionType.BUY,
+        state: TransactionState.FAILED,
+        inputAsset: 'EUR',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when inputAsset is missing', () => {
+    expect(
+      canOpenInvoice({
+        type: TransactionType.BUY,
+        state: TransactionState.COMPLETED,
+        inputAsset: undefined as unknown as string,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for other inputAsset values', () => {
+    expect(
+      canOpenInvoice({
+        type: TransactionType.BUY,
+        state: TransactionState.COMPLETED,
+        inputAsset: 'BTC',
+      }),
+    ).toBe(false);
+    expect(
+      canOpenInvoice({
+        type: TransactionType.BUY,
+        state: TransactionState.COMPLETED,
+        inputAsset: 'dCHF',
+      }),
+    ).toBe(false);
+    expect(
+      canOpenInvoice({
+        type: TransactionType.BUY,
+        state: TransactionState.COMPLETED,
+        inputAsset: 'eur',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('revealInvoicePdf', () => {
+  const pdf = btoa('pdf');
+
+  beforeEach(() => {
+    mockOpenPdfFromString.mockClear();
+    jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:invoice');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sets location.href to a blob URL for a live preview window and does not call openPdfFromString', () => {
+    const preview = {
+      closed: false,
+      close: jest.fn(),
+      location: { href: '' },
+    };
+
+    revealInvoicePdf(pdf, preview as unknown as Window);
+
+    expect(preview.location.href).toBe('blob:invoice');
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(mockOpenPdfFromString).not.toHaveBeenCalled();
+  });
+
+  it('calls openPdfFromString(pdf, false) when preview is null', () => {
+    revealInvoicePdf(pdf, null);
+
+    expect(mockOpenPdfFromString).toHaveBeenCalledWith(pdf, false);
+  });
+
+  it('calls openPdfFromString(pdf, false) when preview is already closed', () => {
+    const preview = {
+      closed: true,
+      close: jest.fn(),
+      location: { href: '' },
+    };
+
+    revealInvoicePdf(pdf, preview as unknown as Window);
+
+    expect(mockOpenPdfFromString).toHaveBeenCalledWith(pdf, false);
+    expect(preview.location.href).toBe('');
+  });
+});

--- a/src/__tests__/transaction-list-txinfo.test.tsx
+++ b/src/__tests__/transaction-list-txinfo.test.tsx
@@ -1260,9 +1260,9 @@ describe('TransactionList open invoice visibility', () => {
   });
 });
 
-// Line 915: Open receipt success path calls openPdfFromString.
+// Open receipt: reserved about:blank window + embed fallback when window.open is blocked.
 describe('TransactionList open receipt success', () => {
-  it('opens the receipt PDF via openPdfFromString on success', async () => {
+  it('opens about:blank then falls back to openPdfFromString(pdf, false) when window.open returns null', async () => {
     mockGetDetailTransactions.mockResolvedValue([makeListTx({ id: 77, state: 'Completed' })]);
     mockGetUnassignedTransactions.mockResolvedValue([]);
     mockGetTransactionReceipt.mockResolvedValue({ pdfData: 'receipt-pdf-bytes' });
@@ -1274,7 +1274,8 @@ describe('TransactionList open receipt success', () => {
 
     await waitFor(() => {
       expect(mockGetTransactionReceipt).toHaveBeenCalledWith(77);
-      expect(mockOpenPdfFromString).toHaveBeenCalledWith('receipt-pdf-bytes');
+      expect(window.open).toHaveBeenCalledWith('about:blank');
+      expect(mockOpenPdfFromString).toHaveBeenCalledWith('receipt-pdf-bytes', false);
     });
   });
 });

--- a/src/__tests__/transaction-list-txinfo.test.tsx
+++ b/src/__tests__/transaction-list-txinfo.test.tsx
@@ -619,8 +619,15 @@ beforeEach(() => {
   jest.spyOn(window, 'open').mockImplementation(() => null);
 });
 
+const originalCreateObjectURL = (global.URL as any).createObjectURL;
+
 afterEach(() => {
   jest.restoreAllMocks();
+  if (originalCreateObjectURL) {
+    (global.URL as any).createObjectURL = originalCreateObjectURL;
+  } else {
+    delete (global.URL as any).createObjectURL;
+  }
 });
 
 // Line 281: Create support ticket onClick in TransactionStatus (via TransactionScreen).
@@ -1158,7 +1165,7 @@ describe('TransactionList open invoice success', () => {
   it('assigns the PDF via the reserved window when window.open returns a live preview', async () => {
     const preview = { closed: false, close: jest.fn(), location: { href: '' } };
     jest.spyOn(window, 'open').mockImplementation(() => preview as unknown as Window);
-    jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:invoice');
+    (global.URL as any).createObjectURL = jest.fn(() => 'blob:invoice');
 
     mockGetDetailTransactions.mockResolvedValue([makeListTx({ state: 'Completed', uid: 'inv-live' })]);
     mockGetUnassignedTransactions.mockResolvedValue([]);
@@ -1172,6 +1179,7 @@ describe('TransactionList open invoice success', () => {
     await waitFor(() => {
       expect(window.open).toHaveBeenCalledWith('about:blank');
       expect(preview.location.href).toBe('blob:invoice');
+      expect((global.URL as any).createObjectURL).toHaveBeenCalled();
     });
     expect(mockOpenPdfFromString).not.toHaveBeenCalled();
   });

--- a/src/__tests__/transaction-list-txinfo.test.tsx
+++ b/src/__tests__/transaction-list-txinfo.test.tsx
@@ -1278,6 +1278,47 @@ describe('TransactionList open receipt success', () => {
       expect(mockOpenPdfFromString).toHaveBeenCalledWith('receipt-pdf-bytes', false);
     });
   });
+
+  it('assigns the PDF via the reserved window when window.open returns a live preview', async () => {
+    const preview = { closed: false, close: jest.fn(), location: { href: '' } };
+    jest.spyOn(window, 'open').mockImplementation(() => preview as unknown as Window);
+    (global.URL as any).createObjectURL = jest.fn(() => 'blob:receipt');
+
+    mockGetDetailTransactions.mockResolvedValue([makeListTx({ id: 78, state: 'Completed' })]);
+    mockGetUnassignedTransactions.mockResolvedValue([]);
+    mockGetTransactionReceipt.mockResolvedValue({ pdfData: btoa('pdf') });
+
+    renderList();
+
+    const openReceipt = await screen.findByRole('button', { name: 'Open receipt' });
+    await userEvent.click(openReceipt);
+
+    await waitFor(() => {
+      expect(window.open).toHaveBeenCalledWith('about:blank');
+      expect(preview.location.href).toBe('blob:receipt');
+      expect((global.URL as any).createObjectURL).toHaveBeenCalled();
+    });
+    expect(mockOpenPdfFromString).not.toHaveBeenCalled();
+  });
+
+  it('closes the reserved window and shows ErrorHint when getTransactionReceipt rejects', async () => {
+    const preview = { closed: false, close: jest.fn(), location: { href: '' } };
+    jest.spyOn(window, 'open').mockImplementation(() => preview as unknown as Window);
+
+    mockGetDetailTransactions.mockResolvedValue([makeListTx({ id: 79, state: 'Completed' })]);
+    mockGetUnassignedTransactions.mockResolvedValue([]);
+    mockGetTransactionReceipt.mockRejectedValue({ message: 'Receipt network failure' });
+
+    renderList();
+
+    const openReceipt = await screen.findByRole('button', { name: 'Open receipt' });
+    await userEvent.click(openReceipt);
+
+    await waitFor(() => {
+      expect(preview.close).toHaveBeenCalled();
+      expect(screen.getByTestId('error-hint')).toHaveTextContent('Receipt network failure');
+    });
+  });
 });
 
 // Lines 942-975: refund / increase limit / complete KYC / support Select buttons.

--- a/src/__tests__/transaction-list-txinfo.test.tsx
+++ b/src/__tests__/transaction-list-txinfo.test.tsx
@@ -1136,9 +1136,9 @@ describe('TransactionList block explorer button', () => {
   });
 });
 
-// Line 889: Open invoice success path calls openPdfFromString.
+// Open invoice: reserved about:blank window + embed fallback when window.open is blocked.
 describe('TransactionList open invoice success', () => {
-  it('opens the invoice PDF via openPdfFromString on success', async () => {
+  it('opens about:blank then falls back to openPdfFromString(pdf, false) when window.open returns null', async () => {
     mockGetDetailTransactions.mockResolvedValue([makeListTx({ state: 'Completed', uid: 'inv-1' })]);
     mockGetUnassignedTransactions.mockResolvedValue([]);
     mockGetTransactionInvoice.mockResolvedValue({ pdfData: 'invoice-pdf-bytes' });
@@ -1150,8 +1150,105 @@ describe('TransactionList open invoice success', () => {
 
     await waitFor(() => {
       expect(mockGetTransactionInvoice).toHaveBeenCalledWith('inv-1');
-      expect(mockOpenPdfFromString).toHaveBeenCalledWith('invoice-pdf-bytes');
+      expect(window.open).toHaveBeenCalledWith('about:blank');
+      expect(mockOpenPdfFromString).toHaveBeenCalledWith('invoice-pdf-bytes', false);
     });
+  });
+
+  it('assigns the PDF via the reserved window when window.open returns a live preview', async () => {
+    const preview = { closed: false, close: jest.fn(), location: { href: '' } };
+    jest.spyOn(window, 'open').mockImplementation(() => preview as unknown as Window);
+    jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:invoice');
+
+    mockGetDetailTransactions.mockResolvedValue([makeListTx({ state: 'Completed', uid: 'inv-live' })]);
+    mockGetUnassignedTransactions.mockResolvedValue([]);
+    mockGetTransactionInvoice.mockResolvedValue({ pdfData: btoa('pdf') });
+
+    renderList();
+
+    const openInvoice = await screen.findByRole('button', { name: 'Open invoice' });
+    await userEvent.click(openInvoice);
+
+    await waitFor(() => {
+      expect(window.open).toHaveBeenCalledWith('about:blank');
+      expect(preview.location.href).toBe('blob:invoice');
+    });
+    expect(mockOpenPdfFromString).not.toHaveBeenCalled();
+  });
+
+  it('closes the reserved window and shows ErrorHint when getTransactionInvoice rejects', async () => {
+    const preview = { closed: false, close: jest.fn(), location: { href: '' } };
+    jest.spyOn(window, 'open').mockImplementation(() => preview as unknown as Window);
+
+    mockGetDetailTransactions.mockResolvedValue([makeListTx({ state: 'Completed', uid: 'inv-err' })]);
+    mockGetUnassignedTransactions.mockResolvedValue([]);
+    mockGetTransactionInvoice.mockRejectedValue({ message: 'Network failure detail' });
+
+    renderList();
+
+    const openInvoice = await screen.findByRole('button', { name: 'Open invoice' });
+    await userEvent.click(openInvoice);
+
+    await waitFor(() => {
+      expect(preview.close).toHaveBeenCalled();
+      expect(screen.getByTestId('error-hint')).toHaveTextContent('Network failure detail');
+    });
+  });
+});
+
+describe('TransactionList open invoice visibility', () => {
+  it('hides Open invoice for Completed SELL EUR', async () => {
+    mockGetDetailTransactions.mockResolvedValue([
+      makeListTx({ type: 'Sell', state: 'Completed', inputAsset: 'EUR', uid: 'sell-1' }),
+    ]);
+    mockGetUnassignedTransactions.mockResolvedValue([]);
+
+    renderList();
+
+    await screen.findByRole('button', { name: 'Open receipt' });
+    expect(screen.queryByRole('button', { name: 'Open invoice' })).not.toBeInTheDocument();
+  });
+
+  it('hides Open invoice for Failed Buy EUR', async () => {
+    mockGetDetailTransactions.mockResolvedValue([
+      makeListTx({
+        type: 'Buy',
+        state: 'Failed',
+        inputAsset: 'EUR',
+        uid: 'fail-buy',
+        reason: undefined,
+        chargebackAmount: undefined,
+      }),
+    ]);
+    mockGetUnassignedTransactions.mockResolvedValue([]);
+
+    renderList();
+
+    await screen.findByRole('button', { name: 'Confirm refund' });
+    expect(screen.queryByRole('button', { name: 'Open invoice' })).not.toBeInTheDocument();
+  });
+
+  it('hides Open invoice for Completed Buy BTC', async () => {
+    mockGetDetailTransactions.mockResolvedValue([
+      makeListTx({ type: 'Buy', state: 'Completed', inputAsset: 'BTC', uid: 'buy-btc' }),
+    ]);
+    mockGetUnassignedTransactions.mockResolvedValue([]);
+
+    renderList();
+
+    await screen.findByRole('button', { name: 'Open receipt' });
+    expect(screen.queryByRole('button', { name: 'Open invoice' })).not.toBeInTheDocument();
+  });
+
+  it('shows Open invoice for Completed Buy CHF', async () => {
+    mockGetDetailTransactions.mockResolvedValue([
+      makeListTx({ type: 'Buy', state: 'Completed', inputAsset: 'CHF', uid: 'buy-chf' }),
+    ]);
+    mockGetUnassignedTransactions.mockResolvedValue([]);
+
+    renderList();
+
+    expect(await screen.findByRole('button', { name: 'Open invoice' })).toBeInTheDocument();
   });
 });
 

--- a/src/components/payment/payment-qr-code.tsx
+++ b/src/components/payment/payment-qr-code.tsx
@@ -11,7 +11,7 @@ import { RiExternalLinkFill } from 'react-icons/ri';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useNavigation } from 'src/hooks/navigation.hook';
 import { getStoredPaymentDetailErrorMessage } from 'src/util/personal-iban';
-import { openPdfFromString } from 'src/util/utils';
+import { revealInvoicePdf } from 'src/util/transaction-invoice';
 import { ErrorHint } from '../error-hint';
 import { QrBasic } from './qr-code';
 
@@ -57,14 +57,19 @@ export function PaymentQrCode({ value, txId, collectionAccount = false }: GiroCo
       navigate('/profile', { setRedirect: true });
       return;
     }
+    const preview = window.open('about:blank');
     const generation = invoiceGeneration.current;
     try {
       setIsLoading(true);
       setInvoiceError(undefined);
       const response = await invoiceFor(txId, collectionAccount);
-      if (generation !== invoiceGeneration.current) return;
-      openPdfFromString(response.pdfData);
+      if (generation !== invoiceGeneration.current) {
+        preview?.close();
+        return;
+      }
+      revealInvoicePdf(response.pdfData, preview);
     } catch (err) {
+      preview?.close();
       if (generation !== invoiceGeneration.current) return;
       setInvoiceError(err as ApiError);
     } finally {

--- a/src/screens/transaction.screen.tsx
+++ b/src/screens/transaction.screen.tsx
@@ -65,6 +65,7 @@ import { useUserGuard } from '../hooks/guard.hook';
 import { useLayoutOptions } from '../hooks/layout-config.hook';
 import { useNavigation } from '../hooks/navigation.hook';
 import { getStoredPaymentDetailErrorMessage } from '../util/personal-iban';
+import { canOpenInvoice, revealInvoicePdf } from '../util/transaction-invoice';
 import { blankedAddress, formatSwissDateTimeWithSeconds, openPdfFromString } from '../util/utils';
 import { ZipValidation } from '../util/validation-rules';
 
@@ -878,13 +879,15 @@ export function TransactionList({ isSupport, setError, onSelectTransaction }: Tr
                             <StyledButton
                               label={translate('general/actions', 'Open invoice')}
                               onClick={() => {
+                                const preview = window.open('about:blank');
                                 setIsInvoiceLoading(tx.uid);
                                 setDocumentError(undefined);
                                 getTransactionInvoice(tx.uid)
                                   .then((response: PdfDocument) => {
-                                    openPdfFromString(response.pdfData);
+                                    revealInvoicePdf(response.pdfData, preview);
                                   })
                                   .catch((error: ApiError) => {
+                                    preview?.close();
                                     const storedDetailErrorText = getStoredPaymentDetailErrorMessage(error.message);
                                     setDocumentError({
                                       key: tx.uid,
@@ -897,7 +900,7 @@ export function TransactionList({ isSupport, setError, onSelectTransaction }: Tr
                               }}
                               isLoading={isInvoiceLoading === tx.uid}
                               color={StyledButtonColor.STURDY_WHITE}
-                              hidden={isSupport}
+                              hidden={isSupport || !canOpenInvoice(tx)}
                             />
                             <StyledButton
                               label={translate('general/actions', 'Open receipt')}

--- a/src/screens/transaction.screen.tsx
+++ b/src/screens/transaction.screen.tsx
@@ -66,7 +66,7 @@ import { useLayoutOptions } from '../hooks/layout-config.hook';
 import { useNavigation } from '../hooks/navigation.hook';
 import { getStoredPaymentDetailErrorMessage } from '../util/personal-iban';
 import { canOpenInvoice, revealInvoicePdf } from '../util/transaction-invoice';
-import { blankedAddress, formatSwissDateTimeWithSeconds, openPdfFromString } from '../util/utils';
+import { blankedAddress, formatSwissDateTimeWithSeconds } from '../util/utils';
 import { ZipValidation } from '../util/validation-rules';
 
 export enum ExportType {
@@ -906,14 +906,15 @@ export function TransactionList({ isSupport, setError, onSelectTransaction }: Tr
                               label={translate('general/actions', 'Open receipt')}
                               onClick={() => {
                                 if (!tx.id) return;
-
+                                const preview = window.open('about:blank');
                                 setIsReceiptLoading(tx.id);
                                 setDocumentError(undefined);
                                 getTransactionReceipt(tx.id)
                                   .then((response: PdfDocument) => {
-                                    openPdfFromString(response.pdfData);
+                                    revealInvoicePdf(response.pdfData, preview);
                                   })
                                   .catch((error: ApiError) => {
+                                    preview?.close();
                                     const storedDetailErrorText = getStoredPaymentDetailErrorMessage(error.message);
                                     setDocumentError({
                                       key: String(tx.id),

--- a/src/util/transaction-invoice.ts
+++ b/src/util/transaction-invoice.ts
@@ -1,0 +1,22 @@
+import { DetailTransaction, TransactionState, TransactionType } from '@dfx.swiss/react';
+import { openPdfFromString } from './utils';
+
+export function canOpenInvoice(
+  tx: Pick<DetailTransaction, 'type' | 'state' | 'inputAsset'>,
+): boolean {
+  return (
+    tx.type === TransactionType.BUY &&
+    tx.state === TransactionState.COMPLETED &&
+    (tx.inputAsset === 'CHF' || tx.inputAsset === 'EUR')
+  );
+}
+
+export function revealInvoicePdf(pdf: string, preview: Window | null): void {
+  if (preview && !preview.closed) {
+    const byteArray = Uint8Array.from(atob(pdf), (c) => c.charCodeAt(0));
+    const file = new Blob([byteArray], { type: 'application/pdf' });
+    preview.location.href = URL.createObjectURL(file);
+    return;
+  }
+  openPdfFromString(pdf, false);
+}


### PR DESCRIPTION
EN:
Fixes #1402 and #1412. Open invoice, Open receipt and the buy-QR PDF Invoice button all reserve a tab in the click gesture, so iOS Safari can show the PDF after the request. Open invoice stays limited to completed Buy rows in CHF or EUR. Full-stack tests fail if the tab opens only after the document request, if Open invoice appears on pending or sell rows, or if an API error is swallowed.

DE:
Behebt #1402 und #1412. Rechnung öffnen, Beleg öffnen und PDF Invoice am Buy-QR reservieren den Tab noch im Klick, damit iOS Safari das PDF nach dem Request zeigen kann. Rechnung öffnen bleibt auf abgeschlossene Käufe in CHF oder EUR beschränkt. Die Full-Stack-Tests werden rot, wenn der Tab erst nach dem Dokument-Request kommt, der Invoice-Button auf Pending- oder Verkaufszeilen steht, oder ein API-Fehler still verschluckt wird.

<details>
<summary>Details</summary>

## What changed

- Helper `src/util/transaction-invoice.ts`: `canOpenInvoice` and `revealInvoicePdf` (reserved window or in-page embed).
- List Open invoice / Open receipt and buy-QR PDF Invoice call `window.open('about:blank')` first, then the SDK request, then `revealInvoicePdf`. Reject closes the reserved window and keeps ErrorHint.
- Open invoice hidden unless completed Buy in CHF or EUR. Receipt still gated on COMPLETED.

## Tests

- Unit: helper matrix; reserved-window / embed fallback / error close for invoice, receipt and QR (including KYC path that must not open a window).
- Full-stack (`e2e-stack/specs/transactions.spec.ts`): visibility, 800 ms popup vs 2000 ms delayed document request, HTTP 400 closes the tab and shows the API message — for both Open invoice and Open receipt.
- Reality declaration in `docs/test-architecture.md`: fulfilled invoice/receipt routes do not prove the API can build a PDF from SQL-seeded rows.

## Declared deviations

- Whole-file 100 % coverage on `transaction.screen.tsx` is not raised. The helper is fully covered; list tests cover the new branches.
- Handbook / Playwright visual baselines not regenerated.
- Unit and full-stack suites for these paths were executed on a separate build host, not on the authoring laptop.

</details>
