### PR TITLE
01a02039 - Drop leftover call-queue clerks list

### DIFF
--- a/e2e-stack/specs/compliance-cases.spec.ts
+++ b/e2e-stack/specs/compliance-cases.spec.ts
@@ -15,17 +15,7 @@
  */
 
 import type { Locator, Page } from '@playwright/test';
-import {
-  expect,
-  loginAs,
-  normPath,
-  openScreen,
-  queryOne,
-  queryRows,
-  test,
-  waitForRow,
-  withDb,
-} from './fixtures';
+import { expect, loginAs, normPath, openScreen, queryOne, queryRows, test, waitForRow, withDb } from './fixtures';
 import {
   cleanupCreatedData,
   createBankAccount,
@@ -43,7 +33,7 @@ test.describe.configure({ mode: 'serial' });
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Raise staff kycLevel + name so clerks lists and MROS caseManager resolve. */
+/** Raise staff kycLevel + name so MROS caseManager and staff identity resolve. */
 async function ensureStaffReady(userId: number, surname = 'Compliance'): Promise<void> {
   await withDb(async (client) => {
     await client.query(
@@ -52,51 +42,6 @@ async function ensureStaffReady(userId: number, surname = 'Compliance'): Promise
       [userId, surname],
     );
   });
-}
-
-/**
- * GET support/call-queues/clerks still reads setting key `complianceClerks` (no default).
- * Self-identification no longer uses that list; keep a value so later suites see a stable setting.
- */
-/**
- * The previous value, so afterAll can put it back. This is a shared setting: leaving this suite's
- * clerks behind would change what every later suite — and every later run against the same
- * database — sees on the compliance screens.
- */
-let previousComplianceClerks: { existed: boolean; value: string | null } | undefined;
-
-async function ensureComplianceClerks(clerks: string[] = ['E2E Clerk']): Promise<void> {
-  const value = JSON.stringify(clerks);
-  await withDb(async (client) => {
-    const existing = await client.query<{ id: number; value: string | null }>(
-      `SELECT id, value FROM setting WHERE key = $1 LIMIT 1`,
-      ['complianceClerks'],
-    );
-    if (previousComplianceClerks === undefined) {
-      previousComplianceClerks =
-        existing.rows.length > 0
-          ? { existed: true, value: existing.rows[0].value }
-          : { existed: false, value: null };
-    }
-    if (existing.rows.length > 0) {
-      await client.query(`UPDATE setting SET value = $1 WHERE key = $2`, [value, 'complianceClerks']);
-    } else {
-      await client.query(`INSERT INTO setting (key, value) VALUES ($1, $2)`, ['complianceClerks', value]);
-    }
-  });
-}
-
-async function restoreComplianceClerks(): Promise<void> {
-  const previous = previousComplianceClerks;
-  if (!previous) return;
-  await withDb(async (client) => {
-    if (previous.existed) {
-      await client.query(`UPDATE setting SET value = $1 WHERE key = $2`, [previous.value, 'complianceClerks']);
-    } else {
-      await client.query(`DELETE FROM setting WHERE key = $1`, ['complianceClerks']);
-    }
-  });
-  previousComplianceClerks = undefined;
 }
 
 /**
@@ -138,7 +83,6 @@ function styledInput(page: Page, fieldLabel: string): Locator {
 
 test.describe('Compliance area (cases)', () => {
   test.afterAll(async () => {
-    await restoreComplianceClerks();
     await cleanupCreatedData();
   });
 
@@ -149,7 +93,6 @@ test.describe('Compliance area (cases)', () => {
   test('/compliance/user/:id/kyc approves ManualReview bank data via UI', async ({ page }) => {
     const { jwt, userId } = await loginAs('Compliance');
     await ensureStaffReady(userId);
-    await ensureComplianceClerks(['E2E Clerk']);
 
     const customer = await createUser({
       tag: 'cmp-kyc-bd',
@@ -501,7 +444,6 @@ test.describe('Compliance area (cases)', () => {
   test('/compliance/call-queues/:queue and detail save a call outcome', async ({ page }) => {
     const { jwt, userId } = await loginAs('Compliance');
     await ensureStaffReady(userId, 'CallClerk');
-    await ensureComplianceClerks(['E2E Clerk']);
 
     const entry = await createCallQueueEntry({
       tag: 'cmp-callq-outcome',
@@ -576,7 +518,9 @@ test.describe('Compliance area (cases)', () => {
     await expect(page.getByText('Signature', { exact: true })).toBeVisible();
     await expect(page.getByText('Outcome', { exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Save Outcome', exact: true })).toBeVisible();
-    await expect(page.getByText('Signature', { exact: true }).locator('xpath=following-sibling::select')).toHaveCount(0);
+    await expect(page.getByText('Signature', { exact: true }).locator('xpath=following-sibling::select')).toHaveCount(
+      0,
+    );
 
     const outcomeSelect = page.getByText('Outcome', { exact: true }).locator('xpath=following-sibling::select');
     await outcomeSelect.selectOption('Completed');

--- a/src/__tests__/call-queue-outcome-form.test.tsx
+++ b/src/__tests__/call-queue-outcome-form.test.tsx
@@ -78,12 +78,7 @@ const USER_CONTEXT = { queue: 'UnavailableSuspicious', userDataId: 1 } as any;
 
 function renderForm(context: any = TX_CONTEXT) {
   return render(
-    <CallQueueOutcomeForm
-      context={context}
-      availableOutcomes={OUTCOMES}
-      onSaved={jest.fn()}
-      title="Save Outcome"
-    />,
+    <CallQueueOutcomeForm context={context} availableOutcomes={OUTCOMES} onSaved={jest.fn()} title="Save Outcome" />,
   );
 }
 
@@ -142,6 +137,14 @@ describe('CallQueueOutcomeForm AmlCheck action', () => {
     renderForm();
 
     expect(screen.getByRole('button', { name: 'Save Outcome' })).toBeDisabled();
+  });
+
+  it('shows the loaded verified name as a read-only signature and has no clerk select', () => {
+    renderForm();
+
+    expect(screen.getByText('JR')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Signature' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Clerk' })).not.toBeInTheDocument();
   });
 
   it('saves the loaded verified name as the signature', async () => {

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -998,13 +998,6 @@ export function useCompliance() {
     });
   }
 
-  async function getCallQueueClerks(): Promise<string[]> {
-    return call<string[]>({
-      url: 'support/call-queues/clerks',
-      method: 'GET',
-    });
-  }
-
   // `file` is a data URL (`data:<contentType>;base64,<data>`, what `toBase64` produces). The API stores
   // it under the account's UserNotes and links it to this very log entry, so the document and the note
   // explaining it stay together — which is what filing a customer's proof of funds needs.
@@ -1534,7 +1527,6 @@ export function useCompliance() {
       getPendingReviewItems,
       getCallQueues,
       getCallQueueItems,
-      getCallQueueClerks,
       saveCallOutcome,
       createKycLog,
       downloadUserFiles,


### PR DESCRIPTION
EN:
The call-queue outcome form no longer has a leftover client for the clerks list. Signature stays the logged-in staff verified name, and a regression test asserts there is no clerk select. The e2e seed that only existed to populate that list is gone.

DE:
Das Call-Queue-Outcome-Formular hat keinen übrig gebliebenen Client mehr für die Clerks-Liste. Die Signatur bleibt der verified name des eingeloggten Staff, und ein Regressionstest stellt sicher, dass es kein Clerk-Select gibt. Der E2E-Seed, der nur diese Liste füllte, entfällt.

<details>
<summary>Details</summary>

Production still shows a clerk dropdown because it ships an older frontend that calls `GET support/call-queues/clerks`. Current develop already renders a read-only verified name (PR 1410). This change removes the unused `getCallQueueClerks` helper and the e2e `complianceClerks` setting seed.

The acting clerk on write is stamped by the API from the auth token. Ticket-assignment clerk dropdowns on support issues are unchanged: those assign work to a colleague, they are not self-identification.

</details>