### PR TITLE
01a01a53 - Point API repo links at DFXswiss/backend

### DIFF
--- a/.github/workflows/e2e-stack.yml
+++ b/.github/workflows/e2e-stack.yml
@@ -5,7 +5,7 @@
 # merge gate. If you ever consider adding a skip anywhere in this file, justify it in
 # a comment right there.
 #
-# Relation to DFXswiss/api: the corresponding workflow there checks this repository out to
+# Relation to DFXswiss/backend: the corresponding workflow there checks this repository out to
 # find e2e-stack/, so it reads whatever is on develop at the time it runs. Until this pull
 # request has merged, that workflow bootstraps the harness from this pull request's head
 # instead, which means neither side is blocked on the other and either merge order works.
@@ -37,7 +37,7 @@ on:
   workflow_dispatch:
     inputs:
       api_ref:
-        description: 'Git ref of DFXswiss/api to check out and build against'
+        description: 'Git ref of DFXswiss/backend to check out and build against'
         required: false
         default: 'develop'
         type: string
@@ -189,7 +189,7 @@ jobs:
         if: steps.scope.outputs.mode != 'none' && steps.api_cred.outputs.available == 'yes'
         uses: actions/checkout@v4
         with:
-          repository: DFXswiss/api
+          repository: DFXswiss/backend
           ref: ${{ inputs.api_ref || 'develop' }}
           path: api-repo
           ssh-key: ${{ secrets.E2E_API_CHECKOUT_KEY }}
@@ -197,7 +197,7 @@ jobs:
 
       # The harness refuses an API image whose process error handling can throw while logging,
       # because such an image cannot stay up in a network with no route out. That guard lives in
-      # DFXswiss/api#4753 and is not on its default branch yet, so until it lands this job builds
+      # DFXswiss/backend#4753 and is not on its default branch yet, so until it lands this job builds
       # from that pull request instead — the mirror image of what the API repository's own workflow
       # does with this one. Self-disabling: once the guard is on develop, the check below passes and
       # this step is skipped. It also refuses to bootstrap from a pull request that is no longer
@@ -213,27 +213,27 @@ jobs:
           if [ -f api-repo/src/shared/utils/safe-log.ts ]; then
             echo "bootstrap=false" >> "$GITHUB_OUTPUT"
           elif [ -n "$API_REF" ]; then
-            echo "::error::DFXswiss/api@${API_REF} does not carry the guarded process error handling"
+            echo "::error::DFXswiss/backend@${API_REF} does not carry the guarded process error handling"
             echo "::error::(src/shared/utils/safe-log.ts), and api_ref was set explicitly, so no fallback"
             echo "::error::applies. Point it at a revision that has it, or omit api_ref to use develop."
             exit 1
           else
             err_file="$(mktemp -p "${RUNNER_TEMP}")"
-            if ! state="$(gh api repos/DFXswiss/api/pulls/4753 --jq .state 2>"$err_file")"; then
-              echo "::error::Could not determine the state of DFXswiss/api#4753 (gh api call failed):"
+            if ! state="$(gh api repos/DFXswiss/backend/pulls/4753 --jq .state 2>"$err_file")"; then
+              echo "::error::Could not determine the state of DFXswiss/backend#4753 (gh api call failed):"
               echo "::error::$(cat "$err_file")"
               rm -f "$err_file"
               exit 1
             fi
             rm -f "$err_file"
             if [ "$state" != "open" ]; then
-              echo "::error::DFXswiss/api#4753 is no longer open (state: ${state}); this fallback is spent."
-              echo "::error::The guard is expected on DFXswiss/api@develop now. Delete this step and the"
+              echo "::error::DFXswiss/backend#4753 is no longer open (state: ${state}); this fallback is spent."
+              echo "::error::The guard is expected on DFXswiss/backend@develop now. Delete this step and the"
               echo "::error::'Check out the API revision that carries the guard' step below."
               exit 1
             fi
-            echo "::warning::DFXswiss/api@develop does not carry the guarded process error handling yet."
-            echo "::warning::Building the API image from DFXswiss/api#4753 instead."
+            echo "::warning::DFXswiss/backend@develop does not carry the guarded process error handling yet."
+            echo "::warning::Building the API image from DFXswiss/backend#4753 instead."
             echo "::warning::Merge that pull request to remove this temporary fallback."
             echo "bootstrap=true" >> "$GITHUB_OUTPUT"
           fi
@@ -242,7 +242,7 @@ jobs:
         if: steps.scope.outputs.mode != 'none' && steps.api_cred.outputs.available == 'yes' && steps.api_source.outputs.bootstrap == 'true'
         uses: actions/checkout@v4
         with:
-          repository: DFXswiss/api
+          repository: DFXswiss/backend
           ref: refs/pull/4753/head
           path: api-repo
           ssh-key: ${{ secrets.E2E_API_CHECKOUT_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Compliance and lower. Prefer Fail or Reset so the automatic AML pipeline can re-
 
 `docs/test-architecture.md` describes the test layers this repository owns, with
 measured numbers for the current state, and points at the canonical
-cross-repository description in `DFXswiss/api`. Read it before adding a test
+cross-repository description in `DFXswiss/backend`. Read it before adding a test
 layer, moving a test between layers, or extending the full-stack harness. (Given
 as a path rather than a link on purpose: the handbook build renders every markdown
 file to HTML, and its integrity check then requires every relative reference

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Reusable web widget to buy, sell and swap crypto assets
 ### Prerequisites
 
 - **Node.js** (LTS version) - [Download](https://nodejs.org)
-- **DFX API** running locally - see [API repository](https://github.com/DFXswiss/api#local-development)
+- **DFX API** running locally - see [API repository](https://github.com/DFXswiss/backend#local-development)
 
 ### Quick Start
 
@@ -103,7 +103,7 @@ Similar to the Web Component, the React component requires a closing callback (`
 
 #### Direct Login
 
-Credentials can be provided directly when opening DFX services. This is recommended for integrators with access to the wallet of the user. The services can be opened with a JWT access token for DFX API. Details on the authentication can be found in the [API documentation](https://github.com/DFXswiss/api#registration). Use the following parameter.
+Credentials can be provided directly when opening DFX services. This is recommended for integrators with access to the wallet of the user. The services can be opened with a JWT access token for DFX API. Details on the authentication can be found in the [API documentation](https://github.com/DFXswiss/backend#registration). Use the following parameter.
 
 - `session`: access token for the DFX API
 
@@ -141,7 +141,7 @@ DFX services supports the following parameters. Note that for the React componen
 - User information
 
   - E-mail (`mail`): user email
-  - Wallet (`wallet`): wallet/client identifier (name or ID), used for sign up, see [API documentation](https://github.com/DFXswiss/api#initial-wallet-setup-optional) (optional, but recommended)
+  - Wallet (`wallet`): wallet/client identifier (name or ID), used for sign up, see [API documentation](https://github.com/DFXswiss/backend#initial-wallet-setup-optional) (optional, but recommended)
   - Referral code (`refcode`): sign-up referral code
   - Special code (`special-code`): special/promo code
 

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -3,7 +3,7 @@
 This document describes the test layers **this repository** owns, with measured numbers for the
 current state. The canonical, cross-repository description of all layers — what each one proves, what
 it deliberately does not prove, and the reality-declaration requirement — lives in
-`DFXswiss/api` under `docs/test-architecture.md`. Read that one first if you need the whole picture.
+`DFXswiss/backend` under `docs/test-architecture.md`. Read that one first if you need the whole picture.
 
 Current state and target are kept apart on purpose. Sections marked _target_ describe what is not
 built yet; nothing here may describe a capability as existing when it does not.
@@ -18,7 +18,7 @@ built yet; nothing here may describe a capability as existing when it does not.
 
 The processing chain behind the API — incoming transfers, AML, purchase calculation, liquidity,
 payout, ledger booking — is **not** testable from this repository. It belongs to the integration
-layer in `DFXswiss/api`, which runs against a real database. Do not try to cover it from here.
+layer in `DFXswiss/backend`, which runs against a real database. Do not try to cover it from here.
 
 ## Current state — measured
 
@@ -84,7 +84,7 @@ declaration.** Anything its parser cannot resolve is a hard failure rather than 
 ## Reality declaration — hard requirement
 
 Full definition, including the categories that count as a fake and the mandatory fields per entry, is in
-`DFXswiss/api` under `docs/test-architecture.md` — that document owns the taxonomy, and its exact extent
+`DFXswiss/backend` under `docs/test-architecture.md` — that document owns the taxonomy, and its exact extent
 is not verifiable from this repository. The short form that binds every pull request here:
 
 Whenever you introduce, remove or change a fake — a faked external provider, a disabled cron job, a
@@ -101,7 +101,7 @@ from memory, with omissions.
 
 This section lists the fakes introduced by this repository's own suites and states what a green
 run does not prove for each one; the taxonomy and cross-repository entries live in
-`DFXswiss/api` under `docs/test-architecture.md`.
+`DFXswiss/backend` under `docs/test-architecture.md`.
 
 - **The buy-process specs answer the quote endpoint themselves.** `e2e/buy-process.spec.ts` fulfils
   `**/v1/buy/paymentInfos` with static payloads, so a green run proves that the screen renders those
@@ -142,12 +142,12 @@ All four points below concern the full-stack harness.
   there — every process-gated cron job — so the processing chain never executes;
   transaction states are inserted with SQL instead. What is verified is the synchronous path:
   interaction, HTTP, validation, authorisation, persistence, display. (A cron without a `process` field
-  is not covered by that switch and keeps running — see the companion document in `DFXswiss/api`.)
+  is not covered by that switch and keeps running — see the companion document in `DFXswiss/backend`.)
 - **The harness does not exercise the migration chain.** It builds the schema from the entities,
   because one migration requires a seed row that does not exist at migration time on a fresh
-  database. Migrations are covered in `DFXswiss/api` instead.
+  database. Migrations are covered in `DFXswiss/backend` instead.
 - **The harness lives in the wrong repository.** It tests the API as much as this frontend, and
-  `DFXswiss/api` has to check this repository out to obtain it. See the target below.
+  `DFXswiss/backend` has to check this repository out to obtain it. See the target below.
 - **The suite is serialised.** All specs share one database and one API instance — `e2e-stack/compose.yml`
   declares a single `db` and a single `api` service — with no per-test isolation, so it runs on a single
   worker with retries disabled (`workers: 1` and `retries: 0` in `e2e-stack/playwright.config.ts`, whose
@@ -160,7 +160,7 @@ _Target — not built yet._ In the order the work should happen:
 
 1. **Per-worker isolation** (a schema or database per worker), so the suite can be parallelised. Cheap
    while it is small.
-2. **Move the harness out of this repository** — into `DFXswiss/api` or a repository of its own,
+2. **Move the harness out of this repository** — into `DFXswiss/backend` or a repository of its own,
    consuming published frontend and API images by tag instead of sibling checkouts. The stage depends
    on the applications, never the reverse.
 3. **Adopt a coverage ratchet for the unit layer**, replacing a rule that CI cannot enforce with one

--- a/src/hooks/bank-tx-assignment.hook.ts
+++ b/src/hooks/bank-tx-assignment.hook.ts
@@ -22,7 +22,7 @@ export interface AssignBankTxDto {
   buyId?: number;
 }
 
-// Mirrors BankTxType in DFXswiss/api (bank-tx.entity.ts), minus the three unassigned markers:
+// Mirrors BankTxType in DFXswiss/backend (bank-tx.entity.ts), minus the three unassigned markers:
 // setting a transaction back to Pending/GSheet/Unknown is not an assignment, and the API maps
 // those to a null transaction type.
 export const AssignableBankTxTypes = [

--- a/src/util/compliance-helpers.tsx
+++ b/src/util/compliance-helpers.tsx
@@ -199,7 +199,7 @@ export function todayAsString(): string {
   return new Date().toISOString().split('T')[0];
 }
 
-// Mirrors `BankTxUnassignedTypes` in DFXswiss/api (bank-tx.entity.ts).
+// Mirrors `BankTxUnassignedTypes` in DFXswiss/backend (bank-tx.entity.ts).
 // Only these types still allow a manual Return via compliance.
 export const BankTxUnassignedTypes = ['GSheet', 'Unknown', 'Pending'];
 

--- a/src/util/job.ts
+++ b/src/util/job.ts
@@ -1,7 +1,7 @@
 import { delay } from './utils';
 
 /**
- * Async job contract of the API (DFXswiss/api#4496): an endpoint whose work outruns its short wait
+ * Async job contract of the API (DFXswiss/backend#4496): an endpoint whose work outruns its short wait
  * window answers HTTP 202 with a job ticket instead of the result. The client polls `GET /job/:uid`
  * until the job is terminal and then asks the originating endpoint for the result again — the
  * result is deliberately not carried in the job.

--- a/src/util/safe-account.ts
+++ b/src/util/safe-account.ts
@@ -5,7 +5,7 @@ import { CustodyAccount } from 'src/dto/safe.dto';
  *
  * The account list marks foreign accounts with their owner and leaves the field off the
  * caller's own; the legacy Safe carries the caller as its owner. That distinction is a side
- * effect of how the API loads its relations rather than a documented guarantee — DFXswiss/api
+ * effect of how the API loads its relations rather than a documented guarantee — DFXswiss/backend
  * PR 4424 adds an explicit flag, and this should move to it once that lands.
  */
 export function isOwnAccount(account: CustodyAccount): boolean {

--- a/src/util/support-stats.ts
+++ b/src/util/support-stats.ts
@@ -2,7 +2,7 @@
 // so it is cheap to unit-test in isolation.
 import type { SupportIssueListItem } from 'src/hooks/support-dashboard.hook';
 
-// Author marker the backend stamps on customer messages (mirrors `CustomerAuthor` in DFXswiss/api).
+// Author marker the backend stamps on customer messages (mirrors `CustomerAuthor` in DFXswiss/backend).
 export const CustomerAuthor = 'Customer';
 
 // --- Customer waiting & escalation ---
@@ -75,7 +75,7 @@ export interface ResolutionBucket {
   count: number;
 }
 
-// Ticket state marking a resolved ticket (mirrors SupportIssueInternalState.COMPLETED in DFXswiss/api).
+// Ticket state marking a resolved ticket (mirrors SupportIssueInternalState.COMPLETED in DFXswiss/backend).
 export const COMPLETED_STATE = 'Completed';
 
 export interface TicketStatistics {

--- a/src/util/validation-rules.ts
+++ b/src/util/validation-rules.ts
@@ -2,7 +2,7 @@ import { Validations } from '@dfx.swiss/react';
 
 // Creditor / payout zip. OLKYPAY rejects any recipient zip longer than 8 characters
 // (CLIENT_INVALID_ZIPCODE), and the backend mirror of that check was retired
-// (DFXswiss/api#3985 closed) in favour of validating at the source — so this frontend cap is
+// (DFXswiss/backend#3985 closed) in favour of validating at the source — so this frontend cap is
 // the ONLY guard for the bank-refund / payout path. Keep it at 8 for creditor zip fields.
 export const ZipValidation = [Validations.Required, Validations.Custom((v) => !v || v.length <= 8 || 'pattern')];
 


### PR DESCRIPTION
EN:
Point GitHub links and the E2E API checkout at DFXswiss/backend after the rename.
Local path api-repo and api.dfx.swiss stay as they are.

DE:
GitHub-Links und der E2E-API-Checkout zeigen nach dem Rename auf DFXswiss/backend.
Lokaler Pfad api-repo und api.dfx.swiss bleiben.

<details>
<summary>Details</summary>

The Nest monolith GitHub repo is now DFXswiss/backend. This updates README anchors, test-architecture, source comments, and `.github/workflows/e2e-stack.yml` `repository:` fields. Checkout directory `api-repo` is unchanged.

</details>