### PR TITLE
Match the assign screen title by text, not by heading role

### DIFF
--- a/e2e-stack/specs/transactions.spec.ts
+++ b/e2e-stack/specs/transactions.spec.ts
@@ -682,6 +682,32 @@ test("assign route for another user's unassigned tx leaves list empty of that ro
 // /tx/:id/refund — refund form (uid)
 // ---------------------------------------------------------------------------
 
+// The refund screen opens on either an action secret or a session (transaction.screen.tsx:
+// `isRefund = ... && (hasActionSecret || isLoggedIn)`). Every other refund test below takes the
+// guest path with a secret, so without this one the logged-in half of that condition is untested
+// and /tx/:id/refund - claimed in the route registry - is never opened.
+test('logged-in refund route opens the refund form without an action secret', async ({ page }) => {
+  const user = await createUser({
+    tag: 'tx-refund-session',
+    kycLevel: 30,
+    completePersonalData: true,
+  });
+  const tx = await createTransaction({
+    state: 'pending_buy',
+    tag: 'tx-refund-session',
+    userId: user.userId,
+    userDataId: user.userDataId,
+    jwt: user.jwt,
+    amount: 189,
+    inputAsset: 'CHF',
+  });
+
+  await openScreen(page, `/tx/${tx.uid}/refund`, user.jwt);
+
+  await expect(page.getByText('Transaction refund', { exact: true })).toBeVisible();
+  await expect(page.locator('input[name="street"]')).toBeVisible();
+});
+
 test('pending buy refund form submits and writes chargeback columns', async ({ page }) => {
   const user = await createUser({
     tag: 'tx-refund-ok',

--- a/e2e-stack/specs/transactions.spec.ts
+++ b/e2e-stack/specs/transactions.spec.ts
@@ -567,9 +567,7 @@ test('assign route opens list with unassigned row and assigns to single buy targ
     .toEqual({ bankTxType: 'BuyCrypto', buyCryptoBuyId: buy.buyId });
 });
 
-test('public uid assign route opens the guest assign form and assigns to the single buy target', async ({
-  page,
-}) => {
+test('public uid assign route opens the guest assign form and assigns to the single buy target', async ({ page }) => {
   const user = await createUser({
     tag: 'tx-assign-uid',
     kycLevel: 30,
@@ -600,7 +598,12 @@ test('public uid assign route opens the guest assign form and assigns to the sin
   await page.goto(`/tx/${unassigned.uid}/${ACTION_SECRET}/assign`);
   await page.waitForLoadState('networkidle');
 
-  await expect(page.getByRole('heading', { name: 'Assign transaction', exact: true })).toBeVisible();
+  // The screen title comes from useLayoutOptions and renders in the app bar as a plain element, not
+  // as a heading, so getByRole('heading') never matches it - the other title assertions in this file
+  // use getByText for the same reason. The submit button carries the same accessible name, so the
+  // text locator matches twice; the app bar precedes the form, hence first(). 'Your Transactions' is
+  // a real in-page heading, so the negative assertion below stays role-based and keeps its meaning.
+  await expect(page.getByText('Assign transaction', { exact: true }).first()).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Your Transactions', exact: true })).not.toBeVisible();
 
   const assignBtn = page.getByRole('button', { name: 'Assign transaction' });

--- a/e2e-stack/specs/transactions.spec.ts
+++ b/e2e-stack/specs/transactions.spec.ts
@@ -601,10 +601,11 @@ test('public uid assign route opens the guest assign form and assigns to the sin
   // The screen title comes from useLayoutOptions and renders in the app bar as a plain element, not
   // as a heading, so getByRole('heading') never matches it - the other title assertions in this file
   // use getByText for the same reason.
-  // first() is load-bearing and safe: exact getByText resolves like :text-is, i.e. the *smallest*
-  // element whose own text nodes match, so it finds the app-bar title and the identically named
-  // submit button - two elements, not their shared ancestors, which contribute no text of their own.
-  // The app bar precedes the form, so first() is the title.
+  // first() is load-bearing: the submit button carries the same accessible name, so the exact text
+  // locator matches the app-bar title and that button. It is safe because exact matching resolves to
+  // the *smallest* element whose text is exactly this string - a wrapping container is never the
+  // smallest match, so ancestors stay out of the set. The app bar precedes the form, so first() is
+  // the title.
   // 'Your Transactions' is a real in-page heading (see the list tests above), so the negative
   // assertion below stays role-based and keeps its meaning.
   await expect(page.getByText('Assign transaction', { exact: true }).first()).toBeVisible();

--- a/e2e-stack/specs/transactions.spec.ts
+++ b/e2e-stack/specs/transactions.spec.ts
@@ -600,9 +600,13 @@ test('public uid assign route opens the guest assign form and assigns to the sin
 
   // The screen title comes from useLayoutOptions and renders in the app bar as a plain element, not
   // as a heading, so getByRole('heading') never matches it - the other title assertions in this file
-  // use getByText for the same reason. The submit button carries the same accessible name, so the
-  // text locator matches twice; the app bar precedes the form, hence first(). 'Your Transactions' is
-  // a real in-page heading, so the negative assertion below stays role-based and keeps its meaning.
+  // use getByText for the same reason.
+  // first() is load-bearing and safe: exact getByText resolves like :text-is, i.e. the *smallest*
+  // element whose own text nodes match, so it finds the app-bar title and the identically named
+  // submit button - two elements, not their shared ancestors, which contribute no text of their own.
+  // The app bar precedes the form, so first() is the title.
+  // 'Your Transactions' is a real in-page heading (see the list tests above), so the negative
+  // assertion below stays role-based and keeps its meaning.
   await expect(page.getByText('Assign transaction', { exact: true }).first()).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Your Transactions', exact: true })).not.toBeVisible();
 


### PR DESCRIPTION
Fixes the last failing check on the DFXswiss/backend release
[#5090](https://github.com/DFXswiss/backend/pull/5090), which is blocked by this test.

The guest assign test added in #1407 asserts the screen title with `getByRole('heading', …)`. That
locator never matches. The title comes from `useLayoutOptions` and renders in the app bar as a plain
element — the Playwright trace from the failing run shows it as `generic [ref=e10]: Assign
transaction`, with no heading role on the page at all.

**The feature is not broken.** The same trace shows the guest form rendering correctly: title, the
single buy target preselected, and the submit button.

```yaml
- generic [ref=e5]:
    - button [ref=e6]                            # back
    - generic [ref=e10]: Assign transaction      # app-bar title — no heading role
    - img [ref=e13]
- generic [ref=e20]:
    - paragraph [ref=e21]: Remittance info
    - button "1C32-386F-20BE Ethereum/ETH 0xc6…" [disabled]
    - button "Assign transaction" [ref=e30]      # submit — same accessible name
```

### The fix

`getByText`, which is what the other title assertions in this file already use (`Transaction status` at 467/495,
`Transaction refund` at 733/796).

`first()` is required because the submit button carries the same accessible name, so the text locator
matches twice — the app bar precedes the form in the DOM, so `first()` is the title. Without it the
assertion trades one failure for a strict-mode violation.

The negative assertion on the following line stays role-based deliberately: `Your Transactions` *is* a
real in-page heading, as the passing list tests at lines 48, 110 and 179 demonstrate, so
`getByRole('heading', …).not.toBeVisible()` keeps its meaning there.

### Verification

Diagnosed from the `e2e-stack-report` artifact of the failing run (job 96361851800): the trace's DOM
snapshot is what establishes both that the title has no heading role and that the button shares the
name. I did **not** run the harness locally — it needs the full compose stack — so the locator change
itself is verified by CI on this PR rather than by a local run.



---

## The route-coverage gate this unmasked

Fixing the locator let the `[coverage-gate]` project run for the first time — it is skipped while any
earlier spec fails, which is why release #5090 never reported it. It then failed:

```
Routes claimed but never opened (1) — the claiming suite must navigate there:
  - /tx/:id/refund
```

#1407 added `/tx/:id/refund` to `App.tsx` and claimed it in `specs/registry/transactions.ts`, but every
refund test navigates the guest variant `/tx/:id/:secret/refund`. The screen opens on either input —
`isRefund = ... && (hasActionSecret || isLoggedIn)` in `transaction.screen.tsx` — so the logged-in half
of that condition was untested and the claimed route never visited.

`route-coverage.spec.ts` states: "Do not weaken or remove a claim just to keep this green; add real
coverage instead." So this adds the missing navigation rather than dropping the claim: open the route
with a session and no secret, assert the refund form renders.

### CI evidence for the first commit

The locator fix is confirmed by the run on this branch - the previously failing test passed, and the
serial-mode skips it was causing disappeared (232 -> 238 passing):

```
231 [chromium] specs/transactions.spec.ts:570:5 public uid assign route opens the guest assign form
    and assigns to the single buy target (2.8s)  PASSED
238 passed (9.9m)
```

