### PR TITLE
feat(support): add fiatOutput

### DIFF
--- a/src/__tests__/compliance-transaction-action-refresh.test.tsx
+++ b/src/__tests__/compliance-transaction-action-refresh.test.tsx
@@ -133,6 +133,7 @@ function renderTable(onStatusChanged?: () => void, rows: TransactionInfo[] = [tx
         onExpandBankTx={jest.fn()}
         onExpandCryptoInput={jest.fn()}
         onExpandBankData={jest.fn()}
+        onExpandFiatOutput={jest.fn()}
         onExpandTxUid={setExpandedTxUid}
         expandedTxUid={expandedTxUid}
         onStatusChanged={onStatusChanged}

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -9,12 +9,13 @@ import {
   BankDataInfo,
   BankTxInfo,
   CryptoInputInfo,
+  FiatOutputInfo,
   RecallInfo,
   TransactionInfo,
-  UserDataDetail,
   useCompliance,
+  UserDataDetail,
 } from 'src/hooks/compliance.hook';
-import { boolBadge, DetailRow, statusBadge, TransactionDetailRows, formatDate } from 'src/util/compliance-helpers';
+import { boolBadge, DetailRow, formatDate, statusBadge, TransactionDetailRows } from 'src/util/compliance-helpers';
 import { PdfLang } from 'src/util/pdf/support-pdf-common';
 
 interface TransactionsTableProps {
@@ -27,11 +28,13 @@ interface TransactionsTableProps {
   expandedBankTxId?: number;
   expandedCryptoInputId?: number;
   expandedBankDataId?: number;
+  expandedFiatOutputId?: number;
   expandedTxUid?: string;
   canPerformActions?: boolean;
   onExpandBankTx: (id: number | undefined) => void;
   onExpandCryptoInput: (id: number | undefined) => void;
   onExpandBankData: (id: number | undefined) => void;
+  onExpandFiatOutput: (id: number | undefined) => void;
   onExpandTxUid: (uid: string | undefined) => void;
   onStatusChanged?: () => void;
 }
@@ -46,11 +49,13 @@ export function TransactionsTable({
   expandedBankTxId,
   expandedCryptoInputId,
   expandedBankDataId,
+  expandedFiatOutputId,
   expandedTxUid,
   canPerformActions = true,
   onExpandBankTx,
   onExpandCryptoInput,
   onExpandBankData,
+  onExpandFiatOutput,
   onExpandTxUid,
   onStatusChanged,
 }: TransactionsTableProps): JSX.Element {
@@ -246,6 +251,7 @@ export function TransactionsTable({
             <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Bank TX</th>
             <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Bank Data</th>
             <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Crypto In</th>
+            <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Fiat Out</th>
             <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Created</th>
             <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Completed</th>
           </tr>
@@ -256,9 +262,11 @@ export function TransactionsTable({
               const bankTx = bankTxByTxId.get(tx.id);
               const cryptoInput = cryptoInputByTxId.get(tx.id);
               const bankData = tx.bankDataId != null ? bankDataById.get(tx.bankDataId) : undefined;
+              const fiatOutput: FiatOutputInfo | undefined = tx.fiatOutput;
               const isBankTxExpanded = expandedBankTxId === bankTx?.id;
               const isCryptoExpanded = expandedCryptoInputId === cryptoInput?.id;
               const isBankDataExpanded = expandedBankDataId === bankData?.id;
+              const isFiatOutputExpanded = expandedFiatOutputId === fiatOutput?.id;
               const detailError = txDetailErrors.get(tx.uid);
 
               return (
@@ -341,6 +349,18 @@ export function TransactionsTable({
                         '-'
                       )}
                     </td>
+                    <td className="px-3 py-2 text-sm text-dfxBlue-800 text-center">
+                      {fiatOutput ? (
+                        <button
+                          className="text-dfxBlue-300 underline hover:text-dfxBlue-800"
+                          onClick={() => onExpandFiatOutput(isFiatOutputExpanded ? undefined : fiatOutput.id)}
+                        >
+                          {fiatOutput.id}
+                        </button>
+                      ) : (
+                        '-'
+                      )}
+                    </td>
                     <td className="px-3 py-2 text-sm text-dfxBlue-800">{formatDate(tx.created)}</td>
                     <td className="px-3 py-2 text-sm text-dfxBlue-800 text-center">
                       {tx.isCompleted ? (
@@ -353,7 +373,7 @@ export function TransactionsTable({
 
                   {isBankTxExpanded && bankTx && (
                     <tr key={`bankTx-${bankTx.id}`} className="bg-dfxGray-300/50">
-                      <td colSpan={15} className="px-6 py-3">
+                      <td colSpan={16} className="px-6 py-3">
                         <table className="text-sm text-dfxBlue-800 text-left">
                           <tbody>
                             <DetailRow label="Account Service Ref" value={bankTx.accountServiceRef} />
@@ -368,7 +388,7 @@ export function TransactionsTable({
 
                   {isBankDataExpanded && bankData && (
                     <tr key={`bankData-${bankData.id}`} className="bg-dfxGray-300/50">
-                      <td colSpan={15} className="px-6 py-3">
+                      <td colSpan={16} className="px-6 py-3">
                         <table className="text-sm text-dfxBlue-800 text-left">
                           <tbody>
                             <DetailRow label="IBAN" value={bankData.iban} mono />
@@ -404,7 +424,7 @@ export function TransactionsTable({
 
                   {isCryptoExpanded && cryptoInput && (
                     <tr key={`ci-${cryptoInput.id}`} className="bg-dfxGray-300/50">
-                      <td colSpan={15} className="px-6 py-3">
+                      <td colSpan={16} className="px-6 py-3">
                         <table className="text-sm text-dfxBlue-800 text-left">
                           <tbody>
                             <DetailRow
@@ -437,9 +457,78 @@ export function TransactionsTable({
                     </tr>
                   )}
 
+                  {isFiatOutputExpanded && fiatOutput && (
+                    <tr key={`fo-${fiatOutput.id}`} className="bg-dfxGray-300/50">
+                      <td colSpan={16} className="px-6 py-3">
+                        <table className="text-sm text-dfxBlue-800 text-left">
+                          <tbody>
+                            <DetailRow label="Type" value={fiatOutput.type} />
+                            <DetailRow
+                              label="Amount"
+                              value={
+                                fiatOutput.amount != null
+                                  ? `${fiatOutput.amount} ${fiatOutput.currency ?? ''}`
+                                  : undefined
+                              }
+                            />
+                            <DetailRow
+                              label="Valuta Date"
+                              value={fiatOutput.valutaDate ? formatDate(fiatOutput.valutaDate) : undefined}
+                            />
+                            <DetailRow label="Name" value={fiatOutput.name} />
+                            <DetailRow
+                              label="Address"
+                              value={
+                                [fiatOutput.address, fiatOutput.houseNumber].filter(Boolean).join(' ') || undefined
+                              }
+                            />
+                            <DetailRow
+                              label="ZIP / City"
+                              value={[fiatOutput.zip, fiatOutput.city].filter(Boolean).join(' ') || undefined}
+                            />
+                            <DetailRow label="Country" value={fiatOutput.country} />
+                            <DetailRow label="IBAN" value={fiatOutput.iban} mono />
+                            <DetailRow label="BIC" value={fiatOutput.bic} mono />
+                            <DetailRow label="Bank ID" value={fiatOutput.bank?.id} />
+                            <DetailRow label="Bank Name" value={fiatOutput.bank?.name} />
+                            <DetailRow label="Bank IBAN" value={fiatOutput.bank?.iban} mono />
+                            <DetailRow label="Bank Tx ID" value={fiatOutput.bankTxId} />
+                            <DetailRow label="Origin Entity ID" value={fiatOutput.originEntityId} />
+                            <DetailRow
+                              label="Ready Date"
+                              value={fiatOutput.isReadyDate ? formatDate(fiatOutput.isReadyDate) : undefined}
+                            />
+                            <DetailRow
+                              label="Transmitted Date"
+                              value={
+                                fiatOutput.isTransmittedDate ? formatDate(fiatOutput.isTransmittedDate) : undefined
+                              }
+                            />
+                            <DetailRow
+                              label="Confirmed Date"
+                              value={fiatOutput.isConfirmedDate ? formatDate(fiatOutput.isConfirmedDate) : undefined}
+                            />
+                            <DetailRow
+                              label="Approved Date"
+                              value={fiatOutput.isApprovedDate ? formatDate(fiatOutput.isApprovedDate) : undefined}
+                            />
+                            <DetailRow
+                              label="Output Date"
+                              value={fiatOutput.outputDate ? formatDate(fiatOutput.outputDate) : undefined}
+                            />
+                            <DetailRow
+                              label="Completed"
+                              value={fiatOutput.isComplete != null ? String(fiatOutput.isComplete) : undefined}
+                            />
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  )}
+
                   {expandedTxUid === tx.uid && (
                     <tr key={`txDetail-${tx.uid}`} className="bg-dfxGray-300/50">
-                      <td colSpan={15} className="px-6 py-3">
+                      <td colSpan={16} className="px-6 py-3">
                         {txDetailLoading === tx.uid ? (
                           <StyledLoadingSpinner size={SpinnerSize.SM} />
                         ) : detailError != null && !txDetailCache.has(tx.uid) ? (
@@ -579,7 +668,7 @@ export function TransactionsTable({
             })
           ) : (
             <tr>
-              <td colSpan={15} className="px-3 py-4 text-center text-dfxGray-700">
+              <td colSpan={16} className="px-3 py-4 text-center text-dfxGray-700">
                 No transactions
               </td>
             </tr>

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -464,7 +464,7 @@ export function TransactionsTable({
                           <tbody>
                             <DetailRow label="Type" value={fiatOutput.type} />
                             <DetailRow
-                              label="Amount"
+                              label="Amount (buyFiat possibly batched)"
                               value={
                                 fiatOutput.amount != null
                                   ? `${fiatOutput.amount} ${fiatOutput.currency ?? ''}`

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -515,6 +515,37 @@ export interface UserInfo {
   created: string;
 }
 
+export interface BankInfo {
+  id: number;
+  name?: string;
+  iban?: string;
+}
+
+export interface FiatOutputInfo {
+  id: number;
+  valutaDate?: string;
+  currency?: string;
+  amount?: number;
+  name?: string;
+  address?: string;
+  houseNumber?: string;
+  zip?: string;
+  city?: string;
+  country?: string;
+  iban?: string;
+  bic?: string;
+  isReadyDate?: string;
+  isTransmittedDate?: string;
+  isConfirmedDate?: string;
+  isApprovedDate?: string;
+  isComplete?: boolean;
+  outputDate?: string;
+  originEntityId?: number;
+  type?: string;
+  bank?: BankInfo;
+  bankTxId?: number;
+}
+
 export interface TransactionInfo {
   id: number;
   uid: string;
@@ -541,6 +572,7 @@ export interface TransactionInfo {
   chargebackAllowedDateUser?: string;
   chargebackDate?: string;
   amlReason?: string;
+  fiatOutput?: FiatOutputInfo;
   isCompleted: boolean;
   created: string;
 }

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -68,6 +68,7 @@ export default function ComplianceUserScreen(): JSX.Element {
   const [expandedBankTxId, setExpandedBankTxId] = useState<number>();
   const [expandedCryptoInputId, setExpandedCryptoInputId] = useState<number>();
   const [expandedBankDataId, setExpandedBankDataId] = useState<number>();
+  const [expandedFiatOutputId, setExpandedFiatOutputId] = useState<number>();
   const [expandedTxUid, setExpandedTxUid] = useState<string>();
   const { containerRef, splitPercent, setSplitPercent, handleSplitDrag } = useSplitPane();
 
@@ -75,12 +76,22 @@ export default function ComplianceUserScreen(): JSX.Element {
     setExpandedBankTxId(id);
     setExpandedCryptoInputId(undefined);
     setExpandedBankDataId(undefined);
+    setExpandedFiatOutputId(undefined);
     setExpandedTxUid(undefined);
   }
 
   function handleExpandCryptoInput(id: number | undefined): void {
     setExpandedCryptoInputId(id);
     setExpandedBankTxId(undefined);
+    setExpandedBankDataId(undefined);
+    setExpandedFiatOutputId(undefined);
+    setExpandedTxUid(undefined);
+  }
+
+  function handleExpandFiatOutput(id: number | undefined): void {
+    setExpandedFiatOutputId(id);
+    setExpandedBankTxId(undefined);
+    setExpandedCryptoInputId(undefined);
     setExpandedBankDataId(undefined);
     setExpandedTxUid(undefined);
   }
@@ -89,6 +100,7 @@ export default function ComplianceUserScreen(): JSX.Element {
     setExpandedBankDataId(id);
     setExpandedBankTxId(undefined);
     setExpandedCryptoInputId(undefined);
+    setExpandedFiatOutputId(undefined);
     setExpandedTxUid(undefined);
   }
 
@@ -97,6 +109,7 @@ export default function ComplianceUserScreen(): JSX.Element {
     setExpandedBankTxId(undefined);
     setExpandedCryptoInputId(undefined);
     setExpandedBankDataId(undefined);
+    setExpandedFiatOutputId(undefined);
   }
 
   async function openFile(file: KycFile): Promise<void> {
@@ -267,11 +280,13 @@ export default function ComplianceUserScreen(): JSX.Element {
               expandedBankTxId={expandedBankTxId}
               expandedCryptoInputId={expandedCryptoInputId}
               expandedBankDataId={expandedBankDataId}
+              expandedFiatOutputId={expandedFiatOutputId}
               expandedTxUid={expandedTxUid}
               canPerformActions={data.permissions.canPerformTransactionActions}
               onExpandBankTx={handleExpandBankTx}
               onExpandCryptoInput={handleExpandCryptoInput}
               onExpandBankData={handleExpandBankData}
+              onExpandFiatOutput={handleExpandFiatOutput}
               onExpandTxUid={handleExpandTxUid}
               onStatusChanged={loadData}
             />


### PR DESCRIPTION
<h2>feat(compliance): expose FiatOutput details in compliance transaction view</h2>

<p>
  BuyFiat transactions in the compliance search user detail view had no way to inspect the
  associated <code>FiatOutput</code> record. The data existed on the entity but was never mapped
  through the support API or surfaced in the UI.
</p>

<h3>Changes</h3>

<h4>Backend</h4>
<ul>
  <li>
    <strong>user-data-support.dto.ts</strong> — added <code>BankSupportInfo</code> (id, name, iban)
    and <code>FiatOutputSupportInfo</code> (valutaDate, currency, amount, name, address,
    houseNumber, zip, city, country, iban, bic, isReadyDate, isTransmittedDate, isConfirmedDate,
    isApprovedDate, isComplete, outputDate, originEntityId, type, bank, bankTxId);
    added <code>fiatOutput?: FiatOutputSupportInfo</code> to <code>TransactionSupportInfo</code>.
  </li>
  <li>
    <strong>transaction.service.ts</strong> — deepened the <code>buyFiat</code> relation in
    <code>getTransactionsByUserDataId</code> from <code>fiatOutput: true</code> to
    <code>fiatOutput: { bank: true, bankTx: true }</code> so the bank and matched bank
    transaction are available to the mapper.
  </li>
  <li>
    <strong>support.service.ts</strong> — added private <code>toFiatOutputSupportInfo()</code>
    mapper and wired it into <code>toTransactionSupportInfo()</code> for BuyFiat transactions
    that carry a <code>fiatOutput</code>.
  </li>
</ul>

<h4>Services</h4>
<ul>
  <li>
    <strong>compliance.hook.ts</strong> — added <code>BankRef</code> and
    <code>FiatOutputInfo</code> interfaces; added <code>fiatOutput?: FiatOutputInfo</code>
    to <code>TransactionInfo</code>.
  </li>
  <li>
    <strong>transactions-tab.tsx</strong> — added a <em>Fiat Out</em> column next to
    <em>Crypto In</em>: shows the <code>FiatOutput</code> id as a clickable link for BuyFiat
    transactions; clicking expands an inline detail row with all mapped fields (dates, recipient
    address, IBAN/BIC, bank info, status flags). Updated <code>colSpan</code> throughout from
    15 → 16.
  </li>
  <li>
    <strong>compliance-user.screen.tsx</strong> — added <code>expandedFiatOutputId</code> state
    and <code>handleExpandFiatOutput</code> handler; all sibling expand-handlers reset it so only
    one panel is open at a time.
  </li>
  <li>
    <strong>compliance-transaction-action-refresh.test.tsx</strong> — passed the required
    <code>onExpandFiatOutput</code> prop to keep the test suite compiling.
  </li>
</ul>


<hr>

<h3>Release Checklist</h3>

<h4>Pre-Release</h4>
<ul>
  <li><input type="checkbox"> Check migrations
    <ul>
      <li>No database related infos (sqldb-xxx)</li>
      <li>Impact on GS (new/removed columns)</li>
    </ul>
  </li>
  <li><input type="checkbox"> Check for linter errors (in PR)</li>
  <li><input type="checkbox"> Test basic user operations (on <a href="https://dev.app.dfx.swiss">DFX services</a>)
    <ul>
      <li>Login/logout</li>
      <li>Buy/sell payment request</li>
      <li>KYC page</li>
    </ul>
  </li>
</ul>

<h4>Post-Release</h4>
<ul>
  <li>Test basic user operations</li>
  <li>Monitor application insights log</li>
</ul>
