### PR TITLE
01a02039 - Skip draft CI, default E2E, and run tests before E2E

### DIFF
--- a/.github/workflows/ci-on-ready.yaml
+++ b/.github/workflows/ci-on-ready.yaml
@@ -32,13 +32,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           THIS_REPO: ${{ github.repository }}
         run: |
-          # Use the REST API via curl so this job does not depend on `gh`
-          # being installed on the runner.
+          # Use the REST/GraphQL APIs via curl so this job does not depend
+          # on `gh` being installed on the runner.
           set -euo pipefail
           api="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}"
           tmp="$(mktemp)"
@@ -46,17 +47,31 @@ jobs:
           # ready_for_review already flipped the PR out of draft. If this
           # kick fails, leftover skipped heavy checks would count as passing
           # on a mergeable PR. Put it back to draft so merge stays blocked.
-          # EXIT (not ERR): the fail paths use explicit `exit 1`.
+          # REST has no convert-to-draft endpoint; GraphQL does
+          # (convertPullRequestToDraft). EXIT (not ERR): fail paths `exit 1`.
           revert_to_draft() {
-            local code
+            local code gql
+            if [ -z "${PR_NODE_ID:-}" ]; then
+              echo "::error::PR_NODE_ID is empty; cannot convert to draft." >&2
+              return 1
+            fi
+            gql="$(jq -n --arg id "$PR_NODE_ID" \
+              '{query:"mutation($id:ID!){ convertPullRequestToDraft(input:{pullRequestId:$id}) { pullRequest { isDraft } } }",variables:{id:$id}}')"
             code="$(curl -sS -o "$tmp" -w '%{http_code}' \
               -X POST \
               -H "Authorization: Bearer ${GH_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              "${api}/pulls/${PR_NUMBER}/convert_to_draft")" || code="000"
+              -H "Content-Type: application/json" \
+              -d "$gql" \
+              "${GITHUB_GRAPHQL_URL}")" || code="000"
             if [ "${code#2}" = "$code" ]; then
               echo "::error::convert_to_draft failed: HTTP ${code}" >&2
+              python3 -c 'import sys; print(sys.stdin.read())' < "$tmp" >&2
+              return 1
+            fi
+            if jq -e '.errors != null' "$tmp" >/dev/null; then
+              echo "::error::convert_to_draft GraphQL errors:" >&2
               python3 -c 'import sys; print(sys.stdin.read())' < "$tmp" >&2
               return 1
             fi

--- a/.github/workflows/ci-on-ready.yaml
+++ b/.github/workflows/ci-on-ready.yaml
@@ -1,0 +1,130 @@
+# Ready adds the `ci` label and workflow_dispatches the heavy suite because
+# GITHUB_TOKEN cannot trigger `labeled`. If `ci` or `ci:full` is already set,
+# this job is skipped — no dispatch, no cancel-in-progress restart.
+
+name: Request CI on ready
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  # Creating the repo label `ci` (POST /labels) needs issues:write.
+  # Adding it to the PR needs pull-requests:write. Both are required
+  # for the Ready path when the label does not already exist.
+  issues: write
+  # workflow_dispatch of the heavy workflows, then label (label must not
+  # stick if a dispatch failed).
+  actions: write
+
+jobs:
+  ensure-ci-label:
+    name: Ensure CI label
+    if: >
+      !contains(github.event.pull_request.labels.*.name, 'ci') &&
+      !contains(github.event.pull_request.labels.*.name, 'ci:full')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch heavy workflows, then create/add ci label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          THIS_REPO: ${{ github.repository }}
+        run: |
+          # Use the REST API via curl so this job does not depend on `gh`
+          # being installed on the runner.
+          set -euo pipefail
+          api="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}"
+          tmp="$(mktemp)"
+
+          # ready_for_review already flipped the PR out of draft. If this
+          # kick fails, leftover skipped heavy checks would count as passing
+          # on a mergeable PR. Put it back to draft so merge stays blocked.
+          # EXIT (not ERR): the fail paths use explicit `exit 1`.
+          revert_to_draft() {
+            local code
+            code="$(curl -sS -o "$tmp" -w '%{http_code}' \
+              -X POST \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "${api}/pulls/${PR_NUMBER}/convert_to_draft")" || code="000"
+            if [ "${code#2}" = "$code" ]; then
+              echo "::error::convert_to_draft failed: HTTP ${code}" >&2
+              python3 -c 'import sys; print(sys.stdin.read())' < "$tmp" >&2
+              return 1
+            fi
+            echo "converted PR ${PR_NUMBER} back to draft (HTTP ${code})"
+          }
+          trap 'revert_to_draft' EXIT
+
+          # Fork heads cannot be workflow_dispatched from this repo. Do not add
+          # `ci` with GITHUB_TOKEN first: that would skip later Ready runs and
+          # would not fire `labeled`. A human-applied `ci` still starts CI.
+          # Fork runs get a read-only GITHUB_TOKEN, so convert_to_draft in the
+          # EXIT trap may also fail; the job still fails loud. A maintainer
+          # must apply `ci` (and approve the run) rather than rely on revert.
+          if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
+            echo "error: fork draft — GITHUB_TOKEN cannot workflow_dispatch a fork head." >&2
+            echo "error: a human must apply the ci label so the labeled event starts CI." >&2
+            exit 1
+          fi
+
+          # Dispatch first. Adding `ci` with GITHUB_TOKEN does not start
+          # `labeled` runs, but it would skip this job on a later Ready, so
+          # the label must not stick if a dispatch failed.
+          body="$(jq -n \
+            --arg ref "$HEAD_REF" \
+            --arg pr "$PR_NUMBER" \
+            --arg base "$BASE_REF" \
+            '{ref:$ref, inputs:{pr_number:$pr, base_ref:$base}}')"
+          for wf in pr.yml e2e-stack.yml codeql.yml pr-review-bot.yml; do
+            code="$(curl -sS -o "$tmp" -w '%{http_code}' \
+              -X POST \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -H "Content-Type: application/json" \
+              -d "$body" \
+              "${api}/actions/workflows/${wf}/dispatches")"
+            if [ "${code#2}" = "$code" ]; then
+              echo "dispatch ${wf} failed: HTTP ${code}" >&2
+              python3 -c 'import sys; print(sys.stdin.read())' < "$tmp" >&2
+              exit 1
+            fi
+            echo "dispatched ${wf} on ref ${HEAD_REF} (pr ${PR_NUMBER}, base ${BASE_REF})"
+          done
+
+          code="$(curl -sS -o "$tmp" -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/json" \
+            -d '{"name":"ci","color":"0E8A16","description":"Run PR CI on this draft"}' \
+            "${api}/labels")"
+          if [ "$code" != "422" ] && [ "${code#2}" = "$code" ]; then
+            echo "create label failed: HTTP ${code}" >&2
+            python3 -c 'import sys; print(sys.stdin.read())' < "$tmp" >&2
+            exit 1
+          fi
+          code="$(curl -sS -o "$tmp" -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/json" \
+            -d '{"labels":["ci"]}' \
+            "${api}/issues/${PR_NUMBER}/labels")"
+          if [ "${code#2}" = "$code" ]; then
+            echo "add label failed: HTTP ${code}" >&2
+            python3 -c 'import sys; print(sys.stdin.read())' < "$tmp" >&2
+            exit 1
+          fi
+          trap - EXIT

--- a/.github/workflows/ci-on-ready.yaml
+++ b/.github/workflows/ci-on-ready.yaml
@@ -101,7 +101,7 @@ jobs:
             --arg pr "$PR_NUMBER" \
             --arg base "$BASE_REF" \
             '{ref:$ref, inputs:{pr_number:$pr, base_ref:$base}}')"
-          for wf in pr.yml e2e-stack.yml codeql.yml pr-review-bot.yml; do
+          for wf in pr.yml codeql.yml pr-review-bot.yml; do
             code="$(curl -sS -o "$tmp" -w '%{http_code}' \
               -X POST \
               -H "Authorization: Bearer ${GH_TOKEN}" \

--- a/.github/workflows/ci-on-ready.yaml
+++ b/.github/workflows/ci-on-ready.yaml
@@ -70,8 +70,10 @@ jobs:
               python3 -c 'import sys; print(sys.stdin.read())' < "$tmp" >&2
               return 1
             fi
-            if jq -e '.errors != null' "$tmp" >/dev/null; then
-              echo "::error::convert_to_draft GraphQL errors:" >&2
+            # Fail closed: parse errors, GraphQL errors, and isDraft!=true
+            # must not look like a successful revert.
+            if ! jq -e '.errors == null and .data.convertPullRequestToDraft.pullRequest.isDraft == true' "$tmp" >/dev/null; then
+              echo "::error::convert_to_draft did not confirm isDraft=true:" >&2
               python3 -c 'import sys; print(sys.stdin.read())' < "$tmp" >&2
               return 1
             fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,10 +5,35 @@ on:
     branches: [ "develop", "master" ]
   pull_request:
     branches: [ "develop", "master" ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number when kicked by ci-on-ready (empty = manual full run)
+        required: false
+        type: string
+      base_ref:
+        description: PR base branch when kicked by ci-on-ready
+        required: false
+        type: string
+
+# Draft-skip runs must not share the working group: concurrency fires before
+# the job `if:` and would cancel a live Ready dispatch.
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}-${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ci') || contains(github.event.pull_request.labels.*.name, 'ci:full')) && 'run' || 'skip' }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    # Draft skip only: a skipped required check counts as passing, which is
+    # acceptable only because GitHub cannot merge a draft. Ready is handled
+    # exclusively by ci-on-ready.yaml. Never listen to ready_for_review here.
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false ||
+      contains(github.event.pull_request.labels.*.name, 'ci') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "develop", "master" ]
+    branches: [ "develop", "main" ]
   pull_request:
-    branches: [ "develop", "master" ]
+    branches: [ "develop", "main" ]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/e2e-stack.yml
+++ b/.github/workflows/e2e-stack.yml
@@ -45,9 +45,8 @@ on:
   workflow_dispatch:
     inputs:
       api_ref:
-        description: 'Git ref of DFXswiss/backend to check out and build against'
+        description: 'Git ref of DFXswiss/backend to check out and build against (empty = develop)'
         required: false
-        default: 'develop'
         type: string
       pr_number:
         description: PR number when kicked by ci-on-ready (empty = manual full run)

--- a/.github/workflows/e2e-stack.yml
+++ b/.github/workflows/e2e-stack.yml
@@ -17,11 +17,11 @@
 # A develop PR without the ci:full label does not bring up the stack (mode=none
 # inside the job). That is what keeps a standard develop PR under 10 minutes.
 # PRs into main, a bare workflow_dispatch, and the ci:full label run the full
-# suite. When PR CI calls this workflow with base_ref, scope follows the pull
-# request (also none unless ci:full). Fork pull requests also take mode=none:
-# they do not receive repository secrets, so E2E_API_CHECKOUT_KEY is empty and
-# Checkout API would
-# fail as "repository not found". The probe is the secret, not github.head_ref
+# suite. PR CI passes the boolean `full` (derived from base branch and labels);
+# the workflow_call path only reads that input. Fork pull requests also take
+# mode=none: they do not receive repository secrets, so E2E_API_CHECKOUT_KEY is
+# empty and Checkout API would fail as "repository not found". The probe is the
+# secret, not github.head_ref
 # (that name is fork-spoofable). Draft skip is the only job-level `if:`. API
 # checkout, bootstrap resolution, and harness tsc run only when mode != none.
 # There is no selected/partial spec mapping in this repository.
@@ -120,7 +120,7 @@ jobs:
             exit 0
           fi
 
-          # Ready kick: workflow_dispatch with a non-empty base_ref maps to
+          # Manual workflow_dispatch with a non-empty base_ref maps to
           # pull-request scope. A bare manual dispatch has empty BASE and stays full.
           if [ "$EVENT_NAME" = 'workflow_dispatch' ] && [ -n "${BASE:-}" ]; then
             EVENT_NAME=pull_request

--- a/.github/workflows/e2e-stack.yml
+++ b/.github/workflows/e2e-stack.yml
@@ -1,15 +1,13 @@
 # Full-stack E2E: real frontend + API + Postgres against mocked external providers.
 #
-# A job-level skip is intentional only for drafts that lack `ci`/`ci:full`.
-# A skipped required check counts as passing; that is acceptable only because
-# GitHub cannot merge a draft. Ready is handled exclusively by ci-on-ready.yaml
-# (adds `ci` and workflow_dispatches this suite; GITHUB_TOKEN cannot trigger
-# `labeled`). Never listen to `ready_for_review` here. A human-applied `ci`
-# still starts via `labeled`. Scope (full vs none) still happens inside the
-# job (the "Determine e2e scope" step) instead of `on.paths` or a job `if:`
-# that would skip a ready or labeled required check.
-# If you ever consider adding another skip anywhere in this file, justify it
-# in a comment right there.
+# Draft skip lives on the caller in pr.yml (job `if:`). This file has no
+# pull_request trigger, so `labeled` and Ready do not start it. Ready dispatches
+# pr.yml (not this file); pr.yml then workflow_calls here after Build and test.
+# workflow_dispatch remains for manual runs. Never listen to ready_for_review
+# here. Scope (full vs none) still happens inside the job (the "Determine e2e
+# scope" step) instead of `on.paths` or a job `if:` that would skip a required
+# check. If you ever consider adding another skip anywhere in this file,
+# justify it in a comment right there.
 #
 # Relation to DFXswiss/backend: the corresponding workflow there checks this repository out to
 # find e2e-stack/, so it reads whatever is on develop at the time it runs. Until this pull
@@ -19,9 +17,10 @@
 # A develop PR without the ci:full label does not bring up the stack (mode=none
 # inside the job). That is what keeps a standard develop PR under 10 minutes.
 # PRs into main, a bare workflow_dispatch, and the ci:full label run the full
-# suite. A Ready kick with base_ref follows pull-request scope (also none
-# unless ci:full). Fork pull requests also take mode=none: they do not receive
-# repository secrets, so E2E_API_CHECKOUT_KEY is empty and Checkout API would
+# suite. When PR CI calls this workflow with base_ref, scope follows the pull
+# request (also none unless ci:full). Fork pull requests also take mode=none:
+# they do not receive repository secrets, so E2E_API_CHECKOUT_KEY is empty and
+# Checkout API would
 # fail as "repository not found". The probe is the secret, not github.head_ref
 # (that name is fork-spoofable). Draft skip is the only job-level `if:`. API
 # checkout, bootstrap resolution, and harness tsc run only when mode != none.
@@ -58,21 +57,23 @@ on:
         required: false
         type: string
       pr_number:
-        description: PR number when kicked by ci-on-ready (empty = manual full run)
+        description: PR number for manual dispatch (empty = no PR)
         required: false
         type: string
       base_ref:
-        description: PR base branch when kicked by ci-on-ready
+        description: PR base branch for manual dispatch (empty = bare/full run)
         required: false
         type: string
 
 permissions:
   contents: read
 
-# Draft-skip runs must not share the working group: concurrency fires before
-# the job `if:` and would cancel a live Ready dispatch.
+# Draft-skip runs must not share the working group with a live call.
+# workflow_call (PR path) and workflow_dispatch (manual) must not share a
+# cancel group either. Include event_name so a dispatch cannot cancel the
+# nested required check.
 concurrency:
-  group: e2e-stack-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}-${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ci') || contains(github.event.pull_request.labels.*.name, 'ci:full')) && 'run' || 'skip' }}
+  group: e2e-stack-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}-${{ github.event_name }}-${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ci') || contains(github.event.pull_request.labels.*.name, 'ci:full')) && 'run' || 'skip' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e-stack.yml
+++ b/.github/workflows/e2e-stack.yml
@@ -1,9 +1,15 @@
 # Full-stack E2E: real frontend + API + Postgres against mocked external providers.
 #
-# Do not add a job-level `if:` skip condition (for draft PRs, path filters, or similar).
-# A skipped GitHub Actions check counts as passing, which would silently defeat the
-# merge gate. If you ever consider adding a skip anywhere in this file, justify it in
-# a comment right there.
+# A job-level skip is intentional only for drafts that lack `ci`/`ci:full`.
+# A skipped required check counts as passing; that is acceptable only because
+# GitHub cannot merge a draft. Ready is handled exclusively by ci-on-ready.yaml
+# (adds `ci` and workflow_dispatches this suite; GITHUB_TOKEN cannot trigger
+# `labeled`). Never listen to `ready_for_review` here. A human-applied `ci`
+# still starts via `labeled`. Scope (full vs none) still happens inside the
+# job (the "Determine e2e scope" step) instead of `on.paths` or a job `if:`
+# that would skip a ready or labeled required check.
+# If you ever consider adding another skip anywhere in this file, justify it
+# in a comment right there.
 #
 # Relation to DFXswiss/backend: the corresponding workflow there checks this repository out to
 # find e2e-stack/, so it reads whatever is on develop at the time it runs. Until this pull
@@ -11,13 +17,14 @@
 # instead, which means neither side is blocked on the other and either merge order works.
 #
 # Documentation-only PRs (docs/ and *.md) with safe path characters bring up no stack
-# (mode=none); the job still runs and the Playwright step succeeds with a message.
+# (mode=none); when the job is allowed to run, Playwright succeeds with a message.
 # Fork pull requests also take mode=none: they do not receive repository secrets, so
 # E2E_API_CHECKOUT_KEY is empty and Checkout API would fail as "repository not found".
-# The job still runs (no job-level `if:`). API checkout, bootstrap resolution, and
+# Draft skip is the only job-level `if:`. API checkout, bootstrap resolution, and
 # harness tsc run only when mode != none.
-# PRs into main, workflow_dispatch, and PRs with the `ci:full` label always run the full
-# suite. A change under e2e-stack/ or to .github/workflows/e2e-stack.yml always forces
+# PRs into main, a bare workflow_dispatch (empty base_ref), and PRs with the `ci:full`
+# label always run the full suite. A Ready kick with base_ref follows pull-request
+# scope. A change under e2e-stack/ or to .github/workflows/e2e-stack.yml always forces
 # full (the workflow must not classify itself as none). Every other remaining change
 # after filtering docs/ and *.md is treated as runtime-relevant and runs full. There is
 # no selected/partial spec mapping in this repository.
@@ -33,8 +40,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
-      - edited
       - labeled
       - unlabeled
   workflow_dispatch:
@@ -44,17 +49,32 @@ on:
         required: false
         default: 'develop'
         type: string
+      pr_number:
+        description: PR number when kicked by ci-on-ready (empty = manual full run)
+        required: false
+        type: string
+      base_ref:
+        description: PR base branch when kicked by ci-on-ready
+        required: false
+        type: string
 
 permissions:
   contents: read
 
+# Draft-skip runs must not share the working group: concurrency fires before
+# the job `if:` and would cancel a live Ready dispatch.
 concurrency:
-  group: e2e-stack-${{ github.event.pull_request.number || github.ref }}
+  group: e2e-stack-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}-${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ci') || contains(github.event.pull_request.labels.*.name, 'ci:full')) && 'run' || 'skip' }}
   cancel-in-progress: true
 
 jobs:
   e2e:
     name: Full-stack E2E
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false ||
+      contains(github.event.pull_request.labels.*.name, 'ci') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -66,17 +86,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Decides in-job whether to bring the stack up — never via a job `if:` or a `paths:`
-      # filter, because a skipped check counts as passing (see header comment). Modes are
-      # only full and none; there is no selected/partial spec mapping in this repository.
+      # Decides in-job whether to bring the stack up — never via a `paths:` filter.
+      # Draft skip is the job `if:` above (see header). Modes are only full and none;
+      # there is no selected/partial spec mapping in this repository.
       - name: Determine e2e scope
         id: scope
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE: ${{ github.base_ref }}
+          BASE: ${{ github.base_ref || inputs.base_ref }}
           HAS_API_KEY: ${{ secrets.E2E_API_CHECKOUT_KEY != '' }}
         run: |
           set -euo pipefail
+
+          # Ready kick: workflow_dispatch with a non-empty base_ref maps to
+          # pull-request scope. A bare manual dispatch has empty BASE and stays full.
+          if [ "$EVENT_NAME" = 'workflow_dispatch' ] && [ -n "${BASE:-}" ]; then
+            EVENT_NAME=pull_request
+          fi
 
           # Fork PRs never receive repository secrets. Without E2E_API_CHECKOUT_KEY the
           # next step cannot read the companion API and fails as "repository not found".
@@ -300,8 +326,8 @@ jobs:
         # `if: always()` so artifact collection and teardown still run.
         # --env-file is not optional here: up.sh writes the values it resolved into that file, and
         # a compose run that resolves them differently recreates the API container mid-run.
-        # The step always runs: selection is in-job rather than a skip, so the merge gate
-        # cannot be defeated by a skipped check (see header comment).
+        # Draft skip is the job `if:` above. Inside a run, selection is this step
+        # rather than a `paths:` filter or a scope `if:` (see header comment).
         env:
           MODE: ${{ steps.scope.outputs.mode }}
           API_CRED: ${{ steps.api_cred.outputs.available }}

--- a/.github/workflows/e2e-stack.yml
+++ b/.github/workflows/e2e-stack.yml
@@ -16,18 +16,16 @@
 # request has merged, that workflow bootstraps the harness from this pull request's head
 # instead, which means neither side is blocked on the other and either merge order works.
 #
-# Documentation-only PRs (docs/ and *.md) with safe path characters bring up no stack
-# (mode=none); when the job is allowed to run, Playwright succeeds with a message.
-# Fork pull requests also take mode=none: they do not receive repository secrets, so
-# E2E_API_CHECKOUT_KEY is empty and Checkout API would fail as "repository not found".
-# Draft skip is the only job-level `if:`. API checkout, bootstrap resolution, and
-# harness tsc run only when mode != none.
-# PRs into main, a bare workflow_dispatch (empty base_ref), and PRs with the `ci:full`
-# label always run the full suite. A Ready kick with base_ref follows pull-request
-# scope. A change under e2e-stack/ or to .github/workflows/e2e-stack.yml always forces
-# full (the workflow must not classify itself as none). Every other remaining change
-# after filtering docs/ and *.md is treated as runtime-relevant and runs full. There is
-# no selected/partial spec mapping in this repository.
+# A develop PR without the ci:full label does not bring up the stack (mode=none
+# inside the job). That is what keeps a standard develop PR under 10 minutes.
+# PRs into main, a bare workflow_dispatch, and the ci:full label run the full
+# suite. A Ready kick with base_ref follows pull-request scope (also none
+# unless ci:full). Fork pull requests also take mode=none: they do not receive
+# repository secrets, so E2E_API_CHECKOUT_KEY is empty and Checkout API would
+# fail as "repository not found". The probe is the secret, not github.head_ref
+# (that name is fork-spoofable). Draft skip is the only job-level `if:`. API
+# checkout, bootstrap resolution, and harness tsc run only when mode != none.
+# There is no selected/partial spec mapping in this repository.
 
 name: Full-stack E2E
 
@@ -77,17 +75,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      # Full history (fetch-depth: 0): the scope step below diffs against the merge base
-      # with the PR's base branch (`origin/BASE...HEAD`), which a shallow single-commit
-      # checkout cannot resolve.
-      - name: Checkout services
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      # Decides in-job whether to bring the stack up — never via a `paths:` filter.
-      # Draft skip is the job `if:` above (see header). Modes are only full and none;
-      # there is no selected/partial spec mapping in this repository.
+      # Event-only: no checkout. Develop PRs without ci:full stop here.
+      # Draft skip is the job `if:` above (see header). Modes are only full
+      # and none; there is no selected/partial spec mapping in this repository.
       - name: Determine e2e scope
         id: scope
         env:
@@ -105,10 +95,9 @@ jobs:
 
           # Fork PRs never receive repository secrets. Without E2E_API_CHECKOUT_KEY the
           # next step cannot read the companion API and fails as "repository not found".
-          # Same shape as documentation-only: mode=none, job still runs, check stays
-          # present. Must be first — a change to this file would otherwise force full
-          # and then die on checkout. The probe is the secret, not github.head_ref
-          # (that name is fork-spoofable). workflow_dispatch keeps the secret.
+          # mode=none, job still runs, check stays present. The probe is the secret,
+          # not github.head_ref (that name is fork-spoofable). workflow_dispatch keeps
+          # the secret.
           if [ "$HAS_API_KEY" != 'true' ]; then
             echo 'No run: E2E_API_CHECKOUT_KEY is not available (typical of a fork pull request).'
             echo "mode=none" >> "$GITHUB_OUTPUT"
@@ -138,74 +127,12 @@ jobs:
             exit 0
           fi
 
-          # Safety net: guarantee the base ref exists locally even if the checkout behavior changes.
-          git fetch --quiet origin "$BASE"
+          echo 'E2E skipped: add the ci:full label to run the stack.'
+          echo "mode=none" >> "$GITHUB_OUTPUT"
 
-          # Deletions stay in the diff on purpose (no --diff-filter=d): a PR that only
-          # deletes a runtime-relevant file would otherwise produce an empty list, select
-          # 'none' and bring up no stack at all.
-          #
-          # --no-renames: git's rename detection reports only the NEW path of a renamed
-          # file. With --no-renames a rename is classified as a deletion plus an addition.
-          CHANGED=$(git diff --no-renames --name-only "origin/$BASE...HEAD")
-          echo 'Changed files:'
-          printf '%s\n' "$CHANGED"
-
-          # Path-safety guard on the RAW diff, before filtering: git quotes exotic path
-          # names (core.quotePath), which would distort the classification below - the full
-          # run is the lossless answer for anything outside the safe character set.
-          # Herestring instead of a pipe: with pipefail, grep -q quitting early could turn
-          # a hit into a SIGPIPE failure and silently defuse the guard. grep exit codes 1
-          # (no match) and >=2 (failure) must not be conflated.
-          rc=0
-          grep -qv '^[A-Za-z0-9._/-]*$' <<< "$CHANGED" || rc=$?
-          if (( rc >= 2 )); then
-            echo "::error::grep failed while validating changed paths (exit $rc)."
-            exit 1
-          fi
-          if (( rc == 0 )); then
-            echo 'Full run: a changed path contains characters outside the safe set A-Za-z0-9._/-.'
-            echo "mode=full" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Harness and this workflow are taken from the PR head. A change to either must
-          # not be allowed to classify itself as mode=none.
-          rc=0
-          e2e_hit=$(grep -E '^(e2e-stack/|\.github/workflows/e2e-stack\.yml$)' <<< "$CHANGED") || rc=$?
-          if (( rc >= 2 )); then
-            echo "::error::grep failed while matching e2e-stack or workflow paths (exit $rc)."
-            exit 1
-          fi
-          if (( rc == 0 )); then
-            echo 'Full run: the PR touches e2e-stack/ or this workflow:'
-            echo "$e2e_hit"
-            echo "mode=full" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Drop documentation: a path is documentation if it starts with docs/ or ends
-          # with .md. Empty remainder (docs-only or originally empty diff) → none. Every
-          # leftover path is treated as runtime-relevant → full. grep exit 1 (no remaining
-          # files) is none; >=2 must fail the step.
-          rc=0
-          remaining=$(grep -Ev '(^docs/|\.md$)' <<< "$CHANGED") || rc=$?
-          if (( rc >= 2 )); then
-            echo "::error::grep failed while filtering documentation paths (exit $rc)."
-            exit 1
-          fi
-          # rc==1: grep found no remaining files. Empty remaining after command
-          # substitution also covers an originally empty diff (grep may still exit 0
-          # on a blank herestring line that then collapses to "").
-          if (( rc == 1 )) || [[ -z "$remaining" ]]; then
-            echo 'No run: documentation-only or empty diff (no runtime-relevant changes).'
-            echo "mode=none" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo 'Full run: remaining paths are treated as runtime-relevant:'
-          echo "$remaining"
-          echo "mode=full" >> "$GITHUB_OUTPUT"
+      - name: Checkout services
+        if: steps.scope.outputs.mode != 'none'
+        uses: actions/checkout@v4
 
       # GITHUB_TOKEN of this public repository cannot read the private API
       # repository. A read-only deploy key (secret E2E_API_CHECKOUT_KEY) is
@@ -214,6 +141,7 @@ jobs:
       # Playwright step can take the documented no-stack path instead of
       # failing at checkout with "repository not found".
       - name: Detect API checkout credential
+        if: steps.scope.outputs.mode != 'none'
         id: api_cred
         env:
           KEY: ${{ secrets.E2E_API_CHECKOUT_KEY }}
@@ -332,15 +260,16 @@ jobs:
           API_CRED: ${{ steps.api_cred.outputs.available }}
         run: |
           set -euo pipefail
-          if [ "${API_CRED}" != 'yes' ]; then
-            echo 'No API checkout credential — not starting the e2e stack. The job ran.'
-            exit 0
-          fi
           case "$MODE" in
             none)
-              echo 'No runtime-relevant changes in this PR (documentation-only or empty diff) — not running the e2e stack.'
+              echo 'E2E skipped: add the ci:full label to run the stack (or target main / dispatch).'
+              exit 0
               ;;
             full)
+              if [ "${API_CRED}" != 'yes' ]; then
+                echo 'No API checkout credential — not starting the e2e stack. The job ran.'
+                exit 0
+              fi
               # Every spec is in scope here, so the coverage gate checks navigations, not just claims.
               # E2E_FULL_RUN is inline on this command only — not a static step env that would also
               # apply to mode=none.

--- a/.github/workflows/e2e-stack.yml
+++ b/.github/workflows/e2e-stack.yml
@@ -30,16 +30,27 @@
 name: Full-stack E2E
 
 on:
-  pull_request:
-    branches:
-      - main
-      - develop
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-      - unlabeled
+  # Called from pr.yml after Build and test succeed. A pull_request trigger
+  # here would start this job in parallel with unit tests.
+  workflow_call:
+    inputs:
+      pr_number:
+        description: PR number when called from PR CI
+        required: false
+        type: string
+      base_ref:
+        description: PR base branch when called from PR CI
+        required: false
+        type: string
+      full:
+        description: Bring up the stack (main / ci:full / bare dispatch)
+        required: false
+        type: boolean
+        default: false
+      api_ref:
+        description: Git ref of the companion API to build against
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       api_ref:
@@ -83,25 +94,35 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE: ${{ github.base_ref || inputs.base_ref }}
+          FULL: ${{ inputs.full }}
           HAS_API_KEY: ${{ secrets.E2E_API_CHECKOUT_KEY != '' }}
         run: |
           set -euo pipefail
+
+          # Fork PRs never receive repository secrets. Probe the secret, not
+          # github.head_ref (that name is fork-spoofable).
+          if [ "$HAS_API_KEY" != 'true' ]; then
+            echo 'No run: E2E_API_CHECKOUT_KEY is not available (typical of a fork pull request).'
+            echo "mode=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Caller (PR CI) already decided full vs none after unit tests passed.
+          if [ "$EVENT_NAME" = 'workflow_call' ]; then
+            if [ "$FULL" = 'true' ]; then
+              echo 'Full run: caller requested a full stack.'
+              echo "mode=full" >> "$GITHUB_OUTPUT"
+            else
+              echo 'E2E skipped: add the ci:full label to run the stack.'
+              echo "mode=none" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
 
           # Ready kick: workflow_dispatch with a non-empty base_ref maps to
           # pull-request scope. A bare manual dispatch has empty BASE and stays full.
           if [ "$EVENT_NAME" = 'workflow_dispatch' ] && [ -n "${BASE:-}" ]; then
             EVENT_NAME=pull_request
-          fi
-
-          # Fork PRs never receive repository secrets. Without E2E_API_CHECKOUT_KEY the
-          # next step cannot read the companion API and fails as "repository not found".
-          # mode=none, job still runs, check stays present. The probe is the secret,
-          # not github.head_ref (that name is fork-spoofable). workflow_dispatch keeps
-          # the secret.
-          if [ "$HAS_API_KEY" != 'true' ]; then
-            echo 'No run: E2E_API_CHECKOUT_KEY is not available (typical of a fork pull request).'
-            echo "mode=none" >> "$GITHUB_OUTPUT"
-            exit 0
           fi
 
           # Release PRs into main (and any non-develop base) and manual dispatches always

--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -5,7 +5,23 @@ on:
     branches:
       - main
       - develop
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number when kicked by ci-on-ready (required for a useful run)
+        required: false
+        type: string
+      base_ref:
+        description: PR base branch when kicked by ci-on-ready
+        required: false
+        type: string
+
+# Draft-skip runs must not share the working group: concurrency fires before
+# the job `if:` and would cancel a live Ready dispatch.
+concurrency:
+  group: review-pr-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}-${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ci') || contains(github.event.pull_request.labels.*.name, 'ci:full')) && 'run' || 'skip' }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write
@@ -13,7 +29,18 @@ permissions:
 
 jobs:
   review:
+    # Draft skip only: a skipped required check counts as passing, which is
+    # acceptable only because GitHub cannot merge a draft. Ready is handled
+    # exclusively by ci-on-ready.yaml. Never listen to ready_for_review here.
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false ||
+      contains(github.event.pull_request.labels.*.name, 'ci') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
     runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+      BASE_REF: ${{ github.base_ref || inputs.base_ref }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,10 +61,11 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const prNumber = Number(process.env.PR_NUMBER || context.issue.number);
             const commits = await github.rest.pulls.listCommits({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
+              pull_number: prNumber
             });
 
             const unverified = commits.data.filter(c => !c.commit.verification?.verified);
@@ -103,18 +131,27 @@ jobs:
       - name: Check for new TODOs/FIXMEs
         id: todos
         run: |
-          git diff origin/${{ github.base_ref }}...HEAD -- '*.ts' '*.tsx' | grep -E '^\+.*\b(TODO|FIXME|HACK|XXX)\b' | head -20 > new-todos.txt || true
+          set -euo pipefail
+          if [ -z "${BASE_REF:-}" ]; then
+            echo "::error::BASE_REF is empty; cannot diff TODOs against the PR base."
+            exit 1
+          fi
+          git fetch --quiet origin "$BASE_REF"
+          git diff "origin/${BASE_REF}"...HEAD -- '*.ts' '*.tsx' | grep -E '^\+.*\b(TODO|FIXME|HACK|XXX)\b' | head -20 > new-todos.txt || true
           COUNT=$(wc -l < new-todos.txt | tr -d ' ')
           echo "count=$COUNT" >> $GITHUB_OUTPUT
 
       - name: Post PR comment
         # Fork PRs run with a read-only GITHUB_TOKEN, so the issue-comment API returns 403 and fails the whole job.
         # The bot can only post on same-repo PRs; skip cleanly on forks instead of turning the check red.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        # workflow_dispatch is the in-repo ready kick, so it must post.
+        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
+
+            const prNumber = Number(process.env.PR_NUMBER || context.issue.number);
 
             const unverified = '${{ steps.verify-commits.outputs.unverified }}' === 'true';
             const unverifiedCount = '${{ steps.verify-commits.outputs.unverified_count }}';
@@ -203,7 +240,7 @@ jobs:
             const existingComments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number
+              issue_number: prNumber
             });
 
             const botComment = existingComments.data.find(c =>
@@ -221,7 +258,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: prNumber,
                 body
               });
             }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -252,3 +252,20 @@ jobs:
 
       - name: Build widget
         run: npm run widget:dev
+
+  # After Build and test so E2E cannot start (and occupy a runner) while unit
+  # tests are still queued. Develop without ci:full is an in-job no-op.
+  e2e:
+    name: Full-stack E2E
+    needs: [build]
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false ||
+      contains(github.event.pull_request.labels.*.name, 'ci') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
+    uses: ./.github/workflows/e2e-stack.yml
+    with:
+      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+      base_ref: ${{ github.base_ref || inputs.base_ref }}
+      full: ${{ (github.event_name == 'pull_request' && (github.base_ref == 'main' || contains(github.event.pull_request.labels.*.name, 'ci:full'))) || (github.event_name != 'pull_request' && (inputs.base_ref == '' || inputs.base_ref == 'main')) }}
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,12 +1,20 @@
 # PR CI: lint, format, tests, and builds.
 #
-# The job has no `if:` because a skipped required check counts as passing.
-# Develop PRs without the `ci:full` label run only Jest `--findRelatedTests` on
-# changed files under `src/**` and `functions/**`. The full suite runs for PRs
-# into main, workflow_dispatch, the `ci:full` label, test/build infrastructure
-# changes, unsafe path characters, and any deleted (or renamed-as-deleted)
-# source file under `src/` or `functions/`. Lint, Markdown format check,
-# `build:dev`, and `widget:dev` always run in full.
+# A job-level skip is intentional only for drafts that lack `ci`/`ci:full`.
+# A skipped required check counts as passing; that is acceptable only because
+# GitHub cannot merge a draft. Ready is handled exclusively by ci-on-ready.yaml
+# (adds `ci` and workflow_dispatches this suite; GITHUB_TOKEN cannot trigger
+# `labeled`). Never listen to `ready_for_review` here. A human-applied `ci`
+# still starts via `labeled`.
+#
+# When the job runs, develop PRs without the `ci:full` label run only Jest
+# `--findRelatedTests` on changed files under `src/**` and `functions/**`. The
+# full suite runs for PRs into main, a bare workflow_dispatch (empty
+# base_ref), the `ci:full` label, test/build infrastructure changes, unsafe
+# path characters, and any deleted (or renamed-as-deleted) source file under
+# `src/` or `functions/`. A Ready kick with base_ref follows pull-request
+# scope. Lint, Markdown format check, `build:dev`, and `widget:dev` always
+# run in full.
 
 name: PR CI
 
@@ -19,11 +27,18 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
-      - edited
       - labeled
       - unlabeled
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number when kicked by ci-on-ready (empty = manual full run)
+        required: false
+        type: string
+      base_ref:
+        description: PR base branch when kicked by ci-on-ready
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -31,9 +46,22 @@ permissions:
 env:
   NODE_VERSION: '20.x'
 
+# A new push must cancel the previous run of this PR. Ready dispatch uses
+# pr_number so it shares the group and does not start a sibling suite.
+# Draft-skip runs (job `if:` false) must not share that group: concurrency
+# fires before the skip, and would cancel a live Ready dispatch.
+concurrency:
+  group: pr-ci-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}-${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ci') || contains(github.event.pull_request.labels.*.name, 'ci:full')) && 'run' || 'skip' }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and test
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false ||
+      contains(github.event.pull_request.labels.*.name, 'ci') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
     runs-on: ubuntu-latest
     steps:
       # Full history (fetch-depth: 0): the scope step below diffs against the merge base
@@ -45,13 +73,13 @@ jobs:
           fetch-depth: 0
 
       # Decides, inside the job, whether this run needs the full suite or only the tests
-      # related to the PR's changed files. Never a job `if:` or a `paths:` filter: a
-      # skipped required check counts as passing.
+      # related to the PR's changed files. Never a `paths:` filter: a skipped required
+      # check counts as passing. Draft skip is the job `if:` above, not this step.
       - name: Determine test scope
         id: scope
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE: ${{ github.base_ref }}
+          BASE: ${{ github.base_ref || inputs.base_ref }}
         run: |
           set -euo pipefail
 
@@ -64,6 +92,12 @@ jobs:
             { echo "mode=$mode"; echo "files=$files"; } >> "$GITHUB_OUTPUT"
             exit 0
           }
+
+          # Ready kick: workflow_dispatch with a non-empty base_ref maps to
+          # pull-request scope. A bare manual dispatch has empty BASE and stays full.
+          if [ "$EVENT_NAME" = 'workflow_dispatch' ] && [ -n "${BASE:-}" ]; then
+            EVENT_NAME=pull_request
+          fi
 
           if [[ "$EVENT_NAME" != 'pull_request' ]]; then
             echo "Full run: event is '$EVENT_NAME', not a pull request."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,14 +81,20 @@ Two obligations follow from it for every pull request:
 npm run test
 ```
 
-The PR CI job always runs. Develop PRs without `ci:full` run Jest
+Draft PRs skip the PR CI job unless they carry the `ci` or `ci:full` label.
+Apply `ci` on a draft to run the job, or `ci:full` to force the full Jest
+suite. Marking a same-repo PR ready for review requests CI once: it adds `ci`
+and dispatches the suite. If `ci` or `ci:full` is already present, ready does
+not start a second run. Fork heads cannot be dispatched that way; apply `ci`
+so the `labeled` event starts CI (a maintainer may still need to approve the
+run). When the job runs, develop PRs without `ci:full` run Jest
 `--findRelatedTests` on changed files under `src/` and `functions/`. A PR with
 no such files and no full-run trigger records `mode=none` and skips the suite
 without failing. Apply `ci:full` to force the full suite, as do PRs into `main`,
-`workflow_dispatch`, unsafe path characters, test/build infrastructure, and
-deleting or renaming files under `src/` or `functions/`. Lint, Markdown
-formatting (`format:md:check`), `build:dev` and `widget:dev` always run in full.
-The job is never skipped.
+a bare `workflow_dispatch`, unsafe path characters, test/build infrastructure,
+and deleting or renaming files under `src/` or `functions/`. Lint, Markdown
+formatting (`format:md:check`), `build:dev` and `widget:dev` always run in full
+when the job runs.
 
 #### Coverage
 
@@ -206,11 +212,15 @@ yourself, so nothing fails at build time.
 The full-stack harness under `e2e-stack/` runs the real frontend, API, and
 Postgres together (external providers are mocked). Unlike the visual-regression
 suite under `e2e/` — see [Visual regression tests (Playwright)](#visual-regression-tests-playwright)
-above, which does not run in CI — this harness's job runs on every pull request.
-The stack comes up only for runtime-relevant changes. Documentation-only PRs with
-safe path characters record `mode=none` and skip the stack. Apply `ci:full` (or
-target `main`, run `workflow_dispatch`, use unsafe path characters, or touch
-`e2e-stack/` / `.github/workflows/e2e-stack.yml`) to force a full run.
+above, which does not run in CI — this harness's job follows the same draft
+policy as PR CI: drafts skip it unless they carry `ci` or `ci:full`; a
+same-repo ready requests it once and does not start a second run when that
+label is already present; fork heads need `ci` (and possibly run approval).
+When the job runs, the stack comes up only for runtime-relevant
+changes. Documentation-only PRs with safe path characters record `mode=none`
+and skip the stack. Apply `ci:full` (or target `main`, run a bare
+`workflow_dispatch`, use unsafe path characters, or touch `e2e-stack/` /
+`.github/workflows/e2e-stack.yml`) to force a full run.
 
 A pull request that changes a screen or an API contract should bring or update
 the matching full-stack test.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,8 +234,9 @@ was never actually opened by any test. The browser records every navigation it
 makes, and the gate compares that recording against the route list, so a claim
 pointing at a file that never visits the route does not satisfy it. Adding a route
 therefore means adding a claim in `e2e-stack/specs/registry/` and a test that
-navigates there; otherwise CI goes red on the new route, not on some unrelated
-assertion.
+navigates there. That gate runs only when the stack comes up (`ci:full`, a PR
+into `main`, or a bare `workflow_dispatch`); a standard develop PR without
+`ci:full` does not enforce it.
 
 Run locally:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,9 @@ and deleting or renaming files under `src/` or `functions/`. Lint, Markdown
 formatting (`format:md:check`), `build:dev` and `widget:dev` always run in full
 when the job runs. A standard PR into `develop` (no `ci:full`) must finish CI
 in under 10 minutes wall-clock; the full-stack E2E job is an in-job no-op
-unless `ci:full` is set. Full runs (`ci:full`, PRs into `main`, a bare
-`workflow_dispatch`) may take longer.
+unless `ci:full` is set. Full-stack E2E is called from PR CI after Build and
+test succeed, so it cannot start while unit tests are still queued. Full runs
+(`ci:full`, PRs into `main`, a bare `workflow_dispatch`) may take longer.
 
 #### Coverage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,10 @@ without failing. Apply `ci:full` to force the full suite, as do PRs into `main`,
 a bare `workflow_dispatch`, unsafe path characters, test/build infrastructure,
 and deleting or renaming files under `src/` or `functions/`. Lint, Markdown
 formatting (`format:md:check`), `build:dev` and `widget:dev` always run in full
-when the job runs.
+when the job runs. A standard PR into `develop` (no `ci:full`) must finish CI
+in under 10 minutes wall-clock; the full-stack E2E job is an in-job no-op
+unless `ci:full` is set. Full runs (`ci:full`, PRs into `main`, a bare
+`workflow_dispatch`) may take longer.
 
 #### Coverage
 
@@ -216,11 +219,9 @@ above, which does not run in CI — this harness's job follows the same draft
 policy as PR CI: drafts skip it unless they carry `ci` or `ci:full`; a
 same-repo ready requests it once and does not start a second run when that
 label is already present; fork heads need `ci` (and possibly run approval).
-When the job runs, the stack comes up only for runtime-relevant
-changes. Documentation-only PRs with safe path characters record `mode=none`
-and skip the stack. Apply `ci:full` (or target `main`, run a bare
-`workflow_dispatch`, use unsafe path characters, or touch `e2e-stack/` /
-`.github/workflows/e2e-stack.yml`) to force a full run.
+A develop PR without `ci:full` records `mode=none` and does not bring the
+stack up (the job still runs). Apply `ci:full`, target `main`, or run a bare
+`workflow_dispatch` to force a full run.
 
 A pull request that changes a screen or an API contract should bring or update
 the matching full-stack test.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -12,8 +12,8 @@ built yet; nothing here may describe a capability as existing when it does not.
 
 | Layer             | Location     | What it proves                                                               | What it cannot prove                                               | Runs in CI                                   |
 | ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------- |
-| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | job always; suite full / related / none      |
-| Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — every process-gated job is off during the run | job always; stack not on safe-path docs-only |
+| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | drafts skip unless `ci`/`ci:full`; suite full / related / none |
+| Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — every process-gated job is off during the run | drafts skip unless `ci`/`ci:full`; stack not on safe-path docs-only |
 | Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                           | no                                           |
 
 The processing chain behind the API — incoming transfers, AML, purchase calculation, liquidity,

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -10,11 +10,11 @@ built yet; nothing here may describe a capability as existing when it does not.
 
 ## The layers this repository owns
 
-| Layer             | Location     | What it proves                                                               | What it cannot prove                                               | Runs in CI                                   |
-| ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------- |
-| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | drafts skip unless `ci`/`ci:full`; suite full / related / none |
+| Layer             | Location     | What it proves                                                               | What it cannot prove                                               | Runs in CI                                                          |
+| ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | drafts skip unless `ci`/`ci:full`; suite full / related / none      |
 | Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — every process-gated job is off during the run | drafts skip unless `ci`/`ci:full`; stack not on safe-path docs-only |
-| Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                           | no                                           |
+| Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                           | no                                                                  |
 
 The processing chain behind the API — incoming transfers, AML, purchase calculation, liquidity,
 payout, ledger booking — is **not** testable from this repository. It belongs to the integration
@@ -72,9 +72,9 @@ claimed route the browser never opened. That flag is declared by the run, not me
 only be set when the run really covers every spec: `e2e-stack/scripts/run.sh` sets it when it was given
 no arguments and clears it otherwise — clearing matters because `e2e-stack/compose.tests.yml` forwards
 whatever the caller's environment holds — and the CI workflow sets it when it brings the stack up (full run). Safe-path
-documentation-only PRs never set it; `ci:full`, PRs into `main`, a
-bare `workflow_dispatch` (empty `base_ref`), unsafe path characters, and changes under `e2e-stack/` or
-`.github/workflows/e2e-stack.yml` force that full invocation.
+documentation-only PRs never set it; `ci:full`, PRs into `main`, a bare `workflow_dispatch` (empty
+`base_ref`), unsafe path characters, and changes under `e2e-stack/` or `.github/workflows/e2e-stack.yml`
+force that full invocation.
 Adding a route therefore means adding a claim in `e2e-stack/specs/registry/` and a test that navigates
 there.
 

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -72,8 +72,8 @@ claimed route the browser never opened. That flag is declared by the run, not me
 only be set when the run really covers every spec: `e2e-stack/scripts/run.sh` sets it when it was given
 no arguments and clears it otherwise — clearing matters because `e2e-stack/compose.tests.yml` forwards
 whatever the caller's environment holds — and the CI workflow sets it when it brings the stack up (full run). Safe-path
-documentation-only PRs never set it; `ci:full`, PRs into `main`,
-`workflow_dispatch`, unsafe path characters, and changes under `e2e-stack/` or
+documentation-only PRs never set it; `ci:full`, PRs into `main`, a
+bare `workflow_dispatch` (empty `base_ref`), unsafe path characters, and changes under `e2e-stack/` or
 `.github/workflows/e2e-stack.yml` force that full invocation.
 Adding a route therefore means adding a claim in `e2e-stack/specs/registry/` and a test that navigates
 there.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -10,11 +10,11 @@ built yet; nothing here may describe a capability as existing when it does not.
 
 ## The layers this repository owns
 
-| Layer             | Location     | What it proves                                                               | What it cannot prove                                               | Runs in CI                                                          |
-| ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------- |
-| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | drafts skip unless `ci`/`ci:full`; suite full / related / none      |
-| Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — every process-gated job is off during the run | drafts skip unless `ci`/`ci:full`; stack not on safe-path docs-only |
-| Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                           | no                                                                  |
+| Layer             | Location     | What it proves                                                               | What it cannot prove                                               | Runs in CI                                                                          |
+| ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | drafts skip unless `ci`/`ci:full`; suite full / related / none                      |
+| Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — every process-gated job is off during the run | drafts skip unless `ci`/`ci:full`; stack only with `ci:full` / main / bare dispatch |
+| Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                           | no                                                                                  |
 
 The processing chain behind the API — incoming transfers, AML, purchase calculation, liquidity,
 payout, ledger booking — is **not** testable from this repository. It belongs to the integration
@@ -71,10 +71,9 @@ the spec file a claim names does not exist. When `E2E_FULL_RUN=1` is set, it add
 claimed route the browser never opened. That flag is declared by the run, not measured from it, so it may
 only be set when the run really covers every spec: `e2e-stack/scripts/run.sh` sets it when it was given
 no arguments and clears it otherwise — clearing matters because `e2e-stack/compose.tests.yml` forwards
-whatever the caller's environment holds — and the CI workflow sets it when it brings the stack up (full run). Safe-path
-documentation-only PRs never set it; `ci:full`, PRs into `main`, a bare `workflow_dispatch` (empty
-`base_ref`), unsafe path characters, and changes under `e2e-stack/` or `.github/workflows/e2e-stack.yml`
-force that full invocation.
+whatever the caller's environment holds — and the CI workflow sets it when it brings the stack up (full run).
+Develop PRs without `ci:full` never set it; `ci:full`, PRs into `main`, and a bare `workflow_dispatch`
+(empty `base_ref`) force that full invocation.
 Adding a route therefore means adding a claim in `e2e-stack/specs/registry/` and a test that navigates
 there.
 

--- a/e2e-stack/README.md
+++ b/e2e-stack/README.md
@@ -121,12 +121,15 @@ The tests container starts a `socat`-based TCP forwarder on `127.0.0.1:3000` (ov
 
 The suite under `e2e/` is visual-regression testing (screenshot baselines). It deliberately does not run in CI, because baselines are platform- and font-dependent.
 
-This harness checks function, not appearance. The CI job always runs; the stack
-comes up only for runtime-relevant changes. Documentation-only PRs with safe path
-characters skip the stack (`mode=none`). There is no selected/partial mode:
-every leftover runtime path, the `ci:full` label, PRs into `main`,
-`workflow_dispatch`, unsafe path characters, and changes under `e2e-stack/` or
-`.github/workflows/e2e-stack.yml` force a full run. Both suites exist side by side and serve different purposes.
+This harness checks function, not appearance. Draft PRs skip the CI job unless
+they carry `ci` or `ci:full`; a same-repo ready requests it once and does not
+start a second run when that label is already present. When the job runs, the
+stack comes up only for runtime-relevant changes. Documentation-only PRs with
+safe path characters skip the stack (`mode=none`). There is no selected/partial
+mode: every leftover runtime path, the `ci:full` label, PRs into `main`, a
+bare `workflow_dispatch` (empty `base_ref`), unsafe path characters, and
+changes under `e2e-stack/` or `.github/workflows/e2e-stack.yml` force a full
+run. Both suites exist side by side and serve different purposes.
 
 ## Relationship with the API repository
 

--- a/e2e-stack/README.md
+++ b/e2e-stack/README.md
@@ -123,13 +123,11 @@ The suite under `e2e/` is visual-regression testing (screenshot baselines). It d
 
 This harness checks function, not appearance. Draft PRs skip the CI job unless
 they carry `ci` or `ci:full`; a same-repo ready requests it once and does not
-start a second run when that label is already present. When the job runs, the
-stack comes up only for runtime-relevant changes. Documentation-only PRs with
-safe path characters skip the stack (`mode=none`). There is no selected/partial
-mode: every leftover runtime path, the `ci:full` label, PRs into `main`, a
-bare `workflow_dispatch` (empty `base_ref`), unsafe path characters, and
-changes under `e2e-stack/` or `.github/workflows/e2e-stack.yml` force a full
-run. Both suites exist side by side and serve different purposes.
+start a second run when that label is already present. A develop PR without
+`ci:full` records `mode=none` and does not bring the stack up. There is no
+selected/partial mode: `ci:full`, PRs into `main`, and a bare
+`workflow_dispatch` (empty `base_ref`) force a full run. Both suites exist
+side by side and serve different purposes.
 
 ## Relationship with the API repository
 
@@ -187,7 +185,7 @@ docker run --rm -v "${project}_e2e-test-results:/vol" -v "$(pwd)/test-results:/d
 docker run --rm -v "${project}_e2e-playwright-report:/vol" -v "$(pwd)/playwright-report:/dest" alpine cp -a /vol/. /dest/
 ```
 
-In CI the workflow does this automatically on a full run and uploads an artifact named `e2e-stack-report`. Docs-only runs (`mode=none`) produce no artifact.
+In CI the workflow does this automatically on a full run and uploads an artifact named `e2e-stack-report`. Skipped stack runs (`mode=none`) produce no artifact.
 
 **Stack does not become healthy**
 


### PR DESCRIPTION
EN:
Draft pull requests skip heavy CI unless they carry `ci` or `ci:full`. A develop PR without `ci:full` does not bring up the full-stack E2E. E2E is called from PR CI after Build and test succeed, so it cannot start while unit tests are still queued.

DE:
Draft-PRs überspringen die schwere CI ohne `ci` oder `ci:full`. Ein Develop-PR ohne `ci:full` fährt den Full-Stack-E2E nicht hoch. E2E startet erst nach Build and test, damit Unit-Tests nicht hinter dem Stack in der Queue stehen.

<details>
<summary>Details</summary>

Ready for review requests CI once and does not start a second run when `ci` or `ci:full` is already present. Full E2E remains for `ci:full`, PRs into `main`, and a bare `workflow_dispatch`. The parallel pull_request trigger of e2e-stack.yml is gone; ci-on-ready no longer dispatches it separately.

</details>