### PR TITLE
fix(buy,sell,swap): never refill a cleared amount; form submit runs next step

### DIFF
--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -153,6 +153,10 @@ run does not prove for each one; the taxonomy and cross-repository entries live 
 - **Full-stack guest assign/refund specs SQL-write `transaction.actionSecretHash`.**
   `e2e-stack/specs/transactions.spec.ts` (`seedActionSecret`) updates the hash directly. A green run
   does **not** prove that the mail/API path creates, hashes, or delivers the action secret.
+- **Full-stack buy specs SQL-write `user_data.depositLimit`.**
+  `e2e-stack/specs/buy.spec.ts` (`openQuoteCapableBuy` and older quote cases) updates the limit
+  directly so `LIMIT_EXCEEDED` does not hide payment info. A green run does **not** prove that a
+  customer reaches that limit through the product path.
 
 ## Known gaps
 

--- a/e2e-stack/specs/buy.spec.ts
+++ b/e2e-stack/specs/buy.spec.ts
@@ -559,6 +559,39 @@ test.describe('Buy flow', () => {
     await expect(page.getByText(/Nice! You are all set!/i)).toBeVisible({ timeout: 15000 });
   });
 
+  async function submitBuyForm(page: Page): Promise<void> {
+    const form = page.locator('form').first();
+    await expect(form).toBeVisible();
+    await form.evaluate((el) => (el as HTMLFormElement).requestSubmit());
+  }
+
+  test('/buy: native form submit confirms a final quote', async ({ page }) => {
+    test.setTimeout(90000);
+    await openChfEthAmountIn(page, 'buy-form-submit', '100');
+    expect(await waitForQuoteUi(page, 45000)).toBe('payment');
+    // Payment Information can appear before the exact-price quote is final; confirm()
+    // no-ops until then. The CTA is disabled until isQuoteFinal — wait for that, same
+    // as the click path.
+    const confirmBtn = page.getByRole('button', { name: /Click here once you have issued the transfer/i });
+    await expect(confirmBtn).toBeEnabled();
+
+    await submitBuyForm(page);
+    await expect(page.getByText(/Nice! You are all set!/i)).toBeVisible({ timeout: 15000 });
+  });
+
+  test('/buy: native form submit does not confirm after spend is cleared', async ({ page }) => {
+    test.setTimeout(90000);
+    await openChfEthAmountIn(page, 'buy-form-submit-cleared', '100');
+    expect(await waitForQuoteUi(page, 45000)).toBe('payment');
+
+    await clearNumberInput(spendAmountInput(page));
+    await expect.poll(async () => spendAmountInput(page).inputValue(), { timeout: 8000 }).toBe('');
+
+    await submitBuyForm(page);
+    await expect(page.getByText(/Nice! You are all set!/i)).toHaveCount(0);
+    await expect(spendAmountInput(page)).toHaveValue('');
+  });
+
   async function openChfEthAmountIn(page: Page, tag: string, amountIn: string) {
     await openQuoteCapableBuy(page, tag);
     await page.goto(`/buy?asset-in=CHF&asset-out=ETH&amount-in=${amountIn}&blockchain=Ethereum`);

--- a/e2e-stack/specs/buy.spec.ts
+++ b/e2e-stack/specs/buy.spec.ts
@@ -602,6 +602,24 @@ test.describe('Buy flow', () => {
       .toEqual({ value: '', paymentVisible: false });
   });
 
+  test('/buy: switching currency after clearing spend does not refill the field', async ({ page }) => {
+    test.setTimeout(90000);
+    await openChfEthAmountIn(page, 'buy-clear-fx', '100');
+    expect(await waitForQuoteUi(page, 45000)).toBe('payment');
+
+    await clearNumberInput(spendAmountInput(page));
+    await expect.poll(async () => spendAmountInput(page).inputValue(), { timeout: 8000 }).toBe('');
+
+    await chooseFromSectionDropdown(page, spendSection(page), 'EUR');
+
+    await expect
+      .poll(async () => spendAmountInput(page).inputValue(), {
+        timeout: 8000,
+        message: 'cleared spend amount must stay empty after a currency change',
+      })
+      .toBe('');
+  });
+
   test('/buy: retyping a custom spend amount quotes exactly that amount', async ({ page }) => {
     test.setTimeout(90000);
     const capture = attachPaymentInfoCapture(page);

--- a/e2e-stack/specs/buy.spec.ts
+++ b/e2e-stack/specs/buy.spec.ts
@@ -567,7 +567,7 @@ test.describe('Buy flow', () => {
     await expect(spendAmountInput(page)).toHaveValue(amountIn);
   }
 
-  test('/buy: default spend amount is 300 and payment information quotes it', async ({ page }) => {
+  test('/buy: default spend amount stays 300 after quote settlement', async ({ page }) => {
     test.setTimeout(90000);
     await openQuoteCapableBuy(page, 'buy-default-300');
 

--- a/e2e-stack/specs/buy.spec.ts
+++ b/e2e-stack/specs/buy.spec.ts
@@ -193,13 +193,38 @@ async function chooseFromSectionSearchDropdown(
     .click();
 }
 
+function spendAmountInput(page: Page): Locator {
+  return spendSection(page).locator('input[type="number"]').first();
+}
+
+function getAmountInput(page: Page): Locator {
+  return getSection(page).locator('input[type="number"]').first();
+}
+
 async function setSpendAmount(page: Page, amount: string): Promise<void> {
-  const input = spendSection(page).locator('input[type="number"]').first();
+  const input = spendAmountInput(page);
   await input.click();
   await input.fill('');
   await input.fill(amount);
   await input.blur();
 }
+
+async function clearNumberInput(input: Locator): Promise<void> {
+  await input.click();
+  await input.fill('');
+  await input.blur();
+}
+
+/** Quote-capable /buy user: KYC 50 plus a deposit limit so LIMIT_EXCEEDED does not hide payment info. */
+async function openQuoteCapableBuy(page: Page, tag: string) {
+  const user = await createUser({ tag, kycLevel: 50, completePersonalData: true });
+  await queryRows(`UPDATE user_data SET "depositLimit" = 1000000 WHERE id = $1`, [user.userDataId]);
+  await openScreen(page, '/buy', user.jwt);
+  await expect(page.getByRole('heading', { name: 'You spend' })).toBeVisible();
+  return user;
+}
+
+
 
 /** Capture the latest successful PUT /v1/buy/paymentInfos JSON body. */
 function attachPaymentInfoCapture(page: Page): { get: () => PaymentInfoPayload | undefined } {
@@ -532,6 +557,113 @@ test.describe('Buy flow', () => {
     await expect(confirmBtn).toBeVisible();
     await confirmBtn.click();
     await expect(page.getByText(/Nice! You are all set!/i)).toBeVisible({ timeout: 15000 });
+  });
+
+  async function openChfEthAmountIn(page: Page, tag: string, amountIn: string) {
+    await openQuoteCapableBuy(page, tag);
+    await page.goto(`/buy?asset-in=CHF&asset-out=ETH&amount-in=${amountIn}&blockchain=Ethereum`);
+    await page.waitForLoadState('networkidle');
+    await expect.poll(() => normPath(new URL(page.url()).pathname)).toBe('/buy');
+    await expect(spendAmountInput(page)).toHaveValue(amountIn);
+  }
+
+  test('/buy: default spend amount is 300 and payment information quotes it', async ({ page }) => {
+    test.setTimeout(90000);
+    await openQuoteCapableBuy(page, 'buy-default-300');
+
+    await expect(spendAmountInput(page)).toHaveValue('300');
+    const state = await waitForQuoteUi(page, 45000);
+    expect(state, 'default 300 must leave the loading spinner').not.toBe('pending');
+    // Exact-price used to write 299.98 back into the spend field. The default side stays 300
+    // even when the quote itself is limit/min (seed limits can reject 300).
+    await expect(spendAmountInput(page)).toHaveValue('300');
+  });
+
+  test('/buy: clearing the spend amount keeps the field empty (no cross-side refill)', async ({ page }) => {
+    test.setTimeout(90000);
+    await openChfEthAmountIn(page, 'buy-clear-spend', '100');
+    expect(await waitForQuoteUi(page, 45000)).toBe('payment');
+    await expect(spendAmountInput(page)).toHaveValue('100');
+
+    await clearNumberInput(spendAmountInput(page));
+
+    await expect
+      .poll(
+        async () => {
+          const value = await spendAmountInput(page).inputValue();
+          const paymentVisible = await page
+            .getByRole('heading', { name: 'Payment Information' })
+            .isVisible()
+            .catch(() => false);
+          return { value, paymentVisible };
+        },
+        { timeout: 8000, message: 'cleared spend amount must stay empty and must not refill from the target side' },
+      )
+      .toEqual({ value: '', paymentVisible: false });
+  });
+
+  test('/buy: retyping a custom spend amount quotes exactly that amount', async ({ page }) => {
+    test.setTimeout(90000);
+    const capture = attachPaymentInfoCapture(page);
+    await openChfEthAmountIn(page, 'buy-retype-150', '100');
+    expect(await waitForQuoteUi(page, 45000)).toBe('payment');
+
+    await clearNumberInput(spendAmountInput(page));
+    await expect.poll(async () => spendAmountInput(page).inputValue(), { timeout: 8000 }).toBe('');
+
+    await setSpendAmount(page, '150');
+    const state = await waitForQuoteUi(page, 45000);
+    expect(state, 'retyped 150 must reach Payment Information').toBe('payment');
+    await expect(spendAmountInput(page)).toHaveValue('150');
+
+    await expect
+      .poll(
+        () => capture.get()?.amount,
+        { timeout: 10000, message: 'PUT /buy/paymentInfos must quote the retyped amount' },
+      )
+      .toBeCloseTo(150, 2);
+  });
+
+  test('/buy: clearing the target amount keeps it empty', async ({ page }) => {
+    test.setTimeout(90000);
+    await openChfEthAmountIn(page, 'buy-clear-target', '100');
+    expect(await waitForQuoteUi(page, 45000)).toBe('payment');
+    await expect(getAmountInput(page)).not.toHaveValue('');
+
+    await clearNumberInput(getAmountInput(page));
+
+    await expect
+      .poll(
+        async () => {
+          const value = await getAmountInput(page).inputValue();
+          const paymentVisible = await page
+            .getByRole('heading', { name: 'Payment Information' })
+            .isVisible()
+            .catch(() => false);
+          return { value, paymentVisible };
+        },
+        { timeout: 8000, message: 'cleared target amount must stay empty and must not refill from the spend side' },
+      )
+      .toEqual({ value: '', paymentVisible: false });
+  });
+
+  test('/buy: amount-in deep link is used instead of default 300', async ({ page }) => {
+    test.setTimeout(90000);
+    await openChfEthAmountIn(page, 'buy-amount-in', '100');
+    const state = await waitForQuoteUi(page, 45000);
+    expect(state).not.toBe('pending');
+    await expect(spendAmountInput(page)).toHaveValue('100');
+  });
+
+  test('/buy: switching currency after a quote invalidates payment information', async ({ page }) => {
+    test.setTimeout(90000);
+    await openChfEthAmountIn(page, 'buy-fx-switch', '100');
+    expect(await waitForQuoteUi(page, 45000)).toBe('payment');
+    await expect(page.getByRole('heading', { name: 'Payment Information' })).toBeVisible();
+
+    await chooseFromSectionDropdown(page, spendSection(page), 'EUR');
+
+    await expect(page.getByRole('heading', { name: 'Payment Information' })).toHaveCount(0);
   });
 
   // =========================================================================

--- a/e2e-stack/specs/sell-swap.spec.ts
+++ b/e2e-stack/specs/sell-swap.spec.ts
@@ -565,11 +565,18 @@ test.describe('Sell + Swap e2e', () => {
     await spend.blur();
 
     await expect
-      .poll(async () => spend.inputValue(), {
-        timeout: 8000,
-        message: 'cleared sell spend amount must stay empty',
-      })
-      .toBe('');
+      .poll(
+        async () => {
+          const value = await spend.inputValue();
+          const paymentVisible = await page
+            .getByRole('heading', { name: 'Payment Information' })
+            .isVisible()
+            .catch(() => false);
+          return { value, paymentVisible };
+        },
+        { timeout: 8000, message: 'cleared sell spend amount must stay empty' },
+      )
+      .toEqual({ value: '', paymentVisible: false });
   });
 
   // ---------------------------------------------------------------------------
@@ -806,11 +813,18 @@ test.describe('Sell + Swap e2e', () => {
     await spend.blur();
 
     await expect
-      .poll(async () => spend.inputValue(), {
-        timeout: 8000,
-        message: 'cleared swap spend amount must stay empty',
-      })
-      .toBe('');
+      .poll(
+        async () => {
+          const value = await spend.inputValue();
+          const paymentVisible = await page
+            .getByRole('heading', { name: 'Payment Information' })
+            .isVisible()
+            .catch(() => false);
+          return { value, paymentVisible };
+        },
+        { timeout: 8000, message: 'cleared swap spend amount must stay empty' },
+      )
+      .toEqual({ value: '', paymentVisible: false });
   });
 
   // Sanity: incomplete personal data is redirected off /sell by the API/UI (Ident data incomplete).

--- a/e2e-stack/specs/sell-swap.spec.ts
+++ b/e2e-stack/specs/sell-swap.spec.ts
@@ -446,14 +446,9 @@ test.describe('Sell + Swap e2e', () => {
     await page.keyboard.press('Escape');
   });
 
-  test('/sell currency dropdown offers non-sellable fiats (sell.hook filters buyable, not sellable)', async ({
+  test('/sell currency dropdown only offers sellable fiats', async ({
     page,
   }) => {
-    // CONFIRMED product bug: sell.hook.js's currency dropdown filters options on
-    // buyable || cardBuyable || instantBuyable instead of sellable, so it can offer fiats that
-    // POST /sell would reject. Remove this test.fail() once the hook filters on `sellable`.
-    test.fail(true, 'sell.hook.js filters currency options on buyable||cardBuyable||instantBuyable, not sellable');
-
     const user = await createUser({
       walletIndex: nextWalletIndex(),
       tag: 'sell-fiat',
@@ -481,8 +476,6 @@ test.describe('Sell + Swap e2e', () => {
     const offered = fiatCodes.filter((code) => optionTexts.some((t) => t === code || t.startsWith(code)));
     expect(offered.length, 'currency dropdown should list at least one fiat').toBeGreaterThan(0);
 
-    // Correct behaviour: every offered currency must be sellable. Fails today (test.fail above)
-    // because the hook filters on the wrong flag; passes once the hook is fixed.
     for (const name of offered) {
       expect(sellableNames.includes(name), `currency "${name}" must be sellable`).toBe(true);
     }
@@ -878,11 +871,6 @@ test.describe('Sell + Swap e2e', () => {
   });
 
   test('/sell?bank-account=<iban> selects the account once instead of recreating it', async ({ page }) => {
-    // Measured: the screen answers this parameter by posting /v1/bankAccount over and over — more
-    // than thirty times in twenty seconds — and never gets as far as requesting payment
-    // information, so the sell flow cannot complete at all when the link carries the parameter.
-    // Reported to the team. Remove test.fail() once one request is enough.
-    test.fail(true, 'A bank-account deep link makes /sell create bank accounts in a loop and never price.');
     test.setTimeout(75000);
 
     const user = await createUser({

--- a/e2e-stack/specs/sell-swap.spec.ts
+++ b/e2e-stack/specs/sell-swap.spec.ts
@@ -552,6 +552,26 @@ test.describe('Sell + Swap e2e', () => {
     }
   });
 
+  test('/sell: clearing the spend amount keeps the field empty (no cross-side refill)', async ({ page }) => {
+    test.setTimeout(90000);
+    await setupSellFullUiFlow(page, 'sell-clear-spend');
+    const outcome = await waitForPricingOutcome(page, { timeoutMs: 25000 });
+    expect(outcome.kind).toBe('payment_info');
+
+    const spend = page.locator('h2', { hasText: 'You spend' }).locator('..').locator('input[type="number"]').first();
+    await expect(spend).toHaveValue('0.1');
+    await spend.click();
+    await spend.fill('');
+    await spend.blur();
+
+    await expect
+      .poll(async () => spend.inputValue(), {
+        timeout: 8000,
+        message: 'cleared sell spend amount must stay empty',
+      })
+      .toBe('');
+  });
+
   // ---------------------------------------------------------------------------
   // /sell/info
   // ---------------------------------------------------------------------------
@@ -771,6 +791,26 @@ test.describe('Sell + Swap e2e', () => {
         page.getByText('Nice! You are all set! Give us a minute to handle your transaction.'),
       ).toBeVisible({ timeout: 15000 });
     }
+  });
+
+  test('/swap: clearing the spend amount keeps the field empty (no cross-side refill)', async ({ page }) => {
+    test.setTimeout(90000);
+    await setupSwapFullUiFlow(page, 'swap-clear-spend');
+    const outcome = await waitForPricingOutcome(page, { timeoutMs: 25000 });
+    expect(outcome.kind).toBe('payment_info');
+
+    const spend = page.locator('h2', { hasText: 'You spend' }).locator('..').locator('input[type="number"]').first();
+    await expect(spend).toHaveValue('0.1');
+    await spend.click();
+    await spend.fill('');
+    await spend.blur();
+
+    await expect
+      .poll(async () => spend.inputValue(), {
+        timeout: 8000,
+        message: 'cleared swap spend amount must stay empty',
+      })
+      .toBe('');
   });
 
   // Sanity: incomplete personal data is redirected off /sell by the API/UI (Ident data incomplete).

--- a/e2e-stack/specs/sell-swap.spec.ts
+++ b/e2e-stack/specs/sell-swap.spec.ts
@@ -551,6 +551,12 @@ test.describe('Sell + Swap e2e', () => {
     await setupSellFullUiFlow(page, 'sell-form-submit');
     const outcome = await waitForPricingOutcome(page, { timeoutMs: 25000 });
     expect(outcome.kind).toBe('payment_info');
+    // Wallet CTA (`Complete transaction in your wallet`) is also payment_info; handleNext then
+    // closes instead of completing. Pin the manual path like the panel test and buy form-submit.
+    const completeBtn = page.getByRole('button', {
+      name: /Click here once you have issued the transaction/i,
+    });
+    await expect(completeBtn).toBeVisible();
     const form = page.locator('form').first();
     await expect(form).toBeVisible();
     await form.evaluate((el) => (el as HTMLFormElement).requestSubmit());
@@ -828,6 +834,10 @@ test.describe('Sell + Swap e2e', () => {
     await setupSwapFullUiFlow(page, 'swap-form-submit');
     const outcome = await waitForPricingOutcome(page, { timeoutMs: 25000 });
     expect(outcome.kind).toBe('payment_info');
+    const completeBtn = page.getByRole('button', {
+      name: /Click here once you have issued the transaction/i,
+    });
+    await expect(completeBtn).toBeVisible();
     const form = page.locator('form').first();
     await expect(form).toBeVisible();
     await form.evaluate((el) => (el as HTMLFormElement).requestSubmit());

--- a/e2e-stack/specs/sell-swap.spec.ts
+++ b/e2e-stack/specs/sell-swap.spec.ts
@@ -546,6 +546,35 @@ test.describe('Sell + Swap e2e', () => {
     }
   });
 
+  test('/sell: native form submit completes the transaction', async ({ page }) => {
+    test.setTimeout(90000);
+    await setupSellFullUiFlow(page, 'sell-form-submit');
+    const outcome = await waitForPricingOutcome(page, { timeoutMs: 25000 });
+    expect(outcome.kind).toBe('payment_info');
+    const form = page.locator('form').first();
+    await expect(form).toBeVisible();
+    await form.evaluate((el) => (el as HTMLFormElement).requestSubmit());
+    await expect(
+      page.getByText('Nice! You are all set! Give us a minute to handle your transaction.'),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test('/sell: native form submit does not complete after spend is cleared', async ({ page }) => {
+    test.setTimeout(90000);
+    await setupSellFullUiFlow(page, 'sell-form-submit-cleared');
+    const outcome = await waitForPricingOutcome(page, { timeoutMs: 25000 });
+    expect(outcome.kind).toBe('payment_info');
+    const spend = page.locator('h2', { hasText: 'You spend' }).locator('..').locator('input[type="number"]').first();
+    await spend.click();
+    await spend.fill('');
+    await spend.blur();
+    await expect.poll(async () => spend.inputValue(), { timeout: 8000 }).toBe('');
+    const form = page.locator('form').first();
+    await form.evaluate((el) => (el as HTMLFormElement).requestSubmit());
+    await expect(page.getByText(/Nice! You are all set!/i)).toHaveCount(0);
+    await expect(spend).toHaveValue('');
+  });
+
   test('/sell: clearing the spend amount keeps the field empty (no cross-side refill)', async ({ page }) => {
     test.setTimeout(90000);
     await setupSellFullUiFlow(page, 'sell-clear-spend');
@@ -792,6 +821,35 @@ test.describe('Sell + Swap e2e', () => {
         page.getByText('Nice! You are all set! Give us a minute to handle your transaction.'),
       ).toBeVisible({ timeout: 15000 });
     }
+  });
+
+  test('/swap: native form submit completes the transaction', async ({ page }) => {
+    test.setTimeout(90000);
+    await setupSwapFullUiFlow(page, 'swap-form-submit');
+    const outcome = await waitForPricingOutcome(page, { timeoutMs: 25000 });
+    expect(outcome.kind).toBe('payment_info');
+    const form = page.locator('form').first();
+    await expect(form).toBeVisible();
+    await form.evaluate((el) => (el as HTMLFormElement).requestSubmit());
+    await expect(
+      page.getByText('Nice! You are all set! Give us a minute to handle your transaction.'),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test('/swap: native form submit does not complete after spend is cleared', async ({ page }) => {
+    test.setTimeout(90000);
+    await setupSwapFullUiFlow(page, 'swap-form-submit-cleared');
+    const outcome = await waitForPricingOutcome(page, { timeoutMs: 25000 });
+    expect(outcome.kind).toBe('payment_info');
+    const spend = page.locator('h2', { hasText: 'You spend' }).locator('..').locator('input[type="number"]').first();
+    await spend.click();
+    await spend.fill('');
+    await spend.blur();
+    await expect.poll(async () => spend.inputValue(), { timeout: 8000 }).toBe('');
+    const form = page.locator('form').first();
+    await form.evaluate((el) => (el as HTMLFormElement).requestSubmit());
+    await expect(page.getByText(/Nice! You are all set!/i)).toHaveCount(0);
+    await expect(spend).toHaveValue('');
   });
 
   test('/swap: clearing the spend amount keeps the field empty (no cross-side refill)', async ({ page }) => {

--- a/e2e-stack/specs/sell-swap.spec.ts
+++ b/e2e-stack/specs/sell-swap.spec.ts
@@ -556,7 +556,7 @@ test.describe('Sell + Swap e2e', () => {
     const completeBtn = page.getByRole('button', {
       name: /Click here once you have issued the transaction/i,
     });
-    await expect(completeBtn).toBeVisible();
+    await expect(completeBtn).toBeEnabled();
     const form = page.locator('form').first();
     await expect(form).toBeVisible();
     await form.evaluate((el) => (el as HTMLFormElement).requestSubmit());
@@ -837,7 +837,7 @@ test.describe('Sell + Swap e2e', () => {
     const completeBtn = page.getByRole('button', {
       name: /Click here once you have issued the transaction/i,
     });
-    await expect(completeBtn).toBeVisible();
+    await expect(completeBtn).toBeEnabled();
     const form = page.locator('form').first();
     await expect(form).toBeVisible();
     await form.evaluate((el) => (el as HTMLFormElement).requestSubmit());

--- a/e2e-stack/specs/sell-swap.spec.ts
+++ b/e2e-stack/specs/sell-swap.spec.ts
@@ -5,8 +5,9 @@
  * Browser drives the real frontend; Postgres proves writes where the UI mutates data.
  * UI flows that depend on pricing (`PUT /sell/paymentInfos`, `PUT /swap/paymentInfos`) are split
  * into two tests each — the deposit_route write and the payment panel — and both assert hard.
- * Neither is skipped: pricing does work here, once the URL leaves out the bank-account parameter
- * that sends the sell screen into an endless create-bank-account loop (its own test below).
+ * Neither is skipped: pricing does work here, once the URL leaves out the bank-account parameter.
+ * Passing `bank-account` used to recreate accounts in a loop; that regression is pinned by the
+ * dedicated test at the end of this file (select the existing account, do not POST again).
  * Factory-only tests (`createSell` / `createSwap`) remain as independent API-path proofs.
  */
 
@@ -215,10 +216,10 @@ async function setupSellFullUiFlow(
 
   // Pre-fill amount, asset and currency via URL params so the form is complete without fragile
   // dropdown clicks. The bank account is deliberately NOT passed as a parameter: the account
-  // created above is picked up on its own, and adding `bank-account` to this URL makes the screen
-  // create bank accounts in an endless loop and never price anything — see the dedicated test at
-  // the end of this file. Do not wait for 'networkidle' either: pricing effects keep the network
-  // busy on this screen, so content-based waits are what gate these tests.
+  // created above is picked up on its own. Passing `bank-account` is covered by the dedicated
+  // regression test at the end of this file (select existing, do not recreate). Do not wait for
+  // 'networkidle' either: pricing effects keep the network busy on this screen, so content-based
+  // waits are what gate these tests.
   await gotoWithSession(page, `/sell?asset-in=ETH&asset-out=CHF&amount-in=0.1`, user.jwt);
   expect(normPath(new URL(page.url()).pathname)).toBe('/sell');
 
@@ -896,7 +897,7 @@ test.describe('Sell + Swap e2e', () => {
     await expect(page.getByText('You spend', { exact: true })).toBeVisible({ timeout: 15000 });
     await page.waitForTimeout(20000);
 
-    expect(bankAccountPosts, 'an existing bank account must not be created again').toBeLessThanOrEqual(1);
+    expect(bankAccountPosts, 'an existing bank account must not be created again').toBe(0);
     expect(paymentInfos.last, 'the screen must get as far as requesting payment information').toBeTruthy();
   });
 });

--- a/src/__tests__/bank-account-selector.test.tsx
+++ b/src/__tests__/bank-account-selector.test.tsx
@@ -3,13 +3,14 @@ const mockGetAccount = jest.fn();
 const mockOnChange = jest.fn();
 const mockOnModalToggle = jest.fn();
 const mockValidateIban = jest.fn(() => true as boolean | string);
+const mockFormatIban = jest.fn(() => undefined as string | undefined);
 
 const existing = { id: 1, iban: 'CH9300762011623852957', label: 'Main', default: true };
 let mockBankAccounts: typeof existing[] | undefined = [existing];
 let mockBankAccountParam: string | undefined;
 
 jest.mock('@dfx.swiss/react', () => ({
-  Utils: { formatIban: () => undefined },
+  Utils: { formatIban: (...args: unknown[]) => mockFormatIban(...args) },
   Validations: { Iban: () => ({ validate: (...args: unknown[]) => mockValidateIban(...args) }) },
   useBankAccountContext: () => ({
     bankAccounts: mockBankAccounts,
@@ -83,6 +84,7 @@ describe('BankAccountSelector', () => {
     );
     mockCreateAccount.mockResolvedValue({ id: 2, iban: 'DE89370400440532013000' });
     mockValidateIban.mockReturnValue(true);
+    mockFormatIban.mockReturnValue(undefined);
   });
 
   it('does nothing while bank accounts have not loaded', () => {
@@ -231,7 +233,7 @@ describe('BankAccountSelector', () => {
     expect(mockOnChange).not.toHaveBeenCalled();
   });
 
-  it('clears the in-flight create guard when createAccount rejects', async () => {
+  it('does not retry create after createAccount rejects', async () => {
     mockBankAccountParam = 'DE89370400440532013000';
     mockGetAccount.mockReturnValue(undefined);
     mockCreateAccount.mockRejectedValue(new Error('duplicate'));
@@ -284,6 +286,20 @@ describe('BankAccountSelector', () => {
     fireEvent.blur(screen.getByTestId('open-selector'));
     fireEvent.click(screen.getByTestId('close-modal'));
     expect(mockOnModalToggle).toHaveBeenCalledWith(false);
+  });
+
+  it('shows the formatted IBAN when formatIban returns a value', () => {
+    mockFormatIban.mockReturnValue('CH93 0076 2011 6238 5295 7');
+    render(
+      <BankAccountSelector
+        value={existing}
+        placeholder="IBAN"
+        isModalOpen
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    expect(screen.getByTestId('open-selector')).toHaveTextContent('CH93 0076 2011 6238 5295 7');
   });
 
   it('opens the modal from the selector button', () => {

--- a/src/__tests__/bank-account-selector.test.tsx
+++ b/src/__tests__/bank-account-selector.test.tsx
@@ -2,6 +2,7 @@ const mockCreateAccount = jest.fn();
 const mockGetAccount = jest.fn();
 const mockOnChange = jest.fn();
 const mockOnModalToggle = jest.fn();
+const mockValidateIban = jest.fn(() => true as boolean | string);
 
 const existing = { id: 1, iban: 'CH9300762011623852957', label: 'Main', default: true };
 let mockBankAccounts: typeof existing[] | undefined = [existing];
@@ -9,7 +10,7 @@ let mockBankAccountParam: string | undefined;
 
 jest.mock('@dfx.swiss/react', () => ({
   Utils: { formatIban: () => undefined },
-  Validations: { Iban: () => ({ validate: () => true }) },
+  Validations: { Iban: () => ({ validate: (...args: unknown[]) => mockValidateIban(...args) }) },
   useBankAccountContext: () => ({
     bankAccounts: mockBankAccounts,
     createAccount: (...args: unknown[]) => mockCreateAccount(...args),
@@ -81,6 +82,7 @@ describe('BankAccountSelector', () => {
       iban ? list.find((a) => a.iban === iban) : undefined,
     );
     mockCreateAccount.mockResolvedValue({ id: 2, iban: 'DE89370400440532013000' });
+    mockValidateIban.mockReturnValue(true);
   });
 
   it('does nothing while bank accounts have not loaded', () => {
@@ -176,6 +178,42 @@ describe('BankAccountSelector', () => {
     });
     expect(mockCreateAccount).toHaveBeenCalledTimes(1);
     expect(mockCreateAccount).toHaveBeenCalledWith({ iban: 'DE89370400440532013000' });
+    expect(mockOnChange).toHaveBeenCalledWith({ id: 2, iban: 'DE89370400440532013000' });
+  });
+
+  it('does not create an account when the param IBAN is invalid', () => {
+    mockBankAccountParam = 'not-an-iban';
+    mockGetAccount.mockReturnValue(undefined);
+    mockValidateIban.mockReturnValue('Invalid IBAN');
+    render(
+      <BankAccountSelector
+        placeholder="IBAN"
+        isModalOpen={false}
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    expect(mockCreateAccount).not.toHaveBeenCalled();
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
+  it('clears the in-flight create guard when createAccount rejects', async () => {
+    mockBankAccountParam = 'DE89370400440532013000';
+    mockGetAccount.mockReturnValue(undefined);
+    mockCreateAccount.mockRejectedValue(new Error('duplicate'));
+    render(
+      <BankAccountSelector
+        placeholder="IBAN"
+        isModalOpen={false}
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockCreateAccount).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).not.toHaveBeenCalled();
   });
 
   it('picks an account from the modal and accepts AddBankAccount', () => {

--- a/src/__tests__/bank-account-selector.test.tsx
+++ b/src/__tests__/bank-account-selector.test.tsx
@@ -1,0 +1,229 @@
+const mockCreateAccount = jest.fn();
+const mockGetAccount = jest.fn();
+const mockOnChange = jest.fn();
+const mockOnModalToggle = jest.fn();
+
+const existing = { id: 1, iban: 'CH9300762011623852957', label: 'Main', default: true };
+let mockBankAccounts: typeof existing[] | undefined = [existing];
+let mockBankAccountParam: string | undefined;
+
+jest.mock('@dfx.swiss/react', () => ({
+  Utils: { formatIban: () => undefined },
+  Validations: { Iban: () => ({ validate: () => true }) },
+  useBankAccountContext: () => ({
+    bankAccounts: mockBankAccounts,
+    createAccount: (...args: unknown[]) => mockCreateAccount(...args),
+  }),
+  useBankAccount: () => ({ getAccount: mockGetAccount }),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  StyledModalButton: ({ value, onClick, onBlur, placeholder }: any) => (
+    <button type="button" data-testid="open-selector" onClick={onClick} onBlur={onBlur}>
+      {placeholder}:{value}
+    </button>
+  ),
+  StyledVerticalStack: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({ translate: (_ns: string, key: string) => key, allowedCountries: [] }),
+}));
+jest.mock('src/contexts/window.context', () => ({
+  useWindowContext: () => ({ width: 800 }),
+}));
+jest.mock('src/hooks/app-params.hook', () => ({
+  useAppParams: () => ({ bankAccount: mockBankAccountParam }),
+}));
+jest.mock('src/components/payment/add-bank-account', () => ({
+  AddBankAccount: ({ onSubmit }: any) => (
+    <button type="button" data-testid="add-account" onClick={() => onSubmit({ id: 9, iban: 'AT123' })}>
+      add
+    </button>
+  ),
+}));
+jest.mock('src/components/actionable-list', () => ({
+  __esModule: true,
+  default: ({ items }: any) => (
+    <div>
+      {(items ?? []).map((item: any) => (
+        <button key={item.key} type="button" data-testid={`pick-${item.key}`} onClick={item.onClick}>
+          {item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+jest.mock('src/components/modal', () => ({
+  Modal: ({ children, isOpen, onClose }: any) =>
+    isOpen ? (
+      <div data-testid="selector-modal">
+        <button type="button" data-testid="close-modal" onClick={onClose}>
+          close
+        </button>
+        {children}
+      </div>
+    ) : null,
+}));
+jest.mock('src/util/utils', () => ({
+  blankedAddress: (value: string) => value,
+}));
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { BankAccountSelector } from 'src/components/order/bank-account-selector';
+
+describe('BankAccountSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBankAccounts = [existing];
+    mockBankAccountParam = undefined;
+    mockGetAccount.mockImplementation((list: typeof existing[], iban?: string) =>
+      iban ? list.find((a) => a.iban === iban) : undefined,
+    );
+    mockCreateAccount.mockResolvedValue({ id: 2, iban: 'DE89370400440532013000' });
+  });
+
+  it('does nothing while bank accounts have not loaded', () => {
+    mockBankAccounts = undefined;
+    render(
+      <BankAccountSelector placeholder="IBAN" onChange={mockOnChange} onModalToggle={mockOnModalToggle} />,
+    );
+    expect(mockOnChange).not.toHaveBeenCalled();
+    expect(mockCreateAccount).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-select when several accounts exist and none is default', () => {
+    mockBankAccounts = [
+      { id: 5, iban: 'CH3908307000001001001' },
+      { id: 6, iban: 'CH3908307000001001002' },
+    ];
+    mockGetAccount.mockReturnValue(undefined);
+    render(
+      <BankAccountSelector placeholder="IBAN" onChange={mockOnChange} onModalToggle={mockOnModalToggle} />,
+    );
+    expect(mockOnChange).not.toHaveBeenCalled();
+    expect(mockCreateAccount).not.toHaveBeenCalled();
+  });
+
+  it('selects the only account when none is marked default', () => {
+    const only = { id: 4, iban: 'CH3180869000123456789', label: 'Only' };
+    mockBankAccounts = [only];
+    mockGetAccount.mockReturnValue(undefined);
+    render(
+      <BankAccountSelector placeholder="IBAN" onChange={mockOnChange} onModalToggle={mockOnModalToggle} />,
+    );
+    expect(mockOnChange).toHaveBeenCalledWith(only);
+  });
+
+  it('selects the default account when no bank-account param is set', () => {
+    render(
+      <BankAccountSelector placeholder="IBAN" onChange={mockOnChange} onModalToggle={mockOnModalToggle} />,
+    );
+    expect(mockOnChange).toHaveBeenCalledWith(existing);
+    expect(mockCreateAccount).not.toHaveBeenCalled();
+  });
+
+  it('selects an existing bank-account param without creating a new account', () => {
+    mockBankAccountParam = existing.iban;
+    render(
+      <BankAccountSelector
+        placeholder="IBAN"
+        isModalOpen={false}
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    expect(mockOnChange).toHaveBeenCalledWith(existing);
+    expect(mockCreateAccount).not.toHaveBeenCalled();
+  });
+
+  it('does not create again after the existing account is already selected', () => {
+    mockBankAccountParam = existing.iban;
+    const { rerender } = render(
+      <BankAccountSelector
+        placeholder="IBAN"
+        isModalOpen={false}
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    rerender(
+      <BankAccountSelector
+        value={existing}
+        placeholder="IBAN"
+        isModalOpen={false}
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    expect(mockCreateAccount).not.toHaveBeenCalled();
+    expect(mockOnChange.mock.calls.length).toBe(1);
+  });
+
+  it('creates once when the param IBAN is not in the list', async () => {
+    mockBankAccountParam = 'DE89370400440532013000';
+    mockGetAccount.mockReturnValue(undefined);
+    await act(async () => {
+      render(
+        <BankAccountSelector
+          placeholder="IBAN"
+          isModalOpen={false}
+          onChange={mockOnChange}
+          onModalToggle={mockOnModalToggle}
+        />,
+      );
+      await Promise.resolve();
+    });
+    expect(mockCreateAccount).toHaveBeenCalledTimes(1);
+    expect(mockCreateAccount).toHaveBeenCalledWith({ iban: 'DE89370400440532013000' });
+  });
+
+  it('picks an account from the modal and accepts AddBankAccount', () => {
+    render(
+      <BankAccountSelector
+        placeholder="IBAN"
+        isModalOpen
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('pick-1'));
+    expect(mockOnChange).toHaveBeenCalledWith(existing);
+    expect(mockOnModalToggle).toHaveBeenCalledWith(false);
+    fireEvent.click(screen.getByTestId('add-account'));
+    expect(mockOnChange).toHaveBeenCalledWith({ id: 9, iban: 'AT123' });
+  });
+
+  it('falls back to the last four IBAN digits when an account has no label', () => {
+    mockBankAccounts = [{ id: 3, iban: 'FR1420041010050500013M02606' }];
+    mockGetAccount.mockReturnValue(undefined);
+    render(
+      <BankAccountSelector
+        value={{ id: 3, iban: 'FR1420041010050500013M02606' }}
+        placeholder="IBAN"
+        isModalOpen
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    expect(screen.getByTestId('pick-3')).toHaveTextContent('FR 2606');
+    // formatIban falling through to the raw IBAN is covered when the util returns undefined.
+    expect(screen.getByTestId('open-selector')).toBeInTheDocument();
+    fireEvent.blur(screen.getByTestId('open-selector'));
+    fireEvent.click(screen.getByTestId('close-modal'));
+    expect(mockOnModalToggle).toHaveBeenCalledWith(false);
+  });
+
+  it('opens the modal from the selector button', () => {
+    render(
+      <BankAccountSelector
+        placeholder="IBAN"
+        isModalOpen={false}
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('open-selector'));
+    expect(mockOnModalToggle).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/__tests__/bank-account-selector.test.tsx
+++ b/src/__tests__/bank-account-selector.test.tsx
@@ -233,6 +233,75 @@ describe('BankAccountSelector', () => {
     expect(mockOnChange).not.toHaveBeenCalled();
   });
 
+  it('does not apply a create result after the bank-account param has changed', async () => {
+    let resolveCreate: (value: unknown) => void = () => undefined;
+    mockBankAccounts = [];
+    mockBankAccountParam = 'DE89370400440532013000';
+    mockGetAccount.mockReturnValue(undefined);
+    mockCreateAccount.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    const { rerender } = render(
+      <BankAccountSelector
+        placeholder="IBAN"
+        isModalOpen={false}
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockCreateAccount).toHaveBeenCalledTimes(1);
+    mockBankAccountParam = undefined;
+    rerender(
+      <BankAccountSelector
+        placeholder="IBAN"
+        isModalOpen={false}
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    await act(async () => {
+      resolveCreate({ id: 2, iban: 'DE89370400440532013000' });
+      await Promise.resolve();
+    });
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
+  it('does not apply a create result after unmount', async () => {
+    let resolveCreate: (value: unknown) => void = () => undefined;
+    mockBankAccounts = [];
+    mockBankAccountParam = 'DE89370400440532013000';
+    mockGetAccount.mockReturnValue(undefined);
+    mockCreateAccount.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    const { unmount } = render(
+      <BankAccountSelector
+        placeholder="IBAN"
+        isModalOpen={false}
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    unmount();
+    await act(async () => {
+      resolveCreate({ id: 2, iban: 'DE89370400440532013000' });
+      await Promise.resolve();
+    });
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
   it('does not retry create after createAccount rejects', async () => {
     mockBankAccountParam = 'DE89370400440532013000';
     mockGetAccount.mockReturnValue(undefined);

--- a/src/__tests__/bank-account-selector.test.tsx
+++ b/src/__tests__/bank-account-selector.test.tsx
@@ -125,6 +125,40 @@ describe('BankAccountSelector', () => {
     expect(mockCreateAccount).not.toHaveBeenCalled();
   });
 
+  it('does not overwrite a manually selected non-default account when no param is set', () => {
+    const other = { id: 8, iban: 'CH3908307000001001008', label: 'Other' };
+    mockBankAccounts = [existing, other];
+    const { rerender } = render(
+      <BankAccountSelector placeholder="IBAN" onChange={mockOnChange} onModalToggle={mockOnModalToggle} />,
+    );
+    expect(mockOnChange).toHaveBeenCalledWith(existing);
+    mockOnChange.mockClear();
+    rerender(
+      <BankAccountSelector
+        value={other}
+        placeholder="IBAN"
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
+  it('still forces the bank-account param over a different selected value', () => {
+    const other = { id: 8, iban: 'CH3908307000001001008', label: 'Other' };
+    mockBankAccounts = [existing, other];
+    mockBankAccountParam = existing.iban;
+    render(
+      <BankAccountSelector
+        value={other}
+        placeholder="IBAN"
+        onChange={mockOnChange}
+        onModalToggle={mockOnModalToggle}
+      />,
+    );
+    expect(mockOnChange).toHaveBeenCalledWith(existing);
+  });
+
   it('selects an existing bank-account param without creating a new account', () => {
     mockBankAccountParam = existing.iban;
     render(

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -1340,7 +1340,7 @@ describe('BuyScreen cleared amount protection', () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
     });
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockConfirmFor).not.toHaveBeenCalled();
@@ -1359,7 +1359,7 @@ describe('BuyScreen cleared amount protection', () => {
       fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
     });
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockConfirmFor).not.toHaveBeenCalled();
@@ -1373,7 +1373,7 @@ describe('BuyScreen cleared amount protection', () => {
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('boom'));
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockConfirmFor).not.toHaveBeenCalled();
@@ -1389,7 +1389,7 @@ describe('BuyScreen cleared amount protection', () => {
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockConfirmFor).not.toHaveBeenCalled();
@@ -1402,7 +1402,7 @@ describe('BuyScreen cleared amount protection', () => {
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('private-asset-hint')).toBeInTheDocument());
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockConfirmFor).not.toHaveBeenCalled();
@@ -1415,7 +1415,7 @@ describe('BuyScreen cleared amount protection', () => {
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('quote-error')).toBeInTheDocument());
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockConfirmFor).not.toHaveBeenCalled();
@@ -1430,7 +1430,7 @@ describe('BuyScreen cleared amount protection', () => {
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('input-amount-error')).toBeInTheDocument());
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockConfirmFor).not.toHaveBeenCalled();
@@ -1445,7 +1445,7 @@ describe('BuyScreen cleared amount protection', () => {
       expect(screen.getByRole('button', { name: 'Continue without personal IBAN' })).toBeInTheDocument(),
     );
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockConfirmFor).not.toHaveBeenCalled();
@@ -1459,12 +1459,12 @@ describe('BuyScreen cleared amount protection', () => {
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockConfirmFor).toHaveBeenCalledTimes(1);
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockConfirmFor).toHaveBeenCalledTimes(1);

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -481,4 +481,52 @@ describe('BuyScreen cleared amount protection', () => {
     await settle(() => expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument());
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
   });
+
+  it('accepts a retyped target amount without clobbering the spend field', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await settle(() => expect(screen.getByTestId('input-targetAmount')).toHaveValue('0.004709'));
+
+    const callsBeforeClear = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await settle(() => expect(screen.getByTestId('input-targetAmount')).toHaveValue(''));
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    // Typed side stays; exact-price may write the computed spend side.
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('0.01');
+    const retyped = mockReceiveFor.mock.calls.slice(callsBeforeClear);
+    expect(retyped.length).toBeGreaterThan(0);
+    expect(retyped.every((call: any) => String(call[0].targetAmount) === '0.01')).toBe(true);
+  });
+
+  it('still quotes from a never-set spend field via amountOut (deep-link fallback)', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: undefined, amountOut: '0.01' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-targetAmount')).toHaveValue('0.01'));
+    await settle(() => expect(mockReceiveFor).toHaveBeenCalled());
+    expect(mockReceiveFor.mock.calls.some((call: any) => String(call[0].targetAmount) === '0.01')).toBe(true);
+  });
+
+  it('uses amountIn instead of the default 300', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: '100' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('100'));
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    expect(mockReceiveFor.mock.calls.every((call: any) => String(call[0].amount) === '100')).toBe(true);
+  });
 });

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -38,13 +38,13 @@ const mockGetAsset = (list: any[], name?: string) =>
 const mockIsSameAsset = (asset: any, filter: string) => asset.name === filter || asset.uniqueName === filter;
 const mockGetCurrency = (list: any[], name: string) => (list ?? []).find((c: any) => c.name === name);
 const mockGetDefaultCurrency = (list: any[]) => list?.[0];
-const mockCurrencies = [
+let mockCurrencies = [
   { name: 'EUR', sellable: true },
   { name: 'CHF', sellable: true },
   { name: 'USD', sellable: true },
 ];
 // Stable reference: buy.screen currency-selection effect depends on prefCurrency by identity.
-const mockPrefCurrency = { name: 'CHF' };
+let mockPrefCurrency: { name: string } | undefined = { name: 'CHF' };
 
 jest.mock('@dfx.swiss/react', () => {
   const buyInterface = {
@@ -334,6 +334,7 @@ jest.mock('../hooks/navigation.hook', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
+import { StrictMode } from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import BuyScreen from 'src/screens/buy.screen';
 
@@ -359,6 +360,12 @@ describe('BuyScreen quote race protection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSession = undefined;
+    mockPrefCurrency = { name: 'CHF' };
+    mockCurrencies = [
+      { name: 'EUR', sellable: true },
+      { name: 'CHF', sellable: true },
+      { name: 'USD', sellable: true },
+    ];
   });
 
   async function waitFor(callback: () => unknown) {
@@ -497,6 +504,12 @@ describe('BuyScreen cleared amount protection', () => {
     mockUser = { kyc: { level: 0 }, accountId: 1 };
     mockIsUserLoading = false;
     mockIsInitialized = true;
+    mockPrefCurrency = { name: 'CHF' };
+    mockCurrencies = [
+      { name: 'EUR', sellable: true },
+      { name: 'CHF', sellable: true },
+      { name: 'USD', sellable: true },
+    ];
     mockPersonalIbanRows = {
       activePersonalIbans: undefined,
       personalIbanRowsSettled: true,
@@ -1311,5 +1324,162 @@ describe('BuyScreen cleared amount protection', () => {
     await act(async () => {
       screen.getByTestId('switch-provider').click();
     });
+  });
+
+  it('falls back to the preferred currency when assetIn is unknown', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'NOPE' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('select-currency-CHF')).toBeInTheDocument());
+  });
+
+  it('falls back to the default currency when assetIn and preferred currency are unknown', async () => {
+    mockPrefCurrency = { name: 'GBP' };
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'NOPE' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('select-currency-EUR')).toBeInTheDocument());
+  });
+
+  it('skips restoring currency when no preferred currency is set', async () => {
+    mockPrefCurrency = undefined;
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'NOPE' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toBeInTheDocument());
+  });
+
+  it('does not restore currency when the currency list is empty', async () => {
+    mockCurrencies = [];
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('form-submit')).toBeInTheDocument());
+  });
+
+  it('tolerates a repeated quote signature under StrictMode', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(
+      <StrictMode>
+        <BuyScreen />
+      </StrictMode>,
+    );
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+  });
+
+  it('uses Unknown error when confirm omits a message', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    mockConfirmFor.mockRejectedValue({});
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByRole('button', { name: 'Click here once you have issued the transfer' }).click();
+      await Promise.resolve();
+    });
+    await settle(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('Unknown error'));
+  });
+
+  it('maps a personal-IBAN issuance failure without offering Show available IBAN', async () => {
+    mockPersonalIban.mockReturnValue('Frick');
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockRejectedValue({ statusCode: 400, message: 'PersonalIbanIssuanceFailed' });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('error-hint')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Show available IBAN' })).not.toBeInTheDocument();
+  });
+
+  it('falls back to the first address when the URL chain is not in the list', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockSession = { address: '0xabc' };
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({
+        hideTargetSelection: false,
+        availableBlockchains: ['Ethereum'],
+        blockchain: 'Arbitrum',
+      }),
+    );
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('form-submit')).toBeInTheDocument());
+  });
+
+  it('falls back to the first address when blockchain is unset', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockSession = { address: '0xabc' };
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({
+        hideTargetSelection: false,
+        availableBlockchains: ['Ethereum'],
+        blockchain: undefined,
+      }),
+    );
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('form-submit')).toBeInTheDocument());
+  });
+
+  it('does not set an address while the app is uninitialized', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockIsInitialized = false;
+    mockSession = { address: '0xabc' };
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({
+        hideTargetSelection: false,
+        availableBlockchains: ['Ethereum'],
+        blockchain: 'Ethereum',
+      }),
+    );
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toBeInTheDocument());
+  });
+
+  it('drops a quote that resolves after unmount', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    let resolveQuote: (value: unknown) => void = () => undefined;
+    mockReceiveFor.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveQuote = resolve;
+        }),
+    );
+    const { unmount } = render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    unmount();
+    await act(async () => {
+      resolveQuote(quoteFor({ amount: 300 }));
+      await Promise.resolve();
+    });
+  });
+
+  it('does not quote a zero spend amount', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0' } });
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('0'));
+  });
+
+  it('uses availableBlockchains when both wallet and URL chain are unset', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({ blockchain: undefined, availableBlockchains: ['Ethereum'] }),
+    );
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('select-asset-BTC')).toBeInTheDocument());
   });
 });

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -1096,6 +1096,8 @@ describe('BuyScreen cleared amount protection', () => {
     await act(async () => {
       screen.getByTestId('form-submit').click();
     });
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
   });
 
   it('waits for personal IBAN rows instead of quoting while the user is loading', async () => {
@@ -1134,6 +1136,9 @@ describe('BuyScreen cleared amount protection', () => {
     await act(async () => {
       screen.getByRole('button', { name: 'Show available IBAN' }).click();
     });
+    await settle(() =>
+      expect(screen.queryByRole('button', { name: 'Show available IBAN' })).not.toBeInTheDocument(),
+    );
   });
 
   it('suppresses automatic Frick after a KYC rejection when a Yapeal row exists', async () => {
@@ -1153,6 +1158,9 @@ describe('BuyScreen cleared amount protection', () => {
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
     await settle(() => expect(mockReceiveFor.mock.calls.length).toBeGreaterThan(0));
+    const providers = mockReceiveFor.mock.calls.map((call: any) => call[0]?.personalIbanProvider);
+    expect(providers.some((provider: unknown) => provider === 'Frick')).toBe(true);
+    expect(providers[providers.length - 1]).not.toBe('Frick');
   });
 
   it('acknowledges a failed Frick verification and continues without the selector', async () => {
@@ -1166,6 +1174,7 @@ describe('BuyScreen cleared amount protection', () => {
     await act(async () => {
       screen.getByRole('button', { name: 'Continue without personal IBAN' }).click();
     });
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
   });
 
   it('maps a non-KYC personal-IBAN HTTP error onto QuoteErrorHint', async () => {
@@ -1200,6 +1209,7 @@ describe('BuyScreen cleared amount protection', () => {
     await act(async () => {
       screen.getByTestId('switch-provider').click();
     });
+    expect(mockReceiveFor.mock.calls.length).toBeGreaterThan(1);
   });
 
   it('blocks an unrecognized personal IBAN selector', async () => {
@@ -1212,6 +1222,7 @@ describe('BuyScreen cleared amount protection', () => {
     await act(async () => {
       screen.getByRole('button', { name: 'Continue without personal IBAN' }).click();
     });
+    await settle(() => expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument());
   });
 
   it('navigates to generate a personal IBAN from a non-Frick currency', async () => {
@@ -1237,6 +1248,9 @@ describe('BuyScreen cleared amount protection', () => {
     mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    expect(
+      mockReceiveFor.mock.calls.every((call: any) => call[0]?.personalIbanProvider !== 'Frick'),
+    ).toBe(true);
   });
 
   it('falls back to the first asset when assetOut does not match', async () => {
@@ -1292,6 +1306,7 @@ describe('BuyScreen cleared amount protection', () => {
     await act(async () => {
       screen.getByRole('button', { name: 'Continue without personal IBAN' }).click();
     });
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
   });
 
   it('maps an Instant paymentMethod param onto bank', async () => {
@@ -1321,9 +1336,11 @@ describe('BuyScreen cleared amount protection', () => {
     );
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('switch-provider')).toBeInTheDocument());
+    const callsBefore = mockReceiveFor.mock.calls.length;
     await act(async () => {
       screen.getByTestId('switch-provider').click();
     });
+    expect(mockReceiveFor.mock.calls.length).toBeGreaterThan(callsBefore);
   });
 
   it('falls back to the preferred currency when assetIn is unknown', async () => {
@@ -1459,6 +1476,8 @@ describe('BuyScreen cleared amount protection', () => {
       resolveQuote(quoteFor({ amount: 300 }));
       await Promise.resolve();
     });
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
   });
 
   it('does not quote a zero spend amount', async () => {
@@ -1467,10 +1486,13 @@ describe('BuyScreen cleared amount protection', () => {
     mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    const callsBefore = mockReceiveFor.mock.calls.length;
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0' } });
     });
     await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('0'));
+    const after = mockReceiveFor.mock.calls.slice(callsBefore);
+    expect(after.every((call: any) => Number(call[0]?.amount) !== 0)).toBe(true);
   });
 
   it('uses availableBlockchains when both wallet and URL chain are unset', async () => {

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -445,19 +445,26 @@ describe('BuyScreen cleared amount protection', () => {
     await settle(() => expect(screen.getByTestId('payment-info')).toHaveTextContent('299.98'));
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('0.004709');
 
-    // The user empties the field to retype: no cross-side recompute may refill it.
+    // The user empties the field to retype: no cross-side recompute may refill it — and no
+    // quote may fire at all for the emptied side (a fired quote would echo 299.98 back in).
+    const callsBeforeClear = mockReceiveFor.mock.calls.length;
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
     });
     await settle(() => expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument());
     expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(mockReceiveFor.mock.calls.length).toBe(callsBeforeClear);
 
-    // Retyping works and the echo still only updates the target side.
+    // Retyping works: the quote is requested for exactly the typed amount and the echo still
+    // only updates the target side, so the purchase can be completed with the custom amount.
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
     });
     await settle(() => expect(screen.getByTestId('payment-info')).toHaveTextContent('149.98'));
     expect(screen.getByTestId('input-amount')).toHaveValue('150');
+    const retypedCalls = mockReceiveFor.mock.calls.slice(callsBeforeClear);
+    expect(retypedCalls.length).toBeGreaterThan(0);
+    expect(retypedCalls.every((call: any) => String(call[0].amount) === '150')).toBe(true);
   });
 
   it('keeps a cleared target amount field empty (mirrored protection)', async () => {

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -567,11 +567,44 @@ describe('BuyScreen cleared amount protection', () => {
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
     });
-    await settle(() => expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice && hangExact)).toBe(true));
+    await settle(() =>
+      expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice && hangExact)).toBe(true),
+    );
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
     });
     await act(async () => {
+      resolveExact(quoteFor({ targetAmount: '0.01', exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
+  it('does not write a resolving exact-price into spend when clear and resolve share a turn', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await settle(() =>
+      expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice && hangExact)).toBe(true),
+    );
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
       resolveExact(quoteFor({ targetAmount: '0.01', exactPrice: true }));
       await Promise.resolve();
     });
@@ -598,7 +631,9 @@ describe('BuyScreen cleared amount protection', () => {
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
     });
-    await settle(() => expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice)).toBe(true));
+    await settle(() =>
+      expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice)).toBe(true),
+    );
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
     });
@@ -608,6 +643,102 @@ describe('BuyScreen cleared amount protection', () => {
     });
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
     expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
+  it('does not write a resolving exact-price into target when clear and resolve share a turn', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
+    });
+    await settle(() =>
+      expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice)).toBe(true),
+    );
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+      resolveExact(quoteFor({ amount: 150, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
+  it('does not let a stale exact-price overwrite a retyped spend amount', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await settle(() =>
+      expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice && hangExact)).toBe(true),
+    );
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
+    });
+    await act(async () => {
+      resolveExact(quoteFor({ targetAmount: '0.01', exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('150');
+  });
+
+  it('does not write a resolving exact-price into a retyped spend amount in the same turn', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await settle(() =>
+      expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice && hangExact)).toBe(true),
+    );
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
+      resolveExact(quoteFor({ targetAmount: '0.01', exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('150');
   });
 
   it('still invalidates quotes when spend is cleared after an exact-price no-op write', async () => {

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -1071,6 +1071,33 @@ describe('BuyScreen cleared amount protection', () => {
     },
   );
 
+  it('does not retry a quote after the spend amount becomes invalid', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor
+      .mockRejectedValueOnce({ statusCode: 500, message: 'boom' })
+      .mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('boom'));
+    const callsBefore = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0' } });
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('0'));
+    const retry = screen.queryByRole('button', { name: 'Retry' });
+    if (retry) {
+      await act(async () => {
+        retry.click();
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+    }
+    const after = mockReceiveFor.mock.calls.slice(callsBefore);
+    expect(after.every((call: any) => Number(call[0]?.amount) !== 300)).toBe(true);
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
   it('shows a generic error and retries', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams());

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -676,6 +676,28 @@ describe('BuyScreen cleared amount protection', () => {
     expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
   });
 
+  it('does not fall through to amountOut after the user clears spend', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: '100', amountOut: '0.01' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('100'));
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
+
+    const callsBeforeAsset = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      screen.getByTestId('select-asset-ETH').click();
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
+    const after = mockReceiveFor.mock.calls.slice(callsBeforeAsset);
+    expect(after.every((call: any) => call[0].amount === undefined)).toBe(true);
+  });
+
   it('does not restore amountIn after the user clears spend and then changes asset', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: '100' }));

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -747,6 +747,17 @@ describe('BuyScreen cleared amount protection', () => {
     await settle(() => expect(screen.getByTestId('quote-error')).toHaveTextContent('KycRequired'));
   });
 
+  it.each(['LimitExceeded', 'EmailRequired', 'BankTransactionMissing', 'BankTransactionOrVideoMissing'])(
+    'routes %s quote errors through QuoteErrorHint',
+    async (error) => {
+      mockPersonalIban.mockReturnValue(undefined);
+      mockUseAppParams.mockReturnValue(baseAppParams());
+      mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error }));
+      render(<BuyScreen />);
+      await settle(() => expect(screen.getByTestId('quote-error')).toHaveTextContent(error));
+    },
+  );
+
   it('shows a generic error and retries', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams());
@@ -792,6 +803,14 @@ describe('BuyScreen cleared amount protection', () => {
     mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), rate: 1 }));
     render(<BuyScreen />);
     await settle(() => expect(screen.getByText('You get')).toBeInTheDocument());
+  });
+
+  it('uses You get about when the rate is not 1', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), rate: 0.9 }));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByText('You get about')).toBeInTheDocument());
   });
 
   it('confirms a final quote', async () => {

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -1209,6 +1209,54 @@ describe('BuyScreen cleared amount protection', () => {
     expect(mockReceiveFor).not.toHaveBeenCalled();
   });
 
+  it('does not resume a stale quote after personal-IBAN rows settle on a cleared spend field', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockIsUserLoading = true;
+    mockPersonalIbanRows = {
+      activePersonalIbans: undefined,
+      personalIbanRowsSettled: false,
+      userLoadTimedOut: false,
+    };
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    const { rerender, unmount } = render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+      mockIsUserLoading = false;
+      mockPersonalIbanRows = {
+        activePersonalIbans: [],
+        personalIbanRowsSettled: true,
+        userLoadTimedOut: false,
+      };
+      rerender(<BuyScreen />);
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    expect(
+      mockReceiveFor.mock.calls.every((call: any) => call[0]?.amount !== 300 && Number(call[0]?.amount) !== 300),
+    ).toBe(true);
+    unmount();
+  });
+
+  it('does not resume a stale quote after a selector change on a cleared target field', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    const { rerender, unmount } = render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+      mockPersonalIban.mockReturnValue('Frick');
+      rerender(<BuyScreen />);
+    });
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+    await settle(() => expect(screen.getByTestId('input-targetAmount')).toHaveValue(''));
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    unmount();
+  });
+
   it('shows a personal-IBAN KYC hint when an explicit Frick selector is rejected', async () => {
     mockPersonalIban.mockReturnValue('Frick');
     mockUseAppParams.mockReturnValue(baseAppParams());

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -169,7 +169,7 @@ jest.mock('@dfx.swiss/react-components', () => {
     StyledHorizontalStack: ({ children }: any) => <div>{children}</div>,
     StyledInfoText: ({ children }: any) => <div>{children}</div>,
     // Interactive so the clear/retype protection can drive the amount fields like a user would.
-    StyledInput: ({ name, control, forceErrorMessage }: any) =>
+    StyledInput: ({ name, control, forceErrorMessage, loading, disabled }: any) =>
       name ? (
         <Controller
           name={name}
@@ -179,6 +179,7 @@ jest.mock('@dfx.swiss/react-components', () => {
               <input
                 data-testid={`input-${name}`}
                 value={field.value ?? ''}
+                disabled={Boolean(loading || disabled)}
                 onChange={(e: any) => field.onChange(e.target.value)}
               />
               {forceErrorMessage && <div data-testid={`input-${name}-error`}>{forceErrorMessage}</div>}
@@ -187,7 +188,7 @@ jest.mock('@dfx.swiss/react-components', () => {
         />
       ) : null,
     StyledLink: ({ children, label }: any) => <div>{label ?? children}</div>,
-    StyledLoadingSpinner: () => null,
+    StyledLoadingSpinner: () => <div data-testid="loading-spinner" />,
     StyledSearchDropdown: ({ name, items, labelFunc, control, filterFunc, descriptionFunc, assetIconFunc }: any) => (
       <Controller
         name={name}
@@ -660,6 +661,8 @@ describe('BuyScreen cleared amount protection', () => {
     });
     await settle(() => expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument());
     expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.getByTestId('input-amount')).not.toBeDisabled();
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
     expect(mockReceiveFor.mock.calls.length).toBe(callsBeforeClear);
 
     // Retyping works: the quote is requested for exactly the typed amount and the echo still
@@ -689,7 +692,7 @@ describe('BuyScreen cleared amount protection', () => {
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
   });
 
-  it('accepts a retyped target amount without clobbering the spend field', async () => {
+  it('accepts a retyped target amount as the quote source', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams());
     mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
@@ -708,8 +711,8 @@ describe('BuyScreen cleared amount protection', () => {
       fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
     });
     await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
-    // Typed side stays; exact-price may write the computed spend side.
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('0.01');
+    expect(screen.getByTestId('input-amount')).not.toHaveValue('');
     const retyped = mockReceiveFor.mock.calls.slice(callsBeforeClear);
     expect(retyped.length).toBeGreaterThan(0);
     expect(retyped.every((call: any) => String(call[0].targetAmount) === '0.01')).toBe(true);
@@ -1232,8 +1235,11 @@ describe('BuyScreen cleared amount protection', () => {
       rerender(<BuyScreen />);
     });
     expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.getByTestId('input-amount')).not.toBeDisabled();
     await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
+    expect(screen.getByTestId('input-amount')).not.toBeDisabled();
     expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
     expect(
       mockReceiveFor.mock.calls.every((call: any) => call[0]?.amount !== 300 && Number(call[0]?.amount) !== 300),
     ).toBe(true);
@@ -1252,8 +1258,11 @@ describe('BuyScreen cleared amount protection', () => {
       rerender(<BuyScreen />);
     });
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+    expect(screen.getByTestId('input-targetAmount')).not.toBeDisabled();
     await settle(() => expect(screen.getByTestId('input-targetAmount')).toHaveValue(''));
+    expect(screen.getByTestId('input-targetAmount')).not.toBeDisabled();
     expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
     unmount();
   });
 
@@ -1402,7 +1411,7 @@ describe('BuyScreen cleared amount protection', () => {
     await settle(() => expect(screen.getByTestId('select-asset-BTC')).toBeInTheDocument());
   });
 
-  it('skips payment-method defaults while the app is uninitialized', async () => {
+  it('renders the spend field while the app is uninitialized', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockIsInitialized = false;
     mockUseAppParams.mockReturnValue(baseAppParams());
@@ -1422,7 +1431,7 @@ describe('BuyScreen cleared amount protection', () => {
     expect(mockReceiveFor.mock.calls.every((call: any) => !call[0]?.exactPrice)).toBe(true);
   });
 
-  it('uses availableBlockchains when wallet and URL blockchain are unset', async () => {
+  it('renders when wallet, URL blockchain and availableBlockchains are unset', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(
       baseAppParams({ blockchain: undefined, availableBlockchains: undefined, assetOut: 'NOPE' }),
@@ -1456,6 +1465,7 @@ describe('BuyScreen cleared amount protection', () => {
     mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.paymentMethod === 'Bank')).toBe(true);
   });
 
   it('switches from a verified Yapeal quote to Frick', async () => {
@@ -1501,7 +1511,7 @@ describe('BuyScreen cleared amount protection', () => {
     await settle(() => expect(screen.getByTestId('select-currency-EUR')).toBeInTheDocument());
   });
 
-  it('skips restoring currency when no preferred currency is set', async () => {
+  it('renders when no preferred currency is set', async () => {
     mockPrefCurrency = undefined;
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'NOPE' }));
@@ -1510,7 +1520,7 @@ describe('BuyScreen cleared amount protection', () => {
     await settle(() => expect(screen.getByTestId('input-amount')).toBeInTheDocument());
   });
 
-  it('does not restore currency when the currency list is empty', async () => {
+  it('renders when the currency list is empty', async () => {
     mockCurrencies = [];
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams());
@@ -1554,7 +1564,7 @@ describe('BuyScreen cleared amount protection', () => {
     expect(screen.queryByRole('button', { name: 'Show available IBAN' })).not.toBeInTheDocument();
   });
 
-  it('falls back to the first address when the URL chain is not in the list', async () => {
+  it('renders the form when the URL chain is not in the address list', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockSession = { address: '0xabc' };
     mockUseAppParams.mockReturnValue(
@@ -1569,7 +1579,7 @@ describe('BuyScreen cleared amount protection', () => {
     await settle(() => expect(screen.getByTestId('form-submit')).toBeInTheDocument());
   });
 
-  it('falls back to the first address when blockchain is unset', async () => {
+  it('renders the form when blockchain is unset', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockSession = { address: '0xabc' };
     mockUseAppParams.mockReturnValue(
@@ -1584,7 +1594,7 @@ describe('BuyScreen cleared amount protection', () => {
     await settle(() => expect(screen.getByTestId('form-submit')).toBeInTheDocument());
   });
 
-  it('does not set an address while the app is uninitialized', async () => {
+  it('renders while uninitialized with a session address present', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockIsInitialized = false;
     mockSession = { address: '0xabc' };

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -920,6 +920,15 @@ describe('BuyScreen cleared amount protection', () => {
     });
   });
 
+  it('blocks an unrecognized personal IBAN selector', async () => {
+    mockPersonalIban.mockReturnValue('nope');
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('error-hint')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Continue without personal IBAN' })).toBeInTheDocument();
+  });
+
   it('navigates to generate a personal IBAN from a non-Frick currency', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams());

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -16,6 +16,14 @@ const mockEmptyPersonalIbans: never[] = [];
 const mockTranslate = (_ns: string, key: string) => key;
 const mockTranslateError = (key: string) => key;
 let mockSession: { address: string } | undefined;
+let mockUser: { kyc: { level: number }; accountId: number } = { kyc: { level: 0 }, accountId: 1 };
+let mockIsUserLoading = false;
+let mockIsInitialized = true;
+let mockPersonalIbanRows = {
+  activePersonalIbans: undefined as unknown[] | undefined,
+  personalIbanRowsSettled: true,
+  userLoadTimedOut: false,
+};
 
 const mockAssets = [
   { name: 'BTC', uniqueName: 'Bitcoin', category: 'Public', blockchain: 'Ethereum', description: 'Bitcoin' },
@@ -25,8 +33,8 @@ const mockAssets = [
 ];
 const mockAssetsMap = new Map([['Ethereum', mockAssets]]);
 const mockGetAssets = () => mockAssets;
-const mockGetAsset = (list: any[], name: string) =>
-  (list ?? []).find((a: any) => a.name === name) ?? list?.[0];
+const mockGetAsset = (list: any[], name?: string) =>
+  name ? (list ?? []).find((a: any) => a.name === name || a.uniqueName === name) : undefined;
 const mockIsSameAsset = (asset: any, filter: string) => asset.name === filter || asset.uniqueName === filter;
 const mockGetCurrency = (list: any[], name: string) => (list ?? []).find((c: any) => c.name === name);
 const mockGetDefaultCurrency = (list: any[]) => list?.[0];
@@ -88,7 +96,7 @@ jest.mock('@dfx.swiss/react', () => {
       getDefaultCurrency: mockGetDefaultCurrency,
     }),
     useSessionContext: () => ({ logout: mockLogout }),
-    useUserContext: () => ({ user: { kyc: { level: 0 }, accountId: 1 }, isUserLoading: false }),
+    useUserContext: () => ({ user: mockUser, isUserLoading: mockIsUserLoading }),
   };
 });
 
@@ -209,7 +217,20 @@ jest.mock('@dfx.swiss/react-components', () => {
 });
 
 jest.mock('src/components/payment/payment-info-buy', () => ({
-  PaymentInformationContent: ({ info }: any) => <div data-testid="payment-info">{info.amount}</div>,
+  PaymentInformationContent: ({ info, personalIbanProviderSwitch }: any) => (
+    <div>
+      <div data-testid="payment-info">{info.amount}</div>
+      {personalIbanProviderSwitch && (
+        <button
+          type="button"
+          data-testid="switch-provider"
+          onClick={() => personalIbanProviderSwitch.onSwitch(personalIbanProviderSwitch.target)}
+        >
+          switch
+        </button>
+      )}
+    </div>
+  ),
 }));
 jest.mock('../components/error-hint', () => ({ ErrorHint: ({ message }: any) => <div data-testid="error-hint">{message}</div> }));
 jest.mock('../components/exchange-rate', () => ({ ExchangeRate: () => <div data-testid="exchange-rate" /> }));
@@ -243,7 +264,7 @@ jest.mock('../config/labels', () => ({
 }));
 
 jest.mock('../contexts/app-handling.context', () => ({
-  useAppHandlingContext: () => ({ isInitialized: true }),
+  useAppHandlingContext: () => ({ isInitialized: mockIsInitialized }),
 }));
 jest.mock('../contexts/layout.context', () => ({
   useLayoutContext: () => ({ scrollToTop: jest.fn(), rootRef: { current: null } }),
@@ -296,6 +317,9 @@ jest.mock('../hooks/personal-iban.hook', () => ({
     customerIdentity: 1,
     hasAuthenticatedCustomer: true,
   }),
+}));
+jest.mock('../hooks/personal-iban-rows.hook', () => ({
+  usePersonalIbanRows: () => mockPersonalIbanRows,
 }));
 jest.mock('../hooks/blockchain.hook', () => ({
   useBlockchain: () => ({ toString: () => '' }),
@@ -470,6 +494,14 @@ describe('BuyScreen cleared amount protection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSession = undefined;
+    mockUser = { kyc: { level: 0 }, accountId: 1 };
+    mockIsUserLoading = false;
+    mockIsInitialized = true;
+    mockPersonalIbanRows = {
+      activePersonalIbans: undefined,
+      personalIbanRowsSettled: true,
+      userLoadTimedOut: false,
+    };
   });
 
   async function settle(callback: () => unknown) {
@@ -487,7 +519,7 @@ describe('BuyScreen cleared amount protection', () => {
       id: 10,
       // the exact-price echo answers with the Rappen-exact equivalent, not the typed amount
       amount: req.exactPrice ? Number((spendAmount - 0.02).toFixed(2)) : spendAmount,
-      currency: { name: 'CHF' },
+      currency: { name: req.currency?.name ?? 'CHF' },
       estimatedAmount: req.exactPrice ? 0.004709 : 0.0047,
       asset: { name: 'BTC', uniqueName: 'Bitcoin' },
       minVolume: 1,
@@ -813,6 +845,98 @@ describe('BuyScreen cleared amount protection', () => {
     await settle(() => expect(screen.getByText('You get about')).toBeInTheDocument());
   });
 
+  it('ignores confirm when the quote is not yet final', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice) return new Promise(() => undefined);
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByRole('button', { name: 'Click here once you have issued the transfer' }).click();
+      await Promise.resolve();
+    });
+    expect(mockConfirmFor).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('buy-completion')).not.toBeInTheDocument();
+  });
+
+  it('drops a stale quote error after the form generation moved on', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    const rejectors: Array<(err: unknown) => void> = [];
+    mockReceiveFor.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectors.push(reject);
+        }),
+    );
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
+    });
+    await settle(() => expect(rejectors.length).toBeGreaterThan(1));
+    await act(async () => {
+      rejectors[0]({ statusCode: 500, message: 'stale' });
+      await Promise.resolve();
+    });
+    expect(screen.queryByText('stale')).not.toBeInTheDocument();
+  });
+
+  it('drops a confirm result after the quote generation moved on', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    let resolveConfirm: (value?: unknown) => void = () => undefined;
+    mockConfirmFor.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveConfirm = resolve;
+        }),
+    );
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByRole('button', { name: 'Click here once you have issued the transfer' }).click();
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
+    });
+    await act(async () => {
+      resolveConfirm();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('buy-completion')).not.toBeInTheDocument();
+  });
+
+  it('drops a confirm error after the quote generation moved on', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    let rejectConfirm: (err: unknown) => void = () => undefined;
+    mockConfirmFor.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectConfirm = reject;
+        }),
+    );
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByRole('button', { name: 'Click here once you have issued the transfer' }).click();
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
+    });
+    await act(async () => {
+      rejectConfirm({ message: 'stale-confirm' });
+      await Promise.resolve();
+    });
+    expect(screen.queryByText('stale-confirm')).not.toBeInTheDocument();
+  });
+
   it('confirms a final quote', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams());
@@ -920,6 +1044,110 @@ describe('BuyScreen cleared amount protection', () => {
     });
   });
 
+  it('waits for personal IBAN rows instead of quoting while the user is loading', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockIsUserLoading = true;
+    mockPersonalIbanRows = {
+      activePersonalIbans: undefined,
+      personalIbanRowsSettled: false,
+      userLoadTimedOut: false,
+    };
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    expect(mockReceiveFor).not.toHaveBeenCalled();
+  });
+
+  it('shows a personal-IBAN KYC hint when an explicit Frick selector is rejected', async () => {
+    mockPersonalIban.mockReturnValue('Frick');
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockRejectedValue({ statusCode: 400, message: 'KycRequired' });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('quote-error')).toBeInTheDocument());
+    expect(screen.getByTestId('quote-error')).toHaveTextContent('KycRequired');
+  });
+
+  it('offers Show available IBAN when the requested provider is missing', async () => {
+    mockPersonalIban.mockReturnValue('Frick');
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockRejectedValue({ statusCode: 400, message: 'PersonalIbanProviderNotAvailable' });
+    render(<BuyScreen />);
+    await settle(() =>
+      expect(screen.getByRole('button', { name: 'Show available IBAN' })).toBeInTheDocument(),
+    );
+    await act(async () => {
+      screen.getByRole('button', { name: 'Show available IBAN' }).click();
+    });
+  });
+
+  it('suppresses automatic Frick after a KYC rejection when a Yapeal row exists', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUser = { kyc: { level: 50 }, accountId: 1 };
+    mockPersonalIbanRows = {
+      activePersonalIbans: [
+        { bank: 'Yapeal', currency: 'CHF', active: true, acceptsPayments: true },
+      ],
+      personalIbanRowsSettled: true,
+      userLoadTimedOut: false,
+    };
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor
+      .mockRejectedValueOnce({ statusCode: 400, message: 'KycRequired' })
+      .mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await settle(() => expect(mockReceiveFor.mock.calls.length).toBeGreaterThan(0));
+  });
+
+  it('acknowledges a failed Frick verification and continues without the selector', async () => {
+    mockPersonalIban.mockReturnValue('Frick');
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() =>
+      expect(screen.getByRole('button', { name: 'Continue without personal IBAN' })).toBeInTheDocument(),
+    );
+    await act(async () => {
+      screen.getByRole('button', { name: 'Continue without personal IBAN' }).click();
+    });
+  });
+
+  it('maps a non-KYC personal-IBAN HTTP error onto QuoteErrorHint', async () => {
+    mockPersonalIban.mockReturnValue('Frick');
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockRejectedValue({ statusCode: 400, message: 'EmailRequired' });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('quote-error')).toHaveTextContent('EmailRequired'));
+  });
+
+  it('switches personal IBAN provider on a verified Frick quote', async () => {
+    mockPersonalIban.mockReturnValue('Frick');
+    mockUser = { kyc: { level: 50 }, accountId: 1 };
+    mockPersonalIbanRows = {
+      activePersonalIbans: [
+        { bank: 'Yapeal', currency: 'CHF', active: true, acceptsPayments: true },
+      ],
+      personalIbanRowsSettled: true,
+      userLoadTimedOut: false,
+    };
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) =>
+      Promise.resolve({
+        ...quoteFor(req),
+        isPersonalIban: true,
+        bank: 'Bank Frick',
+        name: 'DFX AG',
+      }),
+    );
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('switch-provider')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByTestId('switch-provider').click();
+    });
+  });
+
   it('blocks an unrecognized personal IBAN selector', async () => {
     mockPersonalIban.mockReturnValue('nope');
     mockUseAppParams.mockReturnValue(baseAppParams());
@@ -927,6 +1155,9 @@ describe('BuyScreen cleared amount protection', () => {
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('error-hint')).toBeInTheDocument());
     expect(screen.getByRole('button', { name: 'Continue without personal IBAN' })).toBeInTheDocument();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Continue without personal IBAN' }).click();
+    });
   });
 
   it('navigates to generate a personal IBAN from a non-Frick currency', async () => {
@@ -943,5 +1174,101 @@ describe('BuyScreen cleared amount protection', () => {
       screen.getByRole('button', { name: 'Generate personal IBAN' }).click();
     });
     expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  it('treats a user with a different account id as not the active customer', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUser = { kyc: { level: 50 }, accountId: 99 };
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+  });
+
+  it('falls back to the first asset when assetOut does not match', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetOut: 'NOPE', blockchain: 'Ethereum' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('select-asset-BTC')).toBeInTheDocument());
+  });
+
+  it('skips payment-method defaults while the app is uninitialized', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockIsInitialized = false;
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toBeInTheDocument());
+  });
+
+  it('does not request an exact price when the first quote is empty', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) =>
+      req.exactPrice ? Promise.resolve(quoteFor(req)) : Promise.resolve(undefined),
+    );
+    render(<BuyScreen />);
+    await settle(() => expect(mockReceiveFor).toHaveBeenCalled());
+    expect(mockReceiveFor.mock.calls.every((call: any) => !call[0]?.exactPrice)).toBe(true);
+  });
+
+  it('uses availableBlockchains when wallet and URL blockchain are unset', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({ blockchain: undefined, availableBlockchains: undefined, assetOut: 'NOPE' }),
+    );
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toBeInTheDocument());
+  });
+
+  it('continues without personal IBAN when Frick is inapplicable for the currency', async () => {
+    mockPersonalIban.mockReturnValue('Frick');
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await act(async () => {
+      screen.getByTestId('select-currency-USD').click();
+    });
+    await settle(() =>
+      expect(screen.getByRole('button', { name: 'Continue without personal IBAN' })).toBeInTheDocument(),
+    );
+    await act(async () => {
+      screen.getByRole('button', { name: 'Continue without personal IBAN' }).click();
+    });
+  });
+
+  it('maps an Instant paymentMethod param onto bank', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ paymentMethod: 'Instant' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+  });
+
+  it('switches from a verified Yapeal quote to Frick', async () => {
+    mockPersonalIban.mockReturnValue('Yapeal');
+    mockUser = { kyc: { level: 50 }, accountId: 1 };
+    mockPersonalIbanRows = {
+      activePersonalIbans: [{ bank: 'Yapeal', currency: 'CHF', active: true, acceptsPayments: true }],
+      personalIbanRowsSettled: true,
+      userLoadTimedOut: false,
+    };
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) =>
+      Promise.resolve({
+        ...quoteFor(req),
+        isPersonalIban: true,
+        bank: 'Yapeal',
+        name: 'Customer',
+      }),
+    );
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('switch-provider')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByTestId('switch-provider').click();
+    });
   });
 });

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -1408,6 +1408,37 @@ describe('BuyScreen cleared amount protection', () => {
     expect(mockConfirmFor).not.toHaveBeenCalled();
   });
 
+  it('confirms from form submit on a private asset when the private flag is set', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetOut: 'USDT', flags: 'private' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    mockConfirmFor.mockResolvedValue(undefined);
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    expect(screen.queryByTestId('private-asset-hint')).not.toBeInTheDocument();
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
+      await Promise.resolve();
+    });
+    await settle(() => expect(screen.getByTestId('buy-completion')).toBeInTheDocument());
+    expect(mockConfirmFor).toHaveBeenCalled();
+  });
+
+  it('confirms from the payment CTA on a private asset when the private flag is set', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetOut: 'USDT', flags: 'private' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    mockConfirmFor.mockResolvedValue(undefined);
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByRole('button', { name: 'Click here once you have issued the transfer' }).click();
+      await Promise.resolve();
+    });
+    await settle(() => expect(screen.getByTestId('buy-completion')).toBeInTheDocument());
+    expect(mockConfirmFor).toHaveBeenCalled();
+  });
+
   it('does not confirm from form submit when KYC blocks payment', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams());

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -547,6 +547,99 @@ describe('BuyScreen cleared amount protection', () => {
     };
   }
 
+  it('does not write exact-price into a spend field cleared while a spend-side quote is in flight', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await settle(() => expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice && hangExact)).toBe(true));
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      resolveExact(quoteFor({ targetAmount: '0.01', exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
+  it('does not write exact-price into a target field cleared while a get-side quote is in flight', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
+    });
+    await settle(() => expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice)).toBe(true));
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      resolveExact(quoteFor({ amount: 150, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
+  it('still invalidates quotes when spend is cleared after an exact-price no-op write', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      resolveExact(quoteFor({ targetAmount: '0.01', exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
   it('keeps a cleared amount field empty and accepts the retyped amount', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams());

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -1266,6 +1266,26 @@ describe('BuyScreen cleared amount protection', () => {
     unmount();
   });
 
+  it('does not resume a stale quote after a selector change on a retyped spend field', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    const { rerender, unmount } = render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    expect(screen.getByTestId('input-amount')).toHaveValue('300');
+    const callsBeforeRetype = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '400' } });
+      mockPersonalIban.mockReturnValue('Frick');
+      rerender(<BuyScreen />);
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('400');
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('400'));
+    const afterRetype = mockReceiveFor.mock.calls.slice(callsBeforeRetype);
+    expect(afterRetype.every((call: any) => Number(call[0]?.amount) !== 300)).toBe(true);
+    unmount();
+  });
+
   it('shows a personal-IBAN KYC hint when an explicit Frick selector is rejected', async () => {
     mockPersonalIban.mockReturnValue('Frick');
     mockUseAppParams.mockReturnValue(baseAppParams());

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -9,17 +9,25 @@ const mockConfirmFor = jest.fn();
 const mockUseAppParams = jest.fn();
 const mockPersonalIban = jest.fn();
 const mockSetParams = jest.fn();
+const mockLogout = jest.fn();
+const mockNavigate = jest.fn();
+const mockSwitchBlockchain = jest.fn();
 const mockEmptyPersonalIbans: never[] = [];
+const mockTranslate = (_ns: string, key: string) => key;
+const mockTranslateError = (key: string) => key;
+let mockSession: { address: string } | undefined;
 
 const mockAssets = [
   { name: 'BTC', uniqueName: 'Bitcoin', category: 'Public', blockchain: 'Ethereum', description: 'Bitcoin' },
   { name: 'ETH', uniqueName: 'Ethereum/ETH', category: 'Public', blockchain: 'Ethereum', description: 'Ethereum' },
+  { name: 'USDT', uniqueName: 'Ethereum/USDT', category: 'Private', blockchain: 'Ethereum', description: 'Tether' },
+  { name: 'WBTC', uniqueName: 'Bitcoin/WBTC', category: 'Public', blockchain: 'Bitcoin', description: 'Wrapped' },
 ];
 const mockAssetsMap = new Map([['Ethereum', mockAssets]]);
 const mockGetAssets = () => mockAssets;
 const mockGetAsset = (list: any[], name: string) =>
   (list ?? []).find((a: any) => a.name === name) ?? list?.[0];
-const mockIsSameAsset = () => false;
+const mockIsSameAsset = (asset: any, filter: string) => asset.name === filter || asset.uniqueName === filter;
 const mockGetCurrency = (list: any[], name: string) => (list ?? []).find((c: any) => c.name === name);
 const mockGetDefaultCurrency = (list: any[]) => list?.[0];
 const mockCurrencies = [
@@ -71,7 +79,7 @@ jest.mock('@dfx.swiss/react', () => {
       assets: mockAssetsMap,
       getAssets: mockGetAssets,
     }),
-    useAuthContext: () => ({ session: undefined }),
+    useAuthContext: () => ({ session: mockSession }),
     useBuy: () => buyInterface,
     useFiat: () => ({
       toSymbol: () => '',
@@ -79,7 +87,7 @@ jest.mock('@dfx.swiss/react', () => {
       getCurrency: mockGetCurrency,
       getDefaultCurrency: mockGetDefaultCurrency,
     }),
-    useSessionContext: () => ({ logout: jest.fn() }),
+    useSessionContext: () => ({ logout: mockLogout }),
     useUserContext: () => ({ user: { kyc: { level: 0 }, accountId: 1 }, isUserLoading: false }),
   };
 });
@@ -108,7 +116,18 @@ jest.mock('@dfx.swiss/react-components', () => {
 
   return {
     AssetIconVariant: {},
-    Form: ({ children, control }: any) => <div>{enrich(children, control)}</div>,
+    Form: ({ children, control, onSubmit }: any) => (
+      <div>
+        {enrich(children, control)}
+        <button
+          type="button"
+          data-testid="form-submit"
+          onClick={() => onSubmit?.({ preventDefault() { return undefined; } })}
+        >
+          submit
+        </button>
+      </div>
+    ),
     IconColor: { BLUE: 'blue' },
     SpinnerSize: { SM: 'sm', LG: 'lg' },
     StyledButton: ({ label, onClick }: any) => (
@@ -118,20 +137,21 @@ jest.mock('@dfx.swiss/react-components', () => {
     ),
     StyledButtonColor: { STURDY_WHITE: 'sturdy-white' },
     StyledButtonWidth: { MIN: 'min', FULL: 'full' },
-    StyledDropdown: ({ name, items, labelFunc, control }: any) => (
+    StyledDropdown: ({ name, items, labelFunc, descriptionFunc, control }: any) => (
       <Controller
         name={name}
         control={control}
         render={({ field }: any) => (
           <div data-testid={`dropdown-${name}`}>
-            {(items ?? []).map((item: any) => (
+            {(items ?? []).map((item: any, index: number) => (
               <button
-                key={labelFunc(item)}
+                key={`${labelFunc(item)}-${index}`}
                 type="button"
-                data-testid={`select-${name}-${labelFunc(item)}`}
+                data-testid={`select-${name}-${labelFunc(item) || index}`}
                 onClick={() => field.onChange(item)}
               >
                 {labelFunc(item)}
+                {descriptionFunc?.(item)}
               </button>
             ))}
           </div>
@@ -141,28 +161,35 @@ jest.mock('@dfx.swiss/react-components', () => {
     StyledHorizontalStack: ({ children }: any) => <div>{children}</div>,
     StyledInfoText: ({ children }: any) => <div>{children}</div>,
     // Interactive so the clear/retype protection can drive the amount fields like a user would.
-    StyledInput: ({ name, control }: any) =>
+    StyledInput: ({ name, control, forceErrorMessage }: any) =>
       name ? (
         <Controller
           name={name}
           control={control}
           render={({ field }: any) => (
-            <input
-              data-testid={`input-${name}`}
-              value={field.value ?? ''}
-              onChange={(e: any) => field.onChange(e.target.value)}
-            />
+            <>
+              <input
+                data-testid={`input-${name}`}
+                value={field.value ?? ''}
+                onChange={(e: any) => field.onChange(e.target.value)}
+              />
+              {forceErrorMessage && <div data-testid={`input-${name}-error`}>{forceErrorMessage}</div>}
+            </>
           )}
         />
       ) : null,
     StyledLink: ({ children, label }: any) => <div>{label ?? children}</div>,
     StyledLoadingSpinner: () => null,
-    StyledSearchDropdown: ({ name, items, labelFunc, control }: any) => (
+    StyledSearchDropdown: ({ name, items, labelFunc, control, filterFunc, descriptionFunc, assetIconFunc }: any) => (
       <Controller
         name={name}
         control={control}
         render={({ field }: any) => (
           <div data-testid={`dropdown-${name}`}>
+            {items?.[0] && filterFunc?.(items[0], undefined)}
+            {items?.[0] && filterFunc?.(items[0], 'btc')}
+            {items?.[0] && descriptionFunc?.(items[0])}
+            {items?.[0] && assetIconFunc?.(items[0])}
             {(items ?? []).map((item: any) => (
               <button
                 key={labelFunc(item)}
@@ -184,13 +211,29 @@ jest.mock('@dfx.swiss/react-components', () => {
 jest.mock('src/components/payment/payment-info-buy', () => ({
   PaymentInformationContent: ({ info }: any) => <div data-testid="payment-info">{info.amount}</div>,
 }));
-jest.mock('../components/edit/name.edit', () => ({ NameEdit: () => null }));
-jest.mock('../components/error-hint', () => ({ ErrorHint: ({ message }: any) => <div>{message}</div> }));
-jest.mock('../components/exchange-rate', () => ({ ExchangeRate: () => null }));
-jest.mock('../components/payment/address-switch', () => ({ AddressSwitch: () => null }));
-jest.mock('../components/payment/buy-completion', () => ({ BuyCompletion: () => null }));
-jest.mock('../components/private-asset-hint', () => ({ PrivateAssetHint: () => null }));
-jest.mock('../components/quote-error-hint', () => ({ QuoteErrorHint: () => null }));
+jest.mock('../components/error-hint', () => ({ ErrorHint: ({ message }: any) => <div data-testid="error-hint">{message}</div> }));
+jest.mock('../components/exchange-rate', () => ({ ExchangeRate: () => <div data-testid="exchange-rate" /> }));
+jest.mock('../components/payment/address-switch', () => ({
+  AddressSwitch: ({ onClose }: any) => (
+    <div data-testid="address-switch">
+      <button type="button" data-testid="address-switch-confirm" onClick={() => onClose(true)}>
+        confirm
+      </button>
+      <button type="button" data-testid="address-switch-cancel" onClick={() => onClose(false)}>
+        cancel
+      </button>
+    </div>
+  ),
+}));
+jest.mock('../components/payment/buy-completion', () => ({
+  BuyCompletion: () => <div data-testid="buy-completion" />,
+}));
+jest.mock('../components/private-asset-hint', () => ({
+  PrivateAssetHint: () => <div data-testid="private-asset-hint" />,
+}));
+jest.mock('../components/quote-error-hint', () => ({
+  QuoteErrorHint: ({ error }: any) => <div data-testid="quote-error">{error}</div>,
+}));
 jest.mock('../components/sanction-hint', () => ({ SanctionHint: () => null }));
 
 // labels.ts pulls many runtime enums from @dfx.swiss/react at module load; mock the only
@@ -208,13 +251,17 @@ jest.mock('../contexts/layout.context', () => ({
 // prefCurrency must be truthy: currency effect only calls setVal when prefCurrency && currency.
 jest.mock('../contexts/settings.context', () => ({
   useSettingsContext: () => ({
-    translate: (_ns: string, key: string) => key,
-    translateError: (key: string) => key,
+    translate: mockTranslate,
+    translateError: mockTranslateError,
     currency: mockPrefCurrency,
   }),
 }));
 jest.mock('../contexts/wallet.context', () => ({
-  useWalletContext: () => ({ blockchain: undefined, isInitialized: true, switchBlockchain: jest.fn() }),
+  useWalletContext: () => ({
+    blockchain: undefined,
+    isInitialized: true,
+    switchBlockchain: mockSwitchBlockchain,
+  }),
 }));
 jest.mock('src/contexts/window.context', () => ({
   useWindowContext: () => ({ width: 800 }),
@@ -260,7 +307,7 @@ jest.mock('../hooks/layout-config.hook', () => ({
   useLayoutOptions: () => undefined,
 }));
 jest.mock('../hooks/navigation.hook', () => ({
-  useNavigation: () => ({ navigate: jest.fn() }),
+  useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
 import { act, fireEvent, render, screen } from '@testing-library/react';
@@ -287,6 +334,7 @@ function baseAppParams(overrides: Record<string, unknown> = {}) {
 describe('BuyScreen quote race protection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSession = undefined;
   });
 
   async function waitFor(callback: () => unknown) {
@@ -421,6 +469,7 @@ describe('BuyScreen quote race protection', () => {
 describe('BuyScreen cleared amount protection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSession = undefined;
   });
 
   async function settle(callback: () => unknown) {
@@ -668,5 +717,203 @@ describe('BuyScreen cleared amount protection', () => {
     const typed = mockReceiveFor.mock.calls.slice(callsBeforeType);
     expect(typed.length).toBeGreaterThan(0);
     expect(typed.every((call: any) => String(call[0].amount) === '150')).toBe(true);
+  });
+
+  it('shows amount-too-low from the quote error field', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) =>
+      Promise.resolve({ ...quoteFor(req), error: 'AmountTooLow', minVolume: 1 }),
+    );
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount-error')).toBeInTheDocument());
+  });
+
+  it('shows amount-too-high from the quote error field', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) =>
+      Promise.resolve({ ...quoteFor(req), error: 'AmountTooHigh', maxVolume: 1 }),
+    );
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount-error')).toBeInTheDocument());
+  });
+
+  it('routes KYC quote errors through QuoteErrorHint', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('quote-error')).toHaveTextContent('KycRequired'));
+  });
+
+  it('shows a generic error and retries', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockRejectedValueOnce({ statusCode: 500, message: 'boom' }).mockImplementation((req: any) =>
+      Promise.resolve(quoteFor(req)),
+    );
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('boom'));
+    await act(async () => {
+      screen.getByRole('button', { name: 'Retry' }).click();
+    });
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+  });
+
+  it('uses Unknown error when the API omits a message', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockRejectedValue({ statusCode: 500 });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('Unknown error'));
+  });
+
+  it('filters assets when an asset filter is set', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ assets: 'BTC', assetOut: 'BTC' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('select-asset-BTC')).toBeInTheDocument());
+    expect(screen.queryByTestId('select-asset-ETH')).not.toBeInTheDocument();
+  });
+
+  it('shows the private-asset hint', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetOut: 'USDT' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('private-asset-hint')).toBeInTheDocument());
+  });
+
+  it('uses the exact You get heading when rate is 1', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), rate: 1 }));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByText('You get')).toBeInTheDocument());
+  });
+
+  it('confirms a final quote', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    mockConfirmFor.mockResolvedValue(undefined);
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByRole('button', { name: 'Click here once you have issued the transfer' }).click();
+      await Promise.resolve();
+    });
+    await settle(() => expect(screen.getByTestId('buy-completion')).toBeInTheDocument());
+  });
+
+  it('shows a confirm error from the API', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    mockConfirmFor.mockRejectedValue({ message: 'confirm-failed' });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByRole('button', { name: 'Click here once you have issued the transfer' }).click();
+      await Promise.resolve();
+    });
+    await settle(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('confirm-failed'));
+  });
+
+  it('opens and cancels the address switch', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockSession = { address: '0xabc' };
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({
+        hideTargetSelection: false,
+        availableBlockchains: ['Ethereum'],
+        blockchain: 'Ethereum',
+      }),
+    );
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('dropdown-address')).toBeInTheDocument());
+    const switchButton = screen.getByTestId('select-address-Switch address');
+    await act(async () => {
+      switchButton.click();
+    });
+    expect(screen.getByTestId('address-switch')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByTestId('address-switch-cancel').click();
+    });
+    expect(screen.queryByTestId('address-switch')).not.toBeInTheDocument();
+  });
+
+  it('logs out when the address switch is confirmed', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockSession = { address: '0xabc' };
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({
+        hideTargetSelection: false,
+        availableBlockchains: ['Ethereum'],
+        blockchain: 'Ethereum',
+      }),
+    );
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('dropdown-address')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByTestId('select-address-Switch address').click();
+    });
+    await act(async () => {
+      screen.getByTestId('address-switch-confirm').click();
+    });
+    expect(mockLogout).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/connect', { setRedirect: true });
+  });
+
+  it('switches blockchain when another chain address is chosen', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockSession = { address: '0xabc' };
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({
+        hideTargetSelection: false,
+        availableBlockchains: ['Ethereum', 'Bitcoin'],
+        blockchain: 'Ethereum',
+      }),
+    );
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('dropdown-address')).toBeInTheDocument());
+    const buttons = screen.getAllByTestId(/select-address-/);
+    await act(async () => {
+      buttons[1].click();
+    });
+    expect(mockSetParams).toHaveBeenCalled();
+    expect(mockSwitchBlockchain).toHaveBeenCalled();
+  });
+
+  it('submits the empty onSubmit handler', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+    });
+  });
+
+  it('navigates to generate a personal IBAN from a non-Frick currency', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByTestId('select-currency-USD').click();
+    });
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByRole('button', { name: 'Generate personal IBAN' }).click();
+    });
+    expect(mockNavigate).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -139,7 +139,21 @@ jest.mock('@dfx.swiss/react-components', () => {
     ),
     StyledHorizontalStack: ({ children }: any) => <div>{children}</div>,
     StyledInfoText: ({ children }: any) => <div>{children}</div>,
-    StyledInput: () => null,
+    // Interactive so the clear/retype protection can drive the amount fields like a user would.
+    StyledInput: ({ name, control }: any) =>
+      name ? (
+        <Controller
+          name={name}
+          control={control}
+          render={({ field }: any) => (
+            <input
+              data-testid={`input-${name}`}
+              value={field.value ?? ''}
+              onChange={(e: any) => field.onChange(e.target.value)}
+            />
+          )}
+        />
+      ) : null,
     StyledLink: ({ children, label }: any) => <div>{label ?? children}</div>,
     StyledLoadingSpinner: () => null,
     StyledSearchDropdown: () => null,
@@ -229,7 +243,7 @@ jest.mock('../hooks/navigation.hook', () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
 }));
 
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import BuyScreen from 'src/screens/buy.screen';
 
 function baseAppParams(overrides: Record<string, unknown> = {}) {
@@ -378,5 +392,86 @@ describe('BuyScreen quote race protection', () => {
     });
     await waitFor(() => expect(screen.getByTestId('payment-info')).toHaveTextContent('333'));
     expect(mockReceiveFor.mock.calls.every((call: any) => !('personalIbanProvider' in call[0]))).toBe(true);
+  });
+});
+
+// Clear/retype protection: an amount field the user just emptied must never be refilled from the
+// opposite side — the exact-price echo used to write the recomputed equivalent (e.g. 299.98 for
+// the 300 default) into the field mid-typing, making custom amounts nearly impossible to enter.
+describe('BuyScreen cleared amount protection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  async function settle(callback: () => unknown) {
+    await act(async () => {
+      for (let i = 0; i < 10; i += 1) {
+        await Promise.resolve();
+      }
+    });
+    return callback();
+  }
+
+  function quoteFor(req: any) {
+    const spendAmount = req.amount !== undefined ? Number(req.amount) : 300;
+    return {
+      id: 10,
+      // the exact-price echo answers with the Rappen-exact equivalent, not the typed amount
+      amount: req.exactPrice ? Number((spendAmount - 0.02).toFixed(2)) : spendAmount,
+      currency: { name: 'CHF' },
+      estimatedAmount: req.exactPrice ? 0.004709 : 0.0047,
+      asset: { name: 'BTC', uniqueName: 'Bitcoin' },
+      minVolume: 1,
+      maxVolume: 100000,
+      isValid: true,
+      exchangeRate: 1,
+      rate: 1,
+      fees: {},
+      priceSteps: [],
+      isPersonalIban: false,
+      name: 'DFX AG',
+    };
+  }
+
+  it('keeps a cleared amount field empty and accepts the retyped amount', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+
+    // Default flow: 300 stays in the field, the exact estimate lands on the target side only.
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await settle(() => expect(screen.getByTestId('payment-info')).toHaveTextContent('299.98'));
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('0.004709');
+
+    // The user empties the field to retype: no cross-side recompute may refill it.
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await settle(() => expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument());
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+
+    // Retyping works and the echo still only updates the target side.
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
+    });
+    await settle(() => expect(screen.getByTestId('payment-info')).toHaveTextContent('149.98'));
+    expect(screen.getByTestId('input-amount')).toHaveValue('150');
+  });
+
+  it('keeps a cleared target amount field empty (mirrored protection)', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-targetAmount')).toHaveValue('0.004709'));
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await settle(() => expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument());
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
   });
 });

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -1322,7 +1322,7 @@ describe('BuyScreen cleared amount protection', () => {
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     await settle(() => expect(screen.getByTestId('buy-completion')).toBeInTheDocument());

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -594,4 +594,79 @@ describe('BuyScreen cleared amount protection', () => {
     await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
     expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
   });
+
+  it('does not restore amountIn after the user clears spend and then changes asset', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: '100' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('100'));
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
+
+    await act(async () => {
+      screen.getByTestId('select-asset-ETH').click();
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
+  it('quotes the typed spend amount after both fields were cleared', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
+    await settle(() => expect(screen.getByTestId('input-targetAmount')).toHaveValue(''));
+
+    const callsBeforeType = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
+    });
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    expect(screen.getByTestId('input-amount')).toHaveValue('150');
+    const typed = mockReceiveFor.mock.calls.slice(callsBeforeType);
+    expect(typed.length).toBeGreaterThan(0);
+    expect(typed.every((call: any) => String(call[0].amount) === '150')).toBe(true);
+  });
+
+  it('quotes from a new spend amount after the target field was cleared', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await settle(() => expect(screen.getByTestId('input-targetAmount')).toHaveValue(''));
+
+    const callsBeforeType = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '150' } });
+    });
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    expect(screen.getByTestId('input-amount')).toHaveValue('150');
+    const typed = mockReceiveFor.mock.calls.slice(callsBeforeType);
+    expect(typed.length).toBeGreaterThan(0);
+    expect(typed.every((call: any) => String(call[0].amount) === '150')).toBe(true);
+  });
 });

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -609,6 +609,25 @@ describe('BuyScreen cleared amount protection', () => {
     expect(retyped.every((call: any) => String(call[0].targetAmount) === '0.01')).toBe(true);
   });
 
+  it('does not restore amountOut after the user clears target and then changes asset', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: undefined, amountOut: '0.01' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-targetAmount')).toHaveValue('0.01'));
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await settle(() => expect(screen.getByTestId('input-targetAmount')).toHaveValue(''));
+
+    await act(async () => {
+      screen.getByTestId('select-asset-ETH').click();
+    });
+    await settle(() => expect(screen.getByTestId('input-targetAmount')).toHaveValue(''));
+  });
+
   it('still quotes from a never-set spend field via amountOut (deep-link fallback)', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: undefined, amountOut: '0.01' }));

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -13,6 +13,7 @@ const mockEmptyPersonalIbans: never[] = [];
 
 const mockAssets = [
   { name: 'BTC', uniqueName: 'Bitcoin', category: 'Public', blockchain: 'Ethereum', description: 'Bitcoin' },
+  { name: 'ETH', uniqueName: 'Ethereum/ETH', category: 'Public', blockchain: 'Ethereum', description: 'Ethereum' },
 ];
 const mockAssetsMap = new Map([['Ethereum', mockAssets]]);
 const mockGetAssets = () => mockAssets;
@@ -156,7 +157,26 @@ jest.mock('@dfx.swiss/react-components', () => {
       ) : null,
     StyledLink: ({ children, label }: any) => <div>{label ?? children}</div>,
     StyledLoadingSpinner: () => null,
-    StyledSearchDropdown: () => null,
+    StyledSearchDropdown: ({ name, items, labelFunc, control }: any) => (
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }: any) => (
+          <div data-testid={`dropdown-${name}`}>
+            {(items ?? []).map((item: any) => (
+              <button
+                key={labelFunc(item)}
+                type="button"
+                data-testid={`select-${name}-${labelFunc(item)}`}
+                onClick={() => field.onChange(item)}
+              >
+                {labelFunc(item)}
+              </button>
+            ))}
+          </div>
+        )}
+      />
+    ),
     StyledVerticalStack: ({ children }: any) => <div>{children}</div>,
   };
 });
@@ -528,5 +548,50 @@ describe('BuyScreen cleared amount protection', () => {
     await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('100'));
     await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
     expect(mockReceiveFor.mock.calls.every((call: any) => String(call[0].amount) === '100')).toBe(true);
+  });
+
+  it('does not refill a cleared spend field when the currency changes', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
+
+    const callsBeforeCurrency = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      screen.getByTestId('select-currency-EUR').click();
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    const after = mockReceiveFor.mock.calls.slice(callsBeforeCurrency);
+    expect(after.every((call: any) => call[0].amount === undefined)).toBe(true);
+  });
+
+  it('does not refill a cleared spend field when the asset changes', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue('300'));
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
+
+    await act(async () => {
+      screen.getByTestId('select-asset-ETH').click();
+    });
+    await settle(() => expect(screen.getByTestId('input-amount')).toHaveValue(''));
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/buy-screen-race-protection.test.tsx
+++ b/src/__tests__/buy-screen-race-protection.test.tsx
@@ -1314,17 +1314,160 @@ describe('BuyScreen cleared amount protection', () => {
     expect(mockSwitchBlockchain).toHaveBeenCalled();
   });
 
-  it('submits the empty onSubmit handler', async () => {
+  it('confirms a final quote from form submit', async () => {
     mockPersonalIban.mockReturnValue(undefined);
     mockUseAppParams.mockReturnValue(baseAppParams());
     mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    mockConfirmFor.mockResolvedValue(undefined);
     render(<BuyScreen />);
     await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
     await act(async () => {
       screen.getByTestId('form-submit').click();
+      await Promise.resolve();
     });
-    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
-    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
+    await settle(() => expect(screen.getByTestId('buy-completion')).toBeInTheDocument());
+    expect(mockConfirmFor).toHaveBeenCalled();
+  });
+
+  it('does not confirm from form submit after spend is cleared', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    mockConfirmFor.mockResolvedValue(undefined);
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockConfirmFor).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('buy-completion')).not.toBeInTheDocument();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+  });
+
+  it('does not confirm from form submit after target is cleared', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    mockConfirmFor.mockResolvedValue(undefined);
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockConfirmFor).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('buy-completion')).not.toBeInTheDocument();
+  });
+
+  it('does not confirm from form submit when a quote error is showing', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockRejectedValue({ statusCode: 500, message: 'boom' });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('boom'));
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockConfirmFor).not.toHaveBeenCalled();
+  });
+
+  it('does not confirm from form submit while the quote is not final', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice) return new Promise(() => undefined);
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockConfirmFor).not.toHaveBeenCalled();
+  });
+
+  it('does not confirm from form submit on a private asset', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetOut: 'USDT' }));
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('private-asset-hint')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockConfirmFor).not.toHaveBeenCalled();
+  });
+
+  it('does not confirm from form submit when KYC blocks payment', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('quote-error')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockConfirmFor).not.toHaveBeenCalled();
+  });
+
+  it('does not confirm from form submit when amount is too low', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) =>
+      Promise.resolve({ ...quoteFor(req), error: 'AmountTooLow', minVolume: 1 }),
+    );
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('input-amount-error')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockConfirmFor).not.toHaveBeenCalled();
+  });
+
+  it('does not confirm from form submit while personal IBAN needs acknowledgement', async () => {
+    mockPersonalIban.mockReturnValue('Frick');
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<BuyScreen />);
+    await settle(() =>
+      expect(screen.getByRole('button', { name: 'Continue without personal IBAN' })).toBeInTheDocument(),
+    );
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockConfirmFor).not.toHaveBeenCalled();
+  });
+
+  it('does not confirm from form submit while a confirm is already in flight', async () => {
+    mockPersonalIban.mockReturnValue(undefined);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    mockConfirmFor.mockImplementation(() => new Promise(() => undefined));
+    render(<BuyScreen />);
+    await settle(() => expect(screen.getByTestId('payment-info')).toBeInTheDocument());
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockConfirmFor).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockConfirmFor).toHaveBeenCalledTimes(1);
   });
 
   it('waits for personal IBAN rows instead of quoting while the user is loading', async () => {

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -738,6 +738,24 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
   });
 
+  it('does not restore a default amount after the user clears spend and the asset changes', async () => {
+    mockAssets = [eth, btc];
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'ETH' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.1');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    await act(async () => {
+      screen.getByTestId('select-asset-BTC').click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+  });
+
   it('skips the exact-price request when the first quote is empty', async () => {
     mockReceiveFor.mockResolvedValueOnce(undefined);
     render(<SellScreen />);

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -515,9 +515,20 @@ describe('SellScreen', () => {
   });
 
   it('still invalidates quotes when target is cleared after an exact-price no-op write', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
     render(<SellScreen />);
     await flushQuote();
     const targetBefore = (screen.getByTestId('input-targetAmount') as HTMLInputElement).value;
+    hangExact = true;
     await act(async () => {
       screen.getByTestId('select-currency-1').click();
     });
@@ -526,14 +537,28 @@ describe('SellScreen', () => {
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
     });
-    await flushQuote();
+    await act(async () => {
+      resolveExact(quoteFor({ amount: 0.1, exactPrice: true }));
+      await Promise.resolve();
+    });
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
     expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
   });
 
   it('still invalidates quotes when spend is cleared after an exact-price no-op write', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
     render(<SellScreen />);
     await flushQuote();
+    hangExact = true;
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '100' } });
     });
@@ -542,7 +567,10 @@ describe('SellScreen', () => {
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
     });
-    await flushQuote();
+    await act(async () => {
+      resolveExact(quoteFor({ targetAmount: 100, exactPrice: true }));
+      await Promise.resolve();
+    });
     expect(screen.getByTestId('input-amount')).toHaveValue('');
     expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
   });

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -43,7 +43,8 @@ let mockSession: { address: string } | undefined;
 let mockActiveWallet: string | undefined;
 let mockFlags: string | undefined;
 let mockHideTarget = true;
-const mockGetAsset = (list: any[], name?: string) => (list ?? []).find((a: any) => a.name === name) ?? list?.[0];
+const mockGetAsset = (list: any[], name?: string) =>
+  name ? (list ?? []).find((a: any) => a.name === name) : undefined;
 const mockGetAssets = () => mockAssets;
 const mockIsSameAsset = (asset: any, filter: string) => asset.name === filter || asset.uniqueName === filter;
 const mockGetCurrency = (list: any[], name?: string) => (list ?? []).find((c: any) => c.name === name);
@@ -735,5 +736,26 @@ describe('SellScreen', () => {
       screen.getByRole('button', { name: 'Retry' }).click();
     });
     expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
+  });
+
+  it('skips the exact-price request when the first quote is empty', async () => {
+    mockReceiveFor.mockResolvedValueOnce(undefined);
+    render(<SellScreen />);
+    await flushQuote();
+    expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice)).toBe(false);
+  });
+
+  it('renders empty balances in the asset dropdown', async () => {
+    mockGetBalances.mockResolvedValue([]);
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('select-asset-ETH')).toBeInTheDocument();
+  });
+
+  it('falls back to the first asset when assetIn does not match', async () => {
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'NOPE' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('select-asset-ETH')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -178,7 +178,7 @@ jest.mock('@dfx.swiss/react-components', () => {
       />
     ),
     StyledHorizontalStack: ({ children }: any) => <div>{children}</div>,
-    StyledInput: ({ name, control, buttonLabel, buttonClick, forceErrorMessage }: any) =>
+    StyledInput: ({ name, control, buttonLabel, buttonClick, forceErrorMessage, loading, disabled }: any) =>
       name ? (
         <Controller
           name={name}
@@ -188,6 +188,7 @@ jest.mock('@dfx.swiss/react-components', () => {
               <input
                 data-testid={`input-${name}`}
                 value={field.value ?? ''}
+                disabled={Boolean(loading || disabled)}
                 onChange={(e: any) => field.onChange(e.target.value)}
               />
               {buttonLabel && (
@@ -630,6 +631,8 @@ describe('SellScreen', () => {
     await flushQuote();
     expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
     expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.getByTestId('input-amount')).not.toBeDisabled();
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
     expect(mockReceiveFor.mock.calls.length).toBe(callsBeforeClear);
 
     await act(async () => {
@@ -1069,7 +1072,7 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('select-currency-0')).toBeInTheDocument();
   });
 
-  it('skips restoring currency when no preferred currency is set', async () => {
+  it('renders when no preferred currency is set', async () => {
     mockPrefCurrency = undefined;
     mockUseAppParams.mockReturnValue(baseAppParams({ assetOut: 'NOPE' }));
     render(<SellScreen />);
@@ -1106,7 +1109,7 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('payment-info-text')).toBeInTheDocument();
   });
 
-  it('falls back to the first address when the URL chain is not in the list', async () => {
+  it('renders the form when the URL chain is not in the address list', async () => {
     mockSession = { address: '0xabc' };
     mockHideTarget = false;
     mockUseAppParams.mockReturnValue(
@@ -1121,7 +1124,7 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('form-submit')).toBeInTheDocument();
   });
 
-  it('does not set an address while the app is uninitialized', async () => {
+  it('renders while uninitialized with a session address present', async () => {
     mockIsInitialized = false;
     mockSession = { address: '0xabc' };
     mockHideTarget = false;
@@ -1152,7 +1155,7 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('input-amount')).toHaveValue('');
   });
 
-  it('does not select an asset when no chain and no matching asset exist', async () => {
+  it('renders when no chain and no matching asset exist', async () => {
     mockWalletBlockchain = undefined;
     mockUseAppParams.mockReturnValue(
       baseAppParams({ assetIn: 'NOPE', blockchain: undefined, availableBlockchains: undefined }),

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -52,7 +52,7 @@ const mockIsSameAsset = (asset: any, filter: string) => asset.name === filter ||
 const mockGetCurrency = (list: any[], name?: string) => (list ?? []).find((c: any) => c.name === name);
 const mockGetDefaultCurrency = (list: any[]) => list?.[0];
 const mockCurrencies = [chf, eur, gbp];
-const mockFormatIban = jest.fn((iban: string) => iban);
+const mockFormatIban = jest.fn((iban: string): string | undefined => iban);
 let mockWalletBlockchain: string | undefined = 'Ethereum';
 let mockPrefCurrency: { name: string } | undefined;
 let mockIsInitialized = true;
@@ -882,6 +882,12 @@ describe('SellScreen', () => {
       await Promise.resolve();
     });
     expect(screen.getByTestId('error-hint')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Retry' }).click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
   });
 
   it('marks a manual transfer complete without sending', async () => {
@@ -1150,9 +1156,6 @@ describe('SellScreen', () => {
     await act(async () => {
       screen.getByRole('button', { name: 'Retry' }).click();
     });
-    await act(async () => {
-      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
-    });
     await flushQuote();
     expect(screen.getByTestId('payment-info')).toBeInTheDocument();
   });
@@ -1310,7 +1313,7 @@ describe('SellScreen', () => {
   });
 
   it('renders payment info without a formatted IBAN', async () => {
-    mockFormatIban.mockReturnValue(undefined as unknown as string);
+    mockFormatIban.mockReturnValue(undefined);
     render(<SellScreen />);
     await flushQuote();
     expect(screen.getByTestId('payment-info-text')).toBeInTheDocument();

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -784,6 +784,8 @@ describe('SellScreen', () => {
     await act(async () => {
       screen.getByTestId('form-submit').click();
     });
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
   });
 
   it('toggles the bank-account modal title', async () => {
@@ -797,6 +799,8 @@ describe('SellScreen', () => {
     await act(async () => {
       latest.onBack();
     });
+    const afterBack = mockLayoutOptions.mock.calls[mockLayoutOptions.mock.calls.length - 1][0];
+    expect(afterBack.title).toBe('Sell');
   });
 
   it('uses the exact You get heading when rate is 1', async () => {
@@ -844,13 +848,20 @@ describe('SellScreen', () => {
   });
 
   it('invokes Retry after a generic error', async () => {
-    mockReceiveFor.mockRejectedValue({ statusCode: 500, message: 'boom' });
+    mockReceiveFor
+      .mockRejectedValueOnce({ statusCode: 500, message: 'boom' })
+      .mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
     render(<SellScreen />);
     await flushQuote();
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
     await act(async () => {
       screen.getByRole('button', { name: 'Retry' }).click();
     });
-    expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
   });
 
   it('quotes from a new spend amount after the target field was cleared', async () => {
@@ -1053,11 +1064,14 @@ describe('SellScreen', () => {
   it('does not quote a zero spend amount', async () => {
     render(<SellScreen />);
     await flushQuote();
+    const callsBefore = mockReceiveFor.mock.calls.length;
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0' } });
     });
     await flushQuote();
     expect(screen.getByTestId('input-amount')).toHaveValue('0');
+    const after = mockReceiveFor.mock.calls.slice(callsBefore);
+    expect(after.every((call: any) => Number(call[0]?.amount) !== 0)).toBe(true);
   });
 
   it('drops a quote error that rejects after unmount', async () => {
@@ -1077,6 +1091,8 @@ describe('SellScreen', () => {
       rejectQuote({ statusCode: 500, message: 'late' });
       await Promise.resolve();
     });
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
   });
 
   it('drops a quote that resolves after unmount', async () => {
@@ -1096,5 +1112,7 @@ describe('SellScreen', () => {
       resolveQuote(quoteFor({ amount: 0.1 }));
       await Promise.resolve();
     });
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -514,6 +514,20 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('input-amount')).toHaveValue('0.3');
   });
 
+  it('clears a KYC quote error when the user empties the spend field', async () => {
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('quote-error')).toHaveTextContent('KycRequired');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    expect(screen.queryByTestId('quote-error')).not.toBeInTheDocument();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
   it('keeps a cleared amount field empty and accepts the retyped amount', async () => {
     render(<SellScreen />);
     await flushQuote();

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -956,7 +956,7 @@ describe('SellScreen', () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
     });
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
@@ -971,7 +971,7 @@ describe('SellScreen', () => {
       fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
     });
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
@@ -985,7 +985,7 @@ describe('SellScreen', () => {
     await flushQuote();
     expect(screen.getByTestId('private-asset-hint')).toBeInTheDocument();
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
@@ -998,7 +998,7 @@ describe('SellScreen', () => {
     await flushQuote();
     expect(screen.getByTestId('quote-error')).toBeInTheDocument();
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
@@ -1013,7 +1013,7 @@ describe('SellScreen', () => {
     await flushQuote();
     expect(screen.getByTestId('input-amount-error')).toBeInTheDocument();
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
@@ -1026,7 +1026,7 @@ describe('SellScreen', () => {
     await flushQuote();
     expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
@@ -1039,12 +1039,12 @@ describe('SellScreen', () => {
     render(<SellScreen />);
     await flushQuote();
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockSendTransaction).toHaveBeenCalledTimes(1);
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockSendTransaction).toHaveBeenCalledTimes(1);

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -407,6 +407,62 @@ describe('SellScreen', () => {
     jest.useRealTimers();
   });
 
+  it('does not write exact-price into a spend field cleared while a spend-side quote is in flight', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SellScreen />);
+    await flushQuote();
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '100' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      resolveExact(quoteFor({ targetAmount: 100, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+  });
+
+  it('does not write exact-price into a target field cleared while a get-side quote is in flight', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SellScreen />);
+    await flushQuote();
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      resolveExact(quoteFor({ amount: 0.2, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+  });
+
   it('keeps a cleared amount field empty and accepts the retyped amount', async () => {
     render(<SellScreen />);
     await flushQuote();

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -465,6 +465,32 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('input-amount')).toHaveValue('');
   });
 
+  it('does not write a resolving exact-price into spend when clear and resolve share a turn', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SellScreen />);
+    await flushQuote();
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '100' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+      resolveExact(quoteFor({ targetAmount: 100, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+  });
+
   it('does not write exact-price into a target field cleared while a get-side quote is in flight', async () => {
     let resolveExact: (value: unknown) => void = () => undefined;
     let hangExact = false;
@@ -1063,6 +1089,19 @@ describe('SellScreen', () => {
     await flushQuote();
     expect(screen.getByTestId('dropdown-currency')).toHaveTextContent('CHF');
     expect(screen.getByTestId('dropdown-currency')).not.toHaveTextContent('GBP');
+  });
+
+  it('does not apply a non-sellable preferred currency from the bank account', async () => {
+    const previousPreferred = bankAccount.preferredCurrency;
+    bankAccount.preferredCurrency = gbp;
+    try {
+      render(<SellScreen />);
+      await flushQuote();
+      expect(screen.getByTestId('dropdown-currency')).not.toHaveTextContent('GBP');
+      expect(screen.getByTestId('dropdown-currency')).toHaveTextContent('CHF');
+    } finally {
+      bankAccount.preferredCurrency = previousPreferred;
+    }
   });
 
   it('falls back to the preferred currency when assetOut is unknown', async () => {

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -407,6 +407,18 @@ describe('SellScreen', () => {
     jest.useRealTimers();
   });
 
+  it('does not treat a no-op exact-price spend write as a user edit', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.1');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '100' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.1');
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+  });
+
   it('does not write exact-price into a spend field cleared while a spend-side quote is in flight', async () => {
     let resolveExact: (value: unknown) => void = () => undefined;
     let hangExact = false;

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -738,6 +738,24 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
   });
 
+  it('quotes from a new spend amount after the target field was cleared', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    const callsBefore = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.2');
+    const after = mockReceiveFor.mock.calls.slice(callsBefore);
+    expect(after.length).toBeGreaterThan(0);
+    expect(after.every((call: any) => String(call[0].amount) === '0.2')).toBe(true);
+  });
+
   it('does not restore a default amount after the user clears spend and the asset changes', async () => {
     mockAssets = [eth, btc];
     mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'ETH' }));

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -519,6 +519,32 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
   });
 
+  it('does not write a resolving exact-price into target when clear and resolve share a turn', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SellScreen />);
+    await flushQuote();
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+      resolveExact(quoteFor({ amount: 0.2, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+  });
+
   it('drops a quote error after the form generation has moved on', async () => {
     let rejectQuote: (err: unknown) => void = () => undefined;
     mockReceiveFor.mockImplementation(

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -967,6 +967,22 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('sell-completion')).toBeInTheDocument();
   });
 
+  it('does not complete from form submit while the quote is not final', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice) return new Promise(() => undefined);
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
+  });
+
   it('completes a manual transfer from form submit', async () => {
     mockCanSendTransaction.mockReturnValue(false);
     render(<SellScreen />);

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -487,6 +487,16 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('quote-error')).toHaveTextContent('KycRequired');
   });
 
+  it.each(['LimitExceeded', 'EmailRequired', 'BankTransactionMissing', 'BankTransactionOrVideoMissing'])(
+    'routes %s quote errors through QuoteErrorHint',
+    async (error) => {
+      mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error }));
+      render(<SellScreen />);
+      await flushQuote();
+      expect(screen.getByTestId('quote-error')).toHaveTextContent(error);
+    },
+  );
+
   it('shows a balance error when the quote exceeds the wallet balance', async () => {
     mockGetBalances.mockResolvedValue([{ asset: eth, amount: 0.01 }]);
     render(<SellScreen />);

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -991,6 +991,37 @@ describe('SellScreen', () => {
     expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
   });
 
+  it('completes from form submit on a private asset when the private flag is set', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockAssets = [usdtPrivate];
+    mockFlags = 'private';
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT', flags: 'private' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    expect(screen.queryByTestId('private-asset-hint')).not.toBeInTheDocument();
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('sell-completion')).toBeInTheDocument();
+  });
+
+  it('completes from the payment CTA on a private asset when the private flag is set', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockAssets = [usdtPrivate];
+    mockFlags = 'private';
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT', flags: 'private' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Click here once you have issued the transaction' }).click();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('sell-completion')).toBeInTheDocument();
+  });
+
   it('does not complete from form submit when KYC blocks payment', async () => {
     mockCanSendTransaction.mockReturnValue(false);
     mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }));

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -1403,6 +1403,31 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('input-amount')).toBeInTheDocument();
   });
 
+  it('does not restore the spend default after a typed target and an asset change', async () => {
+    mockAssets = [eth, btc];
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice) return Promise.resolve(undefined);
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '10' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    await act(async () => {
+      screen.getByTestId('select-asset-BTC').click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('10');
+  });
+
   it('does not restore amountIn after the user clears spend and the asset changes', async () => {
     mockAssets = [eth, btc];
     mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: '0.2', assetIn: 'ETH' }));

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -942,7 +942,7 @@ describe('SellScreen', () => {
     render(<SellScreen />);
     await flushQuote();
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.getByTestId('sell-completion')).toBeInTheDocument();

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -13,6 +13,7 @@ const mockLayoutOptions = jest.fn();
 
 const chf = { name: 'CHF', sellable: true };
 const eur = { name: 'EUR', sellable: true };
+const gbp = { name: 'GBP', sellable: false };
 const eth = {
   id: 1,
   name: 'ETH',
@@ -50,7 +51,7 @@ const mockGetAssets = () => mockAssets;
 const mockIsSameAsset = (asset: any, filter: string) => asset.name === filter || asset.uniqueName === filter;
 const mockGetCurrency = (list: any[], name?: string) => (list ?? []).find((c: any) => c.name === name);
 const mockGetDefaultCurrency = (list: any[]) => list?.[0];
-const mockCurrencies = [chf, eur];
+const mockCurrencies = [chf, eur, gbp];
 const mockFormatIban = jest.fn((iban: string) => iban);
 let mockWalletBlockchain: string | undefined = 'Ethereum';
 let mockPrefCurrency: { name: string } | undefined;
@@ -1055,6 +1056,13 @@ describe('SellScreen', () => {
       jest.advanceTimersByTime(500);
     });
     expect(screen.getByTestId('input-amount')).toBeInTheDocument();
+  });
+
+  it('omits currencies that are not sellable from the dropdown', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('dropdown-currency')).toHaveTextContent('CHF');
+    expect(screen.getByTestId('dropdown-currency')).not.toHaveTextContent('GBP');
   });
 
   it('falls back to the preferred currency when assetOut is unknown', async () => {

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -1,0 +1,727 @@
+const mockReceiveFor = jest.fn();
+const mockUseAppParams = jest.fn();
+const mockSetParams = jest.fn();
+const mockUpdateAccount = jest.fn();
+const mockSendTransaction = jest.fn();
+const mockCanSendTransaction = jest.fn();
+const mockGetBalances = jest.fn();
+const mockNavigate = jest.fn();
+const mockLogout = jest.fn();
+const mockCloseServices = jest.fn();
+const mockSwitchBlockchain = jest.fn();
+const mockLayoutOptions = jest.fn();
+
+const chf = { name: 'CHF', sellable: true };
+const eur = { name: 'EUR', sellable: true };
+const eth = {
+  id: 1,
+  name: 'ETH',
+  uniqueName: 'Ethereum/ETH',
+  category: 'Public',
+  blockchain: 'Ethereum',
+  description: 'Ethereum',
+};
+const btc = {
+  id: 2,
+  name: 'BTC',
+  uniqueName: 'Bitcoin',
+  category: 'Public',
+  blockchain: 'Bitcoin',
+  description: 'Bitcoin',
+};
+const usdtPrivate = {
+  id: 3,
+  name: 'USDT',
+  uniqueName: 'Ethereum/USDT',
+  category: 'Private',
+  blockchain: 'Ethereum',
+  description: 'Tether',
+};
+const bankAccount = { id: 1, iban: 'CH9300762011623852957', preferredCurrency: chf };
+let mockAssets = [eth];
+let mockSession: { address: string } | undefined;
+let mockActiveWallet: string | undefined;
+let mockFlags: string | undefined;
+let mockHideTarget = true;
+const mockGetAsset = (list: any[], name?: string) => (list ?? []).find((a: any) => a.name === name) ?? list?.[0];
+const mockGetAssets = () => mockAssets;
+const mockIsSameAsset = (asset: any, filter: string) => asset.name === filter || asset.uniqueName === filter;
+const mockGetCurrency = (list: any[], name?: string) => (list ?? []).find((c: any) => c.name === name);
+const mockGetDefaultCurrency = (list: any[]) => list?.[0];
+const mockCurrencies = [chf, eur];
+const mockSellInterface = {
+  get currencies() {
+    return mockCurrencies;
+  },
+  receiveFor: (...args: unknown[]) => mockReceiveFor(...args),
+};
+const mockTranslate = (_ns: string, key: string) => key;
+const mockTranslateError = (key: string) => key;
+const mockBlockchains = ['Ethereum', 'Bitcoin'];
+
+jest.mock('@dfx.swiss/react', () => ({
+  AssetCategory: { PUBLIC: 'Public', PRIVATE: 'Private' },
+  TransactionError: {
+    AMOUNT_TOO_LOW: 'AmountTooLow',
+    AMOUNT_TOO_HIGH: 'AmountTooHigh',
+    LIMIT_EXCEEDED: 'LimitExceeded',
+    KYC_REQUIRED: 'KycRequired',
+    KYC_DATA_REQUIRED: 'KycDataRequired',
+    KYC_REQUIRED_INSTANT: 'KycRequiredInstant',
+    BANK_TRANSACTION_MISSING: 'BankTransactionMissing',
+    BANK_TRANSACTION_OR_VIDEO_MISSING: 'BankTransactionOrVideoMissing',
+    VIDEO_IDENT_REQUIRED: 'VideoIdentRequired',
+    NATIONALITY_NOT_ALLOWED: 'NationalityNotAllowed',
+    IBAN_CURRENCY_MISMATCH: 'IbanCurrencyMismatch',
+    PAYMENT_METHOD_NOT_ALLOWED: 'PaymentMethodNotAllowed',
+    TRADING_NOT_ALLOWED: 'TradingNotAllowed',
+    RECOMMENDATION_REQUIRED: 'RecommendationRequired',
+    EMAIL_REQUIRED: 'EmailRequired',
+  },
+  TransactionType: { SELL: 'Sell' },
+  Utils: {
+    formatAmount: (n: number) => String(n),
+    formatAmountCrypto: (n: number) => String(n),
+    formatIban: (iban: string) => iban,
+    createRules: () => ({}),
+  },
+  Validations: { Required: undefined },
+  useAsset: () => ({
+    getAsset: mockGetAsset,
+    isSameAsset: mockIsSameAsset,
+  }),
+  useAssetContext: () => ({
+    assets: new Map([
+      ['Ethereum', mockAssets.filter((a) => a.blockchain === 'Ethereum')],
+      ['Bitcoin', mockAssets.filter((a) => a.blockchain === 'Bitcoin')],
+    ]),
+    getAssets: mockGetAssets,
+  }),
+  useAuthContext: () => ({ session: mockSession }),
+  useBankAccountContext: () => ({
+    bankAccounts: [bankAccount],
+    updateAccount: (...args: unknown[]) => mockUpdateAccount(...args),
+  }),
+  useFiat: () => ({
+    toDescription: () => 'Swiss Franc',
+    getCurrency: mockGetCurrency,
+    getDefaultCurrency: mockGetDefaultCurrency,
+  }),
+  useSell: () => mockSellInterface,
+  useSessionContext: () => ({ logout: mockLogout }),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const React = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { Controller } = require('react-hook-form');
+
+  function enrich(elements: any, control: any): any {
+    if (!elements) return elements;
+    return React.Children.map(elements, (element: any) => {
+      if (!React.isValidElement(element)) return element;
+      const props: any = element.props;
+      const newChildren = enrich(props.children, control);
+      if (props.name) return React.cloneElement(element, { control, children: newChildren });
+      return React.cloneElement(element, { children: newChildren });
+    });
+  }
+
+  return {
+    AssetIconVariant: {},
+    Form: ({ children, control, onSubmit }: any) => (
+      <div>
+        {enrich(children, control)}
+        <button type="button" data-testid="form-submit" onClick={() => onSubmit?.({ preventDefault() {} })}>
+          submit
+        </button>
+      </div>
+    ),
+    SpinnerSize: { SM: 'sm', LG: 'lg' },
+    StyledButton: ({ label, onClick }: any) => (
+      <button type="button" onClick={onClick}>
+        {label}
+      </button>
+    ),
+    StyledButtonColor: { STURDY_WHITE: 'sturdy-white' },
+    StyledButtonWidth: { MIN: 'min', FULL: 'full' },
+    StyledDropdown: ({ name, items, labelFunc, descriptionFunc, control }: any) => (
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }: any) => (
+          <div data-testid={`dropdown-${name}`}>
+            {(items ?? []).map((item: any, index: number) => (
+              <button
+                key={`${labelFunc(item)}-${index}`}
+                type="button"
+                data-testid={`select-${name}-${index}`}
+                onClick={() => field.onChange(item)}
+              >
+                {labelFunc(item)}
+                {descriptionFunc?.(item)}
+              </button>
+            ))}
+          </div>
+        )}
+      />
+    ),
+    StyledHorizontalStack: ({ children }: any) => <div>{children}</div>,
+    StyledInput: ({ name, control, buttonLabel, buttonClick, forceErrorMessage }: any) =>
+      name ? (
+        <Controller
+          name={name}
+          control={control}
+          render={({ field }: any) => (
+            <>
+              <input
+                data-testid={`input-${name}`}
+                value={field.value ?? ''}
+                onChange={(e: any) => field.onChange(e.target.value)}
+              />
+              {buttonLabel && (
+                <button type="button" data-testid={`input-${name}-max`} onClick={buttonClick}>
+                  {buttonLabel}
+                </button>
+              )}
+              {forceErrorMessage && <div data-testid={`input-${name}-error`}>{forceErrorMessage}</div>}
+            </>
+          )}
+        />
+      ) : null,
+    StyledLink: ({ children, label }: any) => <div>{label ?? children}</div>,
+    StyledLoadingSpinner: () => <div data-testid="loading-spinner" />,
+    StyledSearchDropdown: ({ name, items, labelFunc, control, filterFunc, balanceFunc, descriptionFunc, assetIconFunc }: any) => (
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }: any) => (
+          <div data-testid={`dropdown-${name}`}>
+            {filterFunc?.(items?.[0], undefined)}
+            {filterFunc?.(items?.[0], 'eth')}
+            {balanceFunc?.(items?.[0])}
+            {descriptionFunc?.(items?.[0])}
+            {assetIconFunc?.(items?.[0])}
+            {(items ?? []).map((item: any) => (
+              <button
+                key={labelFunc(item)}
+                type="button"
+                data-testid={`select-${name}-${labelFunc(item)}`}
+                onClick={() => field.onChange(item)}
+              >
+                {labelFunc(item)}
+              </button>
+            ))}
+          </div>
+        )}
+      />
+    ),
+    StyledVerticalStack: ({ children }: any) => <div>{children}</div>,
+  };
+});
+
+jest.mock('src/components/order/bank-account-selector', () => ({
+  BankAccountSelector: ({ onChange, onModalToggle }: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const React = require('react');
+    React.useEffect(() => {
+      onChange(bankAccount);
+      // Intentionally once: the real selector does not re-emit on every parent render.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return (
+      <div data-testid="bank-account-selector">
+        <button type="button" data-testid="bank-account-toggle" onClick={() => onModalToggle(true)}>
+          toggle
+        </button>
+      </div>
+    );
+  },
+}));
+jest.mock('src/components/payment/payment-info-sell', () => ({
+  PaymentInformationContent: ({ info, infoText }: any) => (
+    <div data-testid="payment-info">
+      {info.amount}
+      <span data-testid="payment-info-text">{infoText}</span>
+    </div>
+  ),
+}));
+jest.mock('../components/error-hint', () => ({ ErrorHint: ({ message }: any) => <div data-testid="error-hint">{message}</div> }));
+jest.mock('../components/exchange-rate', () => ({ ExchangeRate: () => <div data-testid="exchange-rate" /> }));
+jest.mock('../components/payment/address-switch', () => ({
+  AddressSwitch: ({ onClose }: any) => (
+    <div data-testid="address-switch">
+      <button type="button" data-testid="address-switch-confirm" onClick={() => onClose(true)}>
+        confirm
+      </button>
+      <button type="button" data-testid="address-switch-cancel" onClick={() => onClose(false)}>
+        cancel
+      </button>
+    </div>
+  ),
+}));
+jest.mock('../components/payment/sell-completion', () => ({
+  SellCompletion: () => <div data-testid="sell-completion" />,
+}));
+jest.mock('../components/private-asset-hint', () => ({
+  PrivateAssetHint: () => <div data-testid="private-asset-hint" />,
+}));
+jest.mock('../components/quote-error-hint', () => ({
+  QuoteErrorHint: ({ error }: any) => <div data-testid="quote-error">{error}</div>,
+}));
+jest.mock('../components/sanction-hint', () => ({ SanctionHint: () => <div data-testid="sanction-hint" /> }));
+jest.mock('../config/labels', () => ({ addressLabel: (wallet: any) => wallet?.address ?? '' }));
+jest.mock('../contexts/app-handling.context', () => ({
+  CloseType: { SELL: 'Sell' },
+  useAppHandlingContext: () => ({ isInitialized: true, closeServices: mockCloseServices }),
+}));
+jest.mock('../contexts/layout.context', () => ({
+  useLayoutContext: () => ({ scrollToTop: jest.fn(), rootRef: { current: null } }),
+}));
+jest.mock('../contexts/settings.context', () => ({
+  useSettingsContext: () => ({
+    translate: mockTranslate,
+    translateError: mockTranslateError,
+    currency: chf,
+  }),
+}));
+jest.mock('../contexts/wallet.context', () => ({
+  useWalletContext: () => ({
+    blockchain: 'Ethereum',
+    activeWallet: mockActiveWallet,
+    switchBlockchain: mockSwitchBlockchain,
+  }),
+}));
+jest.mock('src/contexts/window.context', () => ({
+  useWindowContext: () => ({ width: 800 }),
+}));
+jest.mock('../hooks/app-params.hook', () => ({
+  useAppParams: () => mockUseAppParams(),
+}));
+jest.mock('../hooks/blockchain.hook', () => ({
+  useBlockchain: () => ({ toString: () => 'Ethereum' }),
+}));
+jest.mock('../hooks/guard.hook', () => ({
+  useAddressGuard: () => undefined,
+}));
+jest.mock('../hooks/layout-config.hook', () => ({
+  useLayoutOptions: (opts: unknown) => mockLayoutOptions(opts),
+}));
+jest.mock('../hooks/navigation.hook', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+jest.mock('../hooks/tx-helper.hook', () => ({
+  useTxHelper: () => ({
+    getBalances: (...args: unknown[]) => mockGetBalances(...args),
+    sendTransaction: (...args: unknown[]) => mockSendTransaction(...args),
+    canSendTransaction: () => mockCanSendTransaction(),
+  }),
+}));
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import SellScreen from 'src/screens/sell.screen';
+
+function baseAppParams(overrides: Record<string, unknown> = {}) {
+  return {
+    assets: undefined,
+    assetIn: 'ETH',
+    assetOut: 'CHF',
+    amountIn: undefined,
+    amountOut: undefined,
+    blockchain: 'Ethereum',
+    externalTransactionId: 'ext-1',
+    flags: mockFlags,
+    setParams: mockSetParams,
+    hideTargetSelection: mockHideTarget,
+    availableBlockchains: mockBlockchains,
+    ...overrides,
+  };
+}
+
+function quoteFor(req: any) {
+  const spendAmount = req.amount !== undefined ? Number(req.amount) : 0.1;
+  const getAmount = req.targetAmount !== undefined ? Number(req.targetAmount) : 250;
+  return {
+    id: 10,
+    amount: spendAmount,
+    estimatedAmount: getAmount,
+    currency: chf,
+    asset: mockAssets[0],
+    minVolume: 0.001,
+    maxVolume: 100,
+    isValid: true,
+    exchangeRate: 2500,
+    rate: 2500,
+    feesTarget: {},
+    priceSteps: [],
+  };
+}
+
+async function flushQuote() {
+  await act(async () => {
+    jest.advanceTimersByTime(500);
+  });
+  await act(async () => {
+    for (let i = 0; i < 20; i += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+describe('SellScreen', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockAssets = [eth];
+    mockSession = undefined;
+    mockActiveWallet = undefined;
+    mockFlags = undefined;
+    mockHideTarget = true;
+    mockCanSendTransaction.mockReturnValue(false);
+    mockGetBalances.mockResolvedValue([{ asset: eth, amount: 10 }]);
+    mockUpdateAccount.mockResolvedValue(bankAccount);
+    mockUseAppParams.mockReturnValue(baseAppParams());
+    let quotes = 0;
+    mockReceiveFor.mockImplementation((req: any) => {
+      quotes += 1;
+      if (quotes > 25) return Promise.reject(new Error('quote loop'));
+      return Promise.resolve(quoteFor(req));
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('keeps a cleared amount field empty and accepts the retyped amount', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.1');
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+
+    const callsBeforeClear = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(mockReceiveFor.mock.calls.length).toBe(callsBeforeClear);
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.2');
+    const retyped = mockReceiveFor.mock.calls.slice(callsBeforeClear);
+    expect(retyped.length).toBeGreaterThan(0);
+    expect(retyped.every((call: any) => String(call[0].amount) === '0.2')).toBe(true);
+  });
+
+  it('keeps a cleared target amount field empty', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-targetAmount')).not.toHaveValue('');
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+  });
+
+  it('uses the BTC default amount 0.001', async () => {
+    mockAssets = [btc];
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'BTC' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.001');
+  });
+
+  it('uses amountIn instead of the asset default', async () => {
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: '0.5' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.5');
+  });
+
+  it('quotes from amountOut when spend was never set', async () => {
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: undefined, amountOut: '100' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('100');
+    expect(mockReceiveFor.mock.calls.some((call: any) => String(call[0].targetAmount) === '100')).toBe(true);
+  });
+
+  it('shows amount-too-low from the quote error field', async () => {
+    mockReceiveFor.mockImplementation((req: any) =>
+      Promise.resolve({ ...quoteFor(req), error: 'AmountTooLow', minVolume: 1 }),
+    );
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount-error')).toBeInTheDocument();
+  });
+
+  it('shows amount-too-high from the quote error field', async () => {
+    mockReceiveFor.mockImplementation((req: any) =>
+      Promise.resolve({ ...quoteFor(req), error: 'AmountTooHigh', maxVolume: 1 }),
+    );
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount-error')).toBeInTheDocument();
+  });
+
+  it('routes KYC quote errors through QuoteErrorHint', async () => {
+    mockReceiveFor.mockImplementation((req: any) =>
+      Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }),
+    );
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('quote-error')).toHaveTextContent('KycRequired');
+  });
+
+  it('shows a balance error when the quote exceeds the wallet balance', async () => {
+    mockGetBalances.mockResolvedValue([{ asset: eth, amount: 0.01 }]);
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount-error')).toBeInTheDocument();
+  });
+
+  it('navigates to profile when ident data is incomplete', async () => {
+    mockReceiveFor.mockRejectedValue({ statusCode: 400, message: 'Ident data incomplete' });
+    render(<SellScreen />);
+    await flushQuote();
+    expect(mockNavigate).toHaveBeenCalledWith('/profile');
+  });
+
+  it('shows a generic error and retries', async () => {
+    mockReceiveFor.mockRejectedValueOnce({ statusCode: 500, message: 'boom' }).mockImplementation((req: any) =>
+      Promise.resolve(quoteFor(req)),
+    );
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.11' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+  });
+
+  it('maps a KYC HTTP message onto QuoteErrorHint', async () => {
+    mockReceiveFor.mockRejectedValue({ statusCode: 400, message: 'KycRequired' });
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('quote-error')).toHaveTextContent('KycRequired');
+  });
+
+  it('uses Unknown error when the API omits a message', async () => {
+    mockReceiveFor.mockRejectedValue({ statusCode: 500 });
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('Unknown error');
+  });
+
+  it('fills MAX from the available balance', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByTestId('input-amount-max').click();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('10');
+  });
+
+  it('filters assets when an asset filter is set', async () => {
+    mockAssets = [eth, btc];
+    mockUseAppParams.mockReturnValue(baseAppParams({ assets: 'ETH', assetIn: 'ETH' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('select-asset-ETH')).toBeInTheDocument();
+    expect(screen.queryByTestId('select-asset-BTC')).not.toBeInTheDocument();
+  });
+
+  it('closes services when the wallet can send but is not connected', async () => {
+    mockCanSendTransaction.mockReturnValue(true);
+    mockActiveWallet = undefined;
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Complete transaction in your wallet' }).click();
+    });
+    expect(mockCloseServices).toHaveBeenCalled();
+    expect(mockUpdateAccount).toHaveBeenCalled();
+  });
+
+  it('completes after a successful wallet send', async () => {
+    mockCanSendTransaction.mockReturnValue(true);
+    mockActiveWallet = 'mm';
+    mockSendTransaction.mockResolvedValue('0xtx');
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Complete transaction in your wallet' }).click();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('sell-completion')).toBeInTheDocument();
+  });
+
+  it('swallows a wallet rejection (4001)', async () => {
+    mockCanSendTransaction.mockReturnValue(true);
+    mockActiveWallet = 'mm';
+    mockSendTransaction.mockRejectedValue({ code: 4001 });
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Complete transaction in your wallet' }).click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
+  });
+
+  it('shows a retryable error for other send failures', async () => {
+    mockCanSendTransaction.mockReturnValue(true);
+    mockActiveWallet = 'mm';
+    mockSendTransaction.mockRejectedValue({ code: 500, message: 'nope' });
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Complete transaction in your wallet' }).click();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('error-hint')).toBeInTheDocument();
+  });
+
+  it('marks a manual transfer complete without sending', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Click here once you have issued the transaction' }).click();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('sell-completion')).toBeInTheDocument();
+  });
+
+  it('shows the private-asset hint', async () => {
+    mockAssets = [usdtPrivate];
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('private-asset-hint')).toBeInTheDocument();
+  });
+
+  it('opens and cancels the address switch', async () => {
+    mockSession = { address: '0xabc' };
+    mockHideTarget = false;
+    mockUseAppParams.mockReturnValue(baseAppParams({ hideTargetSelection: false }));
+    render(<SellScreen />);
+    await flushQuote();
+    const addressButtons = screen.getAllByTestId(/select-address-/);
+    await act(async () => {
+      addressButtons[addressButtons.length - 1].click();
+    });
+    expect(screen.getByTestId('address-switch')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByTestId('address-switch-cancel').click();
+    });
+    expect(screen.queryByTestId('address-switch')).not.toBeInTheDocument();
+  });
+
+  it('logs out when the address switch is confirmed', async () => {
+    mockSession = { address: '0xabc' };
+    mockHideTarget = false;
+    mockUseAppParams.mockReturnValue(baseAppParams({ hideTargetSelection: false }));
+    render(<SellScreen />);
+    await flushQuote();
+    const addressButtons = screen.getAllByTestId(/select-address-/);
+    await act(async () => {
+      addressButtons[addressButtons.length - 1].click();
+    });
+    await act(async () => {
+      screen.getByTestId('address-switch-confirm').click();
+    });
+    expect(mockLogout).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/connect', { setRedirect: true });
+  });
+
+  it('submits the empty onSubmit handler', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+    });
+  });
+
+  it('toggles the bank-account modal title', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByTestId('bank-account-toggle').click();
+    });
+    const latest = mockLayoutOptions.mock.calls[mockLayoutOptions.mock.calls.length - 1][0];
+    expect(latest.title).toBe('Select payment account');
+    await act(async () => {
+      latest.onBack();
+    });
+  });
+
+  it('uses the exact You get heading when rate is 1', async () => {
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), rate: 1, exchangeRate: 1 }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByText('You get')).toBeInTheDocument();
+  });
+
+  it('uses a non-ETH default of 300', async () => {
+    mockAssets = [usdtPrivate];
+    mockFlags = 'private';
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT', flags: 'private' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('300');
+  });
+
+  it('quotes from the target side when spend was never set and get data is complete', async () => {
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountOut: '100' }));
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      screen.getByTestId('select-asset-ETH').click();
+    });
+    await flushQuote();
+    expect(mockReceiveFor.mock.calls.some((call: any) => String(call[0].targetAmount) === '100')).toBe(true);
+  });
+
+  it('switches blockchain when another chain address is chosen', async () => {
+    mockAssets = [eth, btc];
+    mockSession = { address: '0xabc' };
+    mockHideTarget = false;
+    mockUseAppParams.mockReturnValue(baseAppParams({ hideTargetSelection: false, assetIn: 'ETH' }));
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByTestId('select-address-1').click();
+    });
+    expect(mockSetParams).toHaveBeenCalled();
+    expect(mockSwitchBlockchain).toHaveBeenCalled();
+  });
+
+  it('invokes Retry after a generic error', async () => {
+    mockReceiveFor.mockRejectedValue({ statusCode: 500, message: 'boom' });
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Retry' }).click();
+    });
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
+  });
+});

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -38,6 +38,7 @@ const usdtPrivate = {
   description: 'Tether',
 };
 const bankAccount = { id: 1, iban: 'CH9300762011623852957', preferredCurrency: { name: 'CHF', sellable: true } };
+const bankAccountAlt = { id: 2, iban: 'DE89370400440532013000', preferredCurrency: { name: 'CHF', sellable: true } };
 let mockAssets = [eth];
 let mockSession: { address: string } | undefined;
 let mockActiveWallet: string | undefined;
@@ -242,6 +243,9 @@ jest.mock('src/components/order/bank-account-selector', () => ({
         <button type="button" data-testid="bank-account-toggle" onClick={() => onModalToggle(true)}>
           toggle
         </button>
+        <button type="button" data-testid="bank-account-alt" onClick={() => onChange(bankAccountAlt)}>
+          alt
+        </button>
       </div>
     );
   },
@@ -405,6 +409,18 @@ describe('SellScreen', () => {
     cleanup();
     jest.clearAllTimers();
     jest.useRealTimers();
+  });
+
+  it('keeps the typed spend amount when only the bank account changes', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.1');
+    await act(async () => {
+      screen.getByTestId('bank-account-alt').click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.1');
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
   });
 
   it('does not treat a no-op exact-price spend write as a user edit', async () => {

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -463,6 +463,57 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
   });
 
+  it('drops a quote error after the form generation has moved on', async () => {
+    let rejectQuote: (err: unknown) => void = () => undefined;
+    mockReceiveFor.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectQuote = reject;
+        }),
+    );
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      rejectQuote({ statusCode: 500, message: 'stale' });
+      await Promise.resolve();
+    });
+    expect(screen.queryByText('stale')).not.toBeInTheDocument();
+  });
+
+  it('does not let a stale exact-price overwrite a retyped spend amount', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SellScreen />);
+    await flushQuote();
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.3' } });
+    });
+    await act(async () => {
+      resolveExact(quoteFor({ amount: 0.2, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.3');
+  });
+
   it('keeps a cleared amount field empty and accepts the retyped amount', async () => {
     render(<SellScreen />);
     await flushQuote();

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -937,14 +937,117 @@ describe('SellScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/connect', { setRedirect: true });
   });
 
-  it('submits the empty onSubmit handler', async () => {
+  it('completes a manual transfer from form submit', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
     render(<SellScreen />);
     await flushQuote();
     await act(async () => {
       screen.getByTestId('form-submit').click();
+      await Promise.resolve();
     });
-    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
-    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sell-completion')).toBeInTheDocument();
+  });
+
+  it('does not complete from form submit after spend is cleared', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+  });
+
+  it('does not complete from form submit after target is cleared', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
+  });
+
+  it('does not complete from form submit on a private asset', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockAssets = [usdtPrivate];
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('private-asset-hint')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
+  });
+
+  it('does not complete from form submit when KYC blocks payment', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('quote-error')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
+  });
+
+  it('does not complete from form submit when amount is too low', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockReceiveFor.mockImplementation((req: any) =>
+      Promise.resolve({ ...quoteFor(req), error: 'AmountTooLow', minVolume: 1 }),
+    );
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount-error')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
+  });
+
+  it('does not complete from form submit when a quote error is showing', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockReceiveFor.mockRejectedValue({ statusCode: 500, message: 'boom' });
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
+  });
+
+  it('does not start a second send while form submit is already processing', async () => {
+    mockCanSendTransaction.mockReturnValue(true);
+    mockActiveWallet = 'mm';
+    mockSendTransaction.mockImplementation(() => new Promise(() => undefined));
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockSendTransaction).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockSendTransaction).toHaveBeenCalledTimes(1);
   });
 
   it('toggles the bank-account modal title', async () => {

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -514,6 +514,39 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('input-amount')).toHaveValue('0.3');
   });
 
+  it('still invalidates quotes when target is cleared after an exact-price no-op write', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    const targetBefore = (screen.getByTestId('input-targetAmount') as HTMLInputElement).value;
+    await act(async () => {
+      screen.getByTestId('select-currency-1').click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue(targetBefore);
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
+  it('still invalidates quotes when spend is cleared after an exact-price no-op write', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '100' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.1');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
   it('clears a KYC quote error when the user empties the spend field', async () => {
     mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }));
     render(<SellScreen />);

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -943,6 +943,30 @@ describe('SellScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/connect', { setRedirect: true });
   });
 
+  it('shows an error and allows retry when updating the bank account fails', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockUpdateAccount.mockRejectedValue({ message: 'iban save failed' });
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
+    expect(screen.getByTestId('error-hint')).toBeInTheDocument();
+    mockUpdateAccount.mockResolvedValue(bankAccount);
+    await act(async () => {
+      screen.getByRole('button', { name: 'Retry' }).click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('sell-completion')).toBeInTheDocument();
+  });
+
   it('completes a manual transfer from form submit', async () => {
     mockCanSendTransaction.mockReturnValue(false);
     render(<SellScreen />);

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -425,6 +425,21 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('payment-info')).toBeInTheDocument();
   });
 
+  it('does not complete from form submit after the bank account changes before the new quote', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByTestId('bank-account-alt').click();
+    });
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
+  });
+
   it('does not treat a no-op exact-price spend write as a user edit', async () => {
     render(<SellScreen />);
     await flushQuote();

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -1201,6 +1201,30 @@ describe('SellScreen', () => {
     expect(mockSwitchBlockchain).toHaveBeenCalled();
   });
 
+  it('does not retry a quote after the spend amount becomes invalid', async () => {
+    mockReceiveFor
+      .mockRejectedValueOnce({ statusCode: 500, message: 'boom' })
+      .mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
+    const callsBefore = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0' } });
+    });
+    await flushQuote();
+    const retry = screen.queryByRole('button', { name: 'Retry' });
+    if (retry) {
+      await act(async () => {
+        retry.click();
+      });
+      await flushQuote();
+    }
+    const after = mockReceiveFor.mock.calls.slice(callsBefore);
+    expect(after.every((call: any) => Number(call[0]?.amount) !== 0.1)).toBe(true);
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
   it('invokes Retry after a generic error', async () => {
     mockReceiveFor
       .mockRejectedValueOnce({ statusCode: 500, message: 'boom' })

--- a/src/__tests__/sell-screen-cleared-amount.test.tsx
+++ b/src/__tests__/sell-screen-cleared-amount.test.tsx
@@ -37,7 +37,7 @@ const usdtPrivate = {
   blockchain: 'Ethereum',
   description: 'Tether',
 };
-const bankAccount = { id: 1, iban: 'CH9300762011623852957', preferredCurrency: chf };
+const bankAccount = { id: 1, iban: 'CH9300762011623852957', preferredCurrency: { name: 'CHF', sellable: true } };
 let mockAssets = [eth];
 let mockSession: { address: string } | undefined;
 let mockActiveWallet: string | undefined;
@@ -50,6 +50,10 @@ const mockIsSameAsset = (asset: any, filter: string) => asset.name === filter ||
 const mockGetCurrency = (list: any[], name?: string) => (list ?? []).find((c: any) => c.name === name);
 const mockGetDefaultCurrency = (list: any[]) => list?.[0];
 const mockCurrencies = [chf, eur];
+const mockFormatIban = jest.fn((iban: string) => iban);
+let mockWalletBlockchain: string | undefined = 'Ethereum';
+let mockPrefCurrency: { name: string } | undefined;
+let mockIsInitialized = true;
 const mockSellInterface = {
   get currencies() {
     return mockCurrencies;
@@ -83,7 +87,7 @@ jest.mock('@dfx.swiss/react', () => ({
   Utils: {
     formatAmount: (n: number) => String(n),
     formatAmountCrypto: (n: number) => String(n),
-    formatIban: (iban: string) => iban,
+    formatIban: (...args: unknown[]) => mockFormatIban(...args),
     createRules: () => ({}),
   },
   Validations: { Required: undefined },
@@ -277,7 +281,7 @@ jest.mock('../components/sanction-hint', () => ({ SanctionHint: () => <div data-
 jest.mock('../config/labels', () => ({ addressLabel: (wallet: any) => wallet?.address ?? '' }));
 jest.mock('../contexts/app-handling.context', () => ({
   CloseType: { SELL: 'Sell' },
-  useAppHandlingContext: () => ({ isInitialized: true, closeServices: mockCloseServices }),
+  useAppHandlingContext: () => ({ isInitialized: mockIsInitialized, closeServices: mockCloseServices }),
 }));
 jest.mock('../contexts/layout.context', () => ({
   useLayoutContext: () => ({ scrollToTop: jest.fn(), rootRef: { current: null } }),
@@ -286,12 +290,12 @@ jest.mock('../contexts/settings.context', () => ({
   useSettingsContext: () => ({
     translate: mockTranslate,
     translateError: mockTranslateError,
-    currency: chf,
+    currency: mockPrefCurrency,
   }),
 }));
 jest.mock('../contexts/wallet.context', () => ({
   useWalletContext: () => ({
-    blockchain: 'Ethereum',
+    blockchain: mockWalletBlockchain,
     activeWallet: mockActiveWallet,
     switchBlockchain: mockSwitchBlockchain,
   }),
@@ -381,6 +385,10 @@ describe('SellScreen', () => {
     mockActiveWallet = undefined;
     mockFlags = undefined;
     mockHideTarget = true;
+    mockWalletBlockchain = 'Ethereum';
+    mockPrefCurrency = chf;
+    mockIsInitialized = true;
+    mockFormatIban.mockImplementation((iban: string) => iban);
     mockCanSendTransaction.mockReturnValue(false);
     mockGetBalances.mockResolvedValue([{ asset: eth, amount: 10 }]);
     mockUpdateAccount.mockResolvedValue(bankAccount);
@@ -793,5 +801,193 @@ describe('SellScreen', () => {
     render(<SellScreen />);
     await flushQuote();
     expect(screen.getByTestId('select-asset-ETH')).toBeInTheDocument();
+  });
+
+  it('uses the URL blockchain when the wallet chain is unset', async () => {
+    mockWalletBlockchain = undefined;
+    mockUseAppParams.mockReturnValue(baseAppParams({ blockchain: 'Ethereum' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('select-asset-ETH')).toBeInTheDocument();
+  });
+
+  it('uses available blockchains when wallet and URL chain are unset', async () => {
+    mockWalletBlockchain = undefined;
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({ blockchain: undefined, availableBlockchains: ['Ethereum'] }),
+    );
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('select-asset-ETH')).toBeInTheDocument();
+  });
+
+  it('uses an empty blockchain list when none are provided', async () => {
+    mockWalletBlockchain = undefined;
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({ blockchain: undefined, availableBlockchains: undefined }),
+    );
+    render(<SellScreen />);
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(screen.getByTestId('input-amount')).toBeInTheDocument();
+  });
+
+  it('falls back to the preferred currency when assetOut is unknown', async () => {
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetOut: 'NOPE' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('select-currency-0')).toBeInTheDocument();
+  });
+
+  it('falls back to the default currency when assetOut and preferred currency are unknown', async () => {
+    mockPrefCurrency = { name: 'GBP' };
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetOut: 'NOPE' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('select-currency-0')).toBeInTheDocument();
+  });
+
+  it('skips restoring currency when no preferred currency is set', async () => {
+    mockPrefCurrency = undefined;
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetOut: 'NOPE' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toBeInTheDocument();
+  });
+
+  it('restores amountOut into the target field', async () => {
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountOut: '100' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('100');
+  });
+
+  it('does not restore amountOut after the user clears target', async () => {
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountOut: '100' }));
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      screen.getByTestId('select-asset-ETH').click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+  });
+
+  it('renders payment info without a formatted IBAN', async () => {
+    mockFormatIban.mockReturnValue(undefined as unknown as string);
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('payment-info-text')).toBeInTheDocument();
+  });
+
+  it('falls back to the first address when the URL chain is not in the list', async () => {
+    mockSession = { address: '0xabc' };
+    mockHideTarget = false;
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({
+        hideTargetSelection: false,
+        availableBlockchains: ['Ethereum'],
+        blockchain: 'Arbitrum',
+      }),
+    );
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('form-submit')).toBeInTheDocument();
+  });
+
+  it('does not set an address while the app is uninitialized', async () => {
+    mockIsInitialized = false;
+    mockSession = { address: '0xabc' };
+    mockHideTarget = false;
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({ hideTargetSelection: false, blockchain: 'Ethereum' }),
+    );
+    render(<SellScreen />);
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(screen.getByTestId('input-amount')).toBeInTheDocument();
+  });
+
+  it('does not restore amountIn after the user clears spend and the asset changes', async () => {
+    mockAssets = [eth, btc];
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: '0.2', assetIn: 'ETH' }));
+    render(<SellScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.2');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      screen.getByTestId('select-asset-BTC').click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+  });
+
+  it('does not select an asset when no chain and no matching asset exist', async () => {
+    mockWalletBlockchain = undefined;
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({ assetIn: 'NOPE', blockchain: undefined, availableBlockchains: undefined }),
+    );
+    render(<SellScreen />);
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(screen.getByTestId('form-submit')).toBeInTheDocument();
+  });
+
+  it('does not quote a zero spend amount', async () => {
+    render(<SellScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0');
+  });
+
+  it('drops a quote error that rejects after unmount', async () => {
+    let rejectQuote: (err: unknown) => void = () => undefined;
+    mockReceiveFor.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectQuote = reject;
+        }),
+    );
+    const { unmount } = render(<SellScreen />);
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    unmount();
+    await act(async () => {
+      rejectQuote({ statusCode: 500, message: 'late' });
+      await Promise.resolve();
+    });
+  });
+
+  it('drops a quote that resolves after unmount', async () => {
+    let resolveQuote: (value: unknown) => void = () => undefined;
+    mockReceiveFor.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveQuote = resolve;
+        }),
+    );
+    const { unmount } = render(<SellScreen />);
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    unmount();
+    await act(async () => {
+      resolveQuote(quoteFor({ amount: 0.1 }));
+      await Promise.resolve();
+    });
   });
 });

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -681,4 +681,20 @@ describe('SwapScreen', () => {
     await flushQuote();
     expect(mockReceiveFor.mock.calls.some((call: any) => String(call[0].targetAmount) === '0.01')).toBe(true);
   });
+
+  it('falls back to the target side after spend is cleared and the source asset changes', async () => {
+    render(<SwapScreen />);
+    await flushQuote();
+    const targetBefore = (screen.getByTestId('input-targetAmount') as HTMLInputElement).value;
+    expect(targetBefore).not.toBe('');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      screen.getByTestId('select-sourceAsset-BTC').click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('select-sourceAsset-BTC')).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -429,6 +429,57 @@ describe('SwapScreen', () => {
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
   });
 
+  it('drops a quote error after the form generation has moved on', async () => {
+    let rejectQuote: (err: unknown) => void = () => undefined;
+    mockReceiveFor.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectQuote = reject;
+        }),
+    );
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      rejectQuote({ statusCode: 500, message: 'stale' });
+      await Promise.resolve();
+    });
+    expect(screen.queryByText('stale')).not.toBeInTheDocument();
+  });
+
+  it('does not let a stale exact-price overwrite a retyped spend amount', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SwapScreen />);
+    await flushQuote();
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.3' } });
+    });
+    await act(async () => {
+      resolveExact(quoteFor({ amount: 0.2, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.3');
+  });
+
   it('keeps a cleared amount field empty and accepts the retyped amount', async () => {
     render(<SwapScreen />);
     await flushQuote();

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -869,6 +869,21 @@ describe('SwapScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/connect', { setRedirect: true });
   });
 
+  it('does not complete from form submit while the quote is not final', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice) return new Promise(() => undefined);
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
+  });
+
   it('completes a manual transfer from form submit', async () => {
     mockCanSendTransaction.mockReturnValue(false);
     render(<SwapScreen />);

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -1076,6 +1076,30 @@ describe('SwapScreen', () => {
     expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.receiverAddress === '0xdef')).toBe(true);
   });
 
+  it('does not retry a quote after the spend amount becomes invalid', async () => {
+    mockReceiveFor
+      .mockRejectedValueOnce({ statusCode: 500, message: 'boom' })
+      .mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
+    const callsBefore = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0' } });
+    });
+    await flushQuote();
+    const retry = screen.queryByRole('button', { name: 'Retry' });
+    if (retry) {
+      await act(async () => {
+        retry.click();
+      });
+      await flushQuote();
+    }
+    const after = mockReceiveFor.mock.calls.slice(callsBefore);
+    expect(after.every((call: any) => Number(call[0]?.amount) !== 0.1)).toBe(true);
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
   it('invokes Retry after a generic error', async () => {
     mockReceiveFor
       .mockRejectedValueOnce({ statusCode: 500, message: 'boom' })

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -917,6 +917,51 @@ describe('SwapScreen', () => {
     expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
   });
 
+  it('completes from form submit on a private source when the private flag is set', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockAssets = [usdtPrivate, btc];
+    mockFlags = 'private';
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT', flags: 'private' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    expect(screen.queryByTestId('private-asset-hint')).not.toBeInTheDocument();
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('swap-completion')).toBeInTheDocument();
+  });
+
+  it('completes from the payment CTA on a private source when the private flag is set', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockAssets = [usdtPrivate, btc];
+    mockFlags = 'private';
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT', flags: 'private' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Click here once you have issued the transaction' }).click();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('swap-completion')).toBeInTheDocument();
+  });
+
+  it('does not complete from form submit on a private target asset', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockAssets = [eth, usdtPrivate];
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetOut: 'USDT' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('private-asset-hint')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
+  });
+
   it('does not complete from form submit when KYC blocks payment', async () => {
     mockCanSendTransaction.mockReturnValue(false);
     mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }));

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -675,6 +675,11 @@ describe('SwapScreen', () => {
     render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('input-amount-error')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
   });
 
   it('shows amount-too-high from the quote error field', async () => {
@@ -858,14 +863,102 @@ describe('SwapScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/connect', { setRedirect: true });
   });
 
-  it('submits the empty onSubmit handler', async () => {
+  it('completes a manual transfer from form submit', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
     render(<SwapScreen />);
     await flushQuote();
     await act(async () => {
       screen.getByTestId('form-submit').click();
+      await Promise.resolve();
     });
-    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
-    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
+    expect(screen.getByTestId('swap-completion')).toBeInTheDocument();
+  });
+
+  it('does not complete from form submit after spend is cleared', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+  });
+
+  it('does not complete from form submit after target is cleared', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
+  });
+
+  it('does not complete from form submit on a private asset', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockAssets = [usdtPrivate, btc];
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('private-asset-hint')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
+  });
+
+  it('does not complete from form submit when KYC blocks payment', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('quote-error')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
+  });
+
+  it('does not complete from form submit when a quote error is showing', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    mockReceiveFor.mockRejectedValue({ statusCode: 500, message: 'boom' });
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
+  });
+
+  it('does not start a second send while form submit is already processing', async () => {
+    mockCanSendTransaction.mockReturnValue(true);
+    mockActiveWallet = 'mm';
+    mockSendTransaction.mockImplementation(() => new Promise(() => undefined));
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockSendTransaction).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      screen.getByTestId('form-submit').click();
+      await Promise.resolve();
+    });
+    expect(mockSendTransaction).toHaveBeenCalledTimes(1);
   });
 
   it('uses the exact You get heading when rate is 1', async () => {

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -704,6 +704,8 @@ describe('SwapScreen', () => {
     await act(async () => {
       screen.getByTestId('form-submit').click();
     });
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
   });
 
   it('uses the exact You get heading when rate is 1', async () => {
@@ -726,13 +728,20 @@ describe('SwapScreen', () => {
   });
 
   it('invokes Retry after a generic error', async () => {
-    mockReceiveFor.mockRejectedValue({ statusCode: 500, message: 'boom' });
+    mockReceiveFor
+      .mockRejectedValueOnce({ statusCode: 500, message: 'boom' })
+      .mockImplementation((req: any) => Promise.resolve(quoteFor(req)));
     render(<SwapScreen />);
     await flushQuote();
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
     await act(async () => {
       screen.getByRole('button', { name: 'Retry' }).click();
     });
-    expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
   });
 
   it('quotes from the target side after spend is cleared and the target asset changes', async () => {
@@ -902,11 +911,14 @@ describe('SwapScreen', () => {
   it('does not quote a zero spend amount', async () => {
     render(<SwapScreen />);
     await flushQuote();
+    const callsBefore = mockReceiveFor.mock.calls.length;
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0' } });
     });
     await flushQuote();
     expect(screen.getByTestId('input-amount')).toHaveValue('0');
+    const after = mockReceiveFor.mock.calls.slice(callsBefore);
+    expect(after.every((call: any) => Number(call[0]?.amount) !== 0)).toBe(true);
   });
 
   it('shows the private-asset hint for a private target asset', async () => {
@@ -1002,6 +1014,8 @@ describe('SwapScreen', () => {
       rejectQuote({ statusCode: 500, message: 'late' });
       await Promise.resolve();
     });
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
   });
 
   it('drops a quote that resolves after unmount', async () => {
@@ -1034,5 +1048,7 @@ describe('SwapScreen', () => {
       });
       await Promise.resolve();
     });
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -480,6 +480,20 @@ describe('SwapScreen', () => {
     expect(screen.getByTestId('input-amount')).toHaveValue('0.3');
   });
 
+  it('clears a KYC quote error when the user empties the spend field', async () => {
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('quote-error')).toHaveTextContent('KycRequired');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    expect(screen.queryByTestId('quote-error')).not.toBeInTheDocument();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
   it('keeps a cleared amount field empty and accepts the retyped amount', async () => {
     render(<SwapScreen />);
     await flushQuote();

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -40,7 +40,8 @@ let mockSession: { address: string; blockchains: string[] } | undefined;
 let mockActiveWallet: string | undefined;
 let mockFlags: string | undefined;
 let mockHideTarget = true;
-const mockGetAsset = (list: any[], name?: string) => (list ?? []).find((a: any) => a.name === name) ?? list?.[0];
+const mockGetAsset = (list: any[], name?: string) =>
+  name ? (list ?? []).find((a: any) => a.name === name || a.uniqueName === name) : undefined;
 const mockGetAssets = () => mockAssets;
 const mockIsSameAsset = (asset: any, filter: string) => asset.name === filter || asset.uniqueName === filter;
 const mockTranslate = (_ns: string, key: string) => key;
@@ -661,5 +662,23 @@ describe('SwapScreen', () => {
     render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('dropdown-address')).toBeInTheDocument();
+  });
+
+  it('falls back to the wallet blockchain when assetIn does not match', async () => {
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'NOPE' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('select-sourceAsset-ETH')).toBeInTheDocument();
+  });
+
+  it('quotes from get data when spend was never set', async () => {
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'NOPE' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await flushQuote();
+    expect(mockReceiveFor.mock.calls.some((call: any) => String(call[0].targetAmount) === '0.01')).toBe(true);
   });
 });

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -161,7 +161,7 @@ jest.mock('@dfx.swiss/react-components', () => {
       />
     ),
     StyledHorizontalStack: ({ children }: any) => <div>{children}</div>,
-    StyledInput: ({ name, control, buttonLabel, buttonClick, forceErrorMessage }: any) =>
+    StyledInput: ({ name, control, buttonLabel, buttonClick, forceErrorMessage, loading, disabled }: any) =>
       name ? (
         <Controller
           name={name}
@@ -171,6 +171,7 @@ jest.mock('@dfx.swiss/react-components', () => {
               <input
                 data-testid={`input-${name}`}
                 value={field.value ?? ''}
+                disabled={Boolean(loading || disabled)}
                 onChange={(e: any) => field.onChange(e.target.value)}
               />
               {buttonLabel && (
@@ -569,6 +570,8 @@ describe('SwapScreen', () => {
     await flushQuote();
     expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
     expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.getByTestId('input-amount')).not.toBeDisabled();
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
     expect(mockReceiveFor.mock.calls.length).toBe(callsBeforeClear);
 
     await act(async () => {
@@ -864,7 +867,7 @@ describe('SwapScreen', () => {
     expect(mockSwitchBlockchain).toHaveBeenCalledWith('Bitcoin');
   });
 
-  it('picks the assetOut chain for the default address when blockchain is unset', async () => {
+  it('shows the address dropdown when blockchain is unset and assetOut is set', async () => {
     mockHideTarget = false;
     mockUseAppParams.mockReturnValue(
       baseAppParams({ blockchain: undefined, assetOut: 'Bitcoin/BTC', hideTargetSelection: false }),
@@ -1030,7 +1033,7 @@ describe('SwapScreen', () => {
     expect(screen.getByTestId('payment-info')).toBeInTheDocument();
   });
 
-  it('falls back to the first address when the assetOut chain is missing', async () => {
+  it('renders the form when the assetOut chain is missing', async () => {
     mockHideTarget = false;
     mockUseAppParams.mockReturnValue(
       baseAppParams({
@@ -1064,14 +1067,14 @@ describe('SwapScreen', () => {
     expect(screen.getByTestId('quote-error')).toHaveTextContent(error);
   });
 
-  it('renders without address items when the session is missing', async () => {
+  it('renders the form when the session is missing', async () => {
     mockSession = undefined;
     render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('form-submit')).toBeInTheDocument();
   });
 
-  it('falls back to no source asset when the wallet chain is unset and assetIn does not match', async () => {
+  it('renders when the wallet chain is unset and assetIn does not match', async () => {
     mockWalletBlockchain = undefined;
     mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'NOPE' }));
     render(<SwapScreen />);

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -458,6 +458,32 @@ describe('SwapScreen', () => {
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
   });
 
+  it('does not write a resolving exact-price into target when clear and resolve share a turn', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SwapScreen />);
+    await flushQuote();
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+      resolveExact(quoteFor({ amount: 0.2, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+  });
+
   it('drops a quote error after the form generation has moved on', async () => {
     let rejectQuote: (err: unknown) => void = () => undefined;
     mockReceiveFor.mockImplementation(

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -676,7 +676,7 @@ describe('SwapScreen', () => {
     await flushQuote();
     expect(screen.getByTestId('input-amount-error')).toBeInTheDocument();
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
@@ -882,7 +882,7 @@ describe('SwapScreen', () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
     });
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
@@ -897,7 +897,7 @@ describe('SwapScreen', () => {
       fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
     });
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
@@ -911,7 +911,7 @@ describe('SwapScreen', () => {
     await flushQuote();
     expect(screen.getByTestId('private-asset-hint')).toBeInTheDocument();
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
@@ -924,7 +924,7 @@ describe('SwapScreen', () => {
     await flushQuote();
     expect(screen.getByTestId('quote-error')).toBeInTheDocument();
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
@@ -937,7 +937,7 @@ describe('SwapScreen', () => {
     await flushQuote();
     expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
@@ -950,12 +950,12 @@ describe('SwapScreen', () => {
     render(<SwapScreen />);
     await flushQuote();
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockSendTransaction).toHaveBeenCalledTimes(1);
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(mockSendTransaction).toHaveBeenCalledTimes(1);

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -697,4 +697,18 @@ describe('SwapScreen', () => {
     await flushQuote();
     expect(screen.getByTestId('select-sourceAsset-BTC')).toBeInTheDocument();
   });
+
+  it('skips the exact-price request when the first quote is empty', async () => {
+    mockReceiveFor.mockResolvedValueOnce(undefined);
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.exactPrice)).toBe(false);
+  });
+
+  it('renders empty balances in the asset dropdown', async () => {
+    mockGetBalances.mockResolvedValue([]);
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('select-sourceAsset-ETH')).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -404,6 +404,32 @@ describe('SwapScreen', () => {
     expect(screen.getByTestId('input-amount')).toHaveValue('');
   });
 
+  it('does not write a resolving exact-price into spend when clear and resolve share a turn', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SwapScreen />);
+    await flushQuote();
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+      resolveExact(quoteFor({ targetAmount: 0.01, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+  });
+
   it('does not write exact-price into a target field cleared while a get-side quote is in flight', async () => {
     let resolveExact: (value: unknown) => void = () => undefined;
     let hangExact = false;

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -1,7 +1,6 @@
 const mockReceiveFor = jest.fn();
 const mockUseAppParams = jest.fn();
 const mockSetParams = jest.fn();
-const mockUpdateAccount = jest.fn();
 const mockSendTransaction = jest.fn();
 const mockCanSendTransaction = jest.fn();
 const mockGetBalances = jest.fn();
@@ -11,8 +10,6 @@ const mockCloseServices = jest.fn();
 const mockSwitchBlockchain = jest.fn();
 const mockLayoutOptions = jest.fn();
 
-const chf = { name: 'CHF', sellable: true };
-const eur = { name: 'EUR', sellable: true };
 const eth = {
   id: 1,
   name: 'ETH',
@@ -25,8 +22,8 @@ const btc = {
   id: 2,
   name: 'BTC',
   uniqueName: 'Bitcoin',
-  category: 'Public',
   blockchain: 'Bitcoin',
+  category: 'Public',
   description: 'Bitcoin',
 };
 const usdtPrivate = {
@@ -37,27 +34,29 @@ const usdtPrivate = {
   blockchain: 'Ethereum',
   description: 'Tether',
 };
-const bankAccount = { id: 1, iban: 'CH9300762011623852957', preferredCurrency: chf };
-let mockAssets = [eth];
-let mockSession: { address: string } | undefined;
+
+let mockAssets = [eth, btc];
+let mockSession: { address: string; blockchains: string[] } | undefined;
 let mockActiveWallet: string | undefined;
 let mockFlags: string | undefined;
 let mockHideTarget = true;
 const mockGetAsset = (list: any[], name?: string) => (list ?? []).find((a: any) => a.name === name) ?? list?.[0];
 const mockGetAssets = () => mockAssets;
 const mockIsSameAsset = (asset: any, filter: string) => asset.name === filter || asset.uniqueName === filter;
-const mockGetCurrency = (list: any[], name?: string) => (list ?? []).find((c: any) => c.name === name);
-const mockGetDefaultCurrency = (list: any[]) => list?.[0];
-const mockCurrencies = [chf, eur];
-const mockSellInterface = {
-  get currencies() {
-    return mockCurrencies;
-  },
-  receiveFor: (...args: unknown[]) => mockReceiveFor(...args),
-};
 const mockTranslate = (_ns: string, key: string) => key;
 const mockTranslateError = (key: string) => key;
-const mockBlockchains = ['Ethereum', 'Bitcoin'];
+const sessionAddress = { address: '0xabc', blockchains: ['Ethereum', 'Bitcoin'] };
+let mockUserAddresses: { address: string; blockchains: string[] }[] = [];
+const mockAssetsMap = () =>
+  new Map([
+    ['Ethereum', mockAssets.filter((a) => a.blockchain === 'Ethereum')],
+    ['Bitcoin', mockAssets.filter((a) => a.blockchain === 'Bitcoin')],
+  ]);
+const mockTxHelper = {
+  getBalances: (...args: unknown[]) => mockGetBalances(...args),
+  sendTransaction: (...args: unknown[]) => mockSendTransaction(...args),
+  canSendTransaction: () => mockCanSendTransaction(),
+};
 
 jest.mock('@dfx.swiss/react', () => ({
   AssetCategory: { PUBLIC: 'Public', PRIVATE: 'Private' },
@@ -78,11 +77,10 @@ jest.mock('@dfx.swiss/react', () => ({
     RECOMMENDATION_REQUIRED: 'RecommendationRequired',
     EMAIL_REQUIRED: 'EmailRequired',
   },
-  TransactionType: { SELL: 'Sell' },
+  TransactionType: { SWAP: 'Swap' },
   Utils: {
     formatAmount: (n: number) => String(n),
     formatAmountCrypto: (n: number) => String(n),
-    formatIban: (iban: string) => iban,
     createRules: () => ({}),
   },
   Validations: { Required: undefined },
@@ -91,24 +89,13 @@ jest.mock('@dfx.swiss/react', () => ({
     isSameAsset: mockIsSameAsset,
   }),
   useAssetContext: () => ({
-    assets: new Map([
-      ['Ethereum', mockAssets.filter((a) => a.blockchain === 'Ethereum')],
-      ['Bitcoin', mockAssets.filter((a) => a.blockchain === 'Bitcoin')],
-    ]),
+    assets: mockAssetsMap(),
     getAssets: mockGetAssets,
   }),
   useAuthContext: () => ({ session: mockSession }),
-  useBankAccountContext: () => ({
-    bankAccounts: [bankAccount],
-    updateAccount: (...args: unknown[]) => mockUpdateAccount(...args),
-  }),
-  useFiat: () => ({
-    toDescription: () => 'Swiss Franc',
-    getCurrency: mockGetCurrency,
-    getDefaultCurrency: mockGetDefaultCurrency,
-  }),
-  useSell: () => mockSellInterface,
   useSessionContext: () => ({ logout: mockLogout }),
+  useUserContext: () => ({ userAddresses: mockUserAddresses, user: { kyc: { level: 0 } }, isUserLoading: false }),
+  useSwap: () => ({ receiveFor: (...args: unknown[]) => mockReceiveFor(...args) }),
 }));
 
 jest.mock('@dfx.swiss/react-components', () => {
@@ -196,7 +183,16 @@ jest.mock('@dfx.swiss/react-components', () => {
       ) : null,
     StyledLink: ({ children, label }: any) => <div>{label ?? children}</div>,
     StyledLoadingSpinner: () => <div data-testid="loading-spinner" />,
-    StyledSearchDropdown: ({ name, items, labelFunc, control, filterFunc, balanceFunc, descriptionFunc, assetIconFunc }: any) => (
+    StyledSearchDropdown: ({
+      name,
+      items,
+      labelFunc,
+      control,
+      filterFunc,
+      balanceFunc,
+      descriptionFunc,
+      assetIconFunc,
+    }: any) => (
       <Controller
         name={name}
         control={control}
@@ -225,30 +221,6 @@ jest.mock('@dfx.swiss/react-components', () => {
   };
 });
 
-jest.mock('src/components/order/bank-account-selector', () => ({
-  BankAccountSelector: ({ onChange, onModalToggle }: any) => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const React = require('react');
-    React.useEffect(() => {
-      onChange(bankAccount);
-    }, []);
-    return (
-      <div data-testid="bank-account-selector">
-        <button type="button" data-testid="bank-account-toggle" onClick={() => onModalToggle(true)}>
-          toggle
-        </button>
-      </div>
-    );
-  },
-}));
-jest.mock('src/components/payment/payment-info-sell', () => ({
-  PaymentInformationContent: ({ info, infoText }: any) => (
-    <div data-testid="payment-info">
-      {info.amount}
-      <span data-testid="payment-info-text">{infoText}</span>
-    </div>
-  ),
-}));
 jest.mock('../components/error-hint', () => ({ ErrorHint: ({ message }: any) => <div data-testid="error-hint">{message}</div> }));
 jest.mock('../components/exchange-rate', () => ({ ExchangeRate: () => <div data-testid="exchange-rate" /> }));
 jest.mock('../components/payment/address-switch', () => ({
@@ -263,8 +235,11 @@ jest.mock('../components/payment/address-switch', () => ({
     </div>
   ),
 }));
-jest.mock('../components/payment/sell-completion', () => ({
-  SellCompletion: () => <div data-testid="sell-completion" />,
+jest.mock('../components/payment/payment-info-sell', () => ({
+  PaymentInformationContent: ({ info }: any) => <div data-testid="payment-info">{info.amount}</div>,
+}));
+jest.mock('../components/payment/swap-completion', () => ({
+  SwapCompletion: () => <div data-testid="swap-completion" />,
 }));
 jest.mock('../components/private-asset-hint', () => ({
   PrivateAssetHint: () => <div data-testid="private-asset-hint" />,
@@ -275,7 +250,7 @@ jest.mock('../components/quote-error-hint', () => ({
 jest.mock('../components/sanction-hint', () => ({ SanctionHint: () => <div data-testid="sanction-hint" /> }));
 jest.mock('../config/labels', () => ({ addressLabel: (wallet: any) => wallet?.address ?? '' }));
 jest.mock('../contexts/app-handling.context', () => ({
-  CloseType: { SELL: 'Sell' },
+  CloseType: { SWAP: 'Swap' },
   useAppHandlingContext: () => ({ isInitialized: true, closeServices: mockCloseServices }),
 }));
 jest.mock('../contexts/layout.context', () => ({
@@ -285,7 +260,6 @@ jest.mock('../contexts/settings.context', () => ({
   useSettingsContext: () => ({
     translate: mockTranslate,
     translateError: mockTranslateError,
-    currency: chf,
   }),
 }));
 jest.mock('../contexts/wallet.context', () => ({
@@ -314,48 +288,43 @@ jest.mock('../hooks/navigation.hook', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 jest.mock('../hooks/tx-helper.hook', () => ({
-  useTxHelper: () => ({
-    getBalances: (...args: unknown[]) => mockGetBalances(...args),
-    sendTransaction: (...args: unknown[]) => mockSendTransaction(...args),
-    canSendTransaction: () => mockCanSendTransaction(),
-  }),
+  useTxHelper: () => mockTxHelper,
 }));
 
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
-import SellScreen from 'src/screens/sell.screen';
+import SwapScreen from 'src/screens/swap.screen';
 
 function baseAppParams(overrides: Record<string, unknown> = {}) {
   return {
     assets: undefined,
     assetIn: 'ETH',
-    assetOut: 'CHF',
+    assetOut: 'BTC',
     amountIn: undefined,
-    amountOut: undefined,
     blockchain: 'Ethereum',
     externalTransactionId: 'ext-1',
     flags: mockFlags,
     setParams: mockSetParams,
     hideTargetSelection: mockHideTarget,
-    availableBlockchains: mockBlockchains,
+    availableBlockchains: ['Ethereum', 'Bitcoin'],
     ...overrides,
   };
 }
 
 function quoteFor(req: any) {
   const spendAmount = req.amount !== undefined ? Number(req.amount) : 0.1;
-  const getAmount = req.targetAmount !== undefined ? Number(req.targetAmount) : 250;
+  const getAmount = req.targetAmount !== undefined ? Number(req.targetAmount) : 0.004;
   return {
     id: 10,
     amount: spendAmount,
     estimatedAmount: getAmount,
-    currency: chf,
-    asset: mockAssets[0],
+    sourceAsset: eth,
+    targetAsset: btc,
     minVolume: 0.001,
     maxVolume: 100,
     isValid: true,
-    exchangeRate: 2500,
-    rate: 2500,
-    feesTarget: {},
+    exchangeRate: 0.04,
+    rate: 0.04,
+    fees: {},
     priceSteps: [],
   };
 }
@@ -371,18 +340,21 @@ async function flushQuote() {
   });
 }
 
-describe('SellScreen', () => {
+describe('SwapScreen', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
-    mockAssets = [eth];
-    mockSession = undefined;
+    mockAssets = [eth, btc];
+    mockSession = sessionAddress;
+    mockUserAddresses = [];
     mockActiveWallet = undefined;
     mockFlags = undefined;
     mockHideTarget = true;
     mockCanSendTransaction.mockReturnValue(false);
-    mockGetBalances.mockResolvedValue([{ asset: eth, amount: 10 }]);
-    mockUpdateAccount.mockResolvedValue(bankAccount);
+    mockGetBalances.mockResolvedValue([
+      { asset: eth, amount: 10 },
+      { asset: btc, amount: 1 },
+    ]);
     mockUseAppParams.mockReturnValue(baseAppParams());
     let quotes = 0;
     mockReceiveFor.mockImplementation((req: any) => {
@@ -399,7 +371,7 @@ describe('SellScreen', () => {
   });
 
   it('keeps a cleared amount field empty and accepts the retyped amount', async () => {
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('input-amount')).toHaveValue('0.1');
     expect(screen.getByTestId('payment-info')).toBeInTheDocument();
@@ -425,7 +397,7 @@ describe('SellScreen', () => {
   });
 
   it('keeps a cleared target amount field empty', async () => {
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('input-targetAmount')).not.toHaveValue('');
 
@@ -437,34 +409,27 @@ describe('SellScreen', () => {
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
   });
 
-  it('uses the BTC default amount 0.001', async () => {
-    mockAssets = [btc];
-    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'BTC' }));
-    render(<SellScreen />);
-    await flushQuote();
-    expect(screen.getByTestId('input-amount')).toHaveValue('0.001');
-  });
-
   it('uses amountIn instead of the asset default', async () => {
     mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: '0.5' }));
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('input-amount')).toHaveValue('0.5');
   });
 
-  it('quotes from amountOut when spend was never set', async () => {
-    mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: undefined, amountOut: '100' }));
-    render(<SellScreen />);
+  it('uses a stablecoin default of 100', async () => {
+    mockAssets = [usdtPrivate, btc];
+    mockFlags = 'private';
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT', flags: 'private' }));
+    render(<SwapScreen />);
     await flushQuote();
-    expect(screen.getByTestId('input-targetAmount')).toHaveValue('100');
-    expect(mockReceiveFor.mock.calls.some((call: any) => String(call[0].targetAmount) === '100')).toBe(true);
+    expect(screen.getByTestId('input-amount')).toHaveValue('100');
   });
 
   it('shows amount-too-low from the quote error field', async () => {
     mockReceiveFor.mockImplementation((req: any) =>
       Promise.resolve({ ...quoteFor(req), error: 'AmountTooLow', minVolume: 1 }),
     );
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('input-amount-error')).toBeInTheDocument();
   });
@@ -473,30 +438,32 @@ describe('SellScreen', () => {
     mockReceiveFor.mockImplementation((req: any) =>
       Promise.resolve({ ...quoteFor(req), error: 'AmountTooHigh', maxVolume: 1 }),
     );
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('input-amount-error')).toBeInTheDocument();
   });
 
   it('routes KYC quote errors through QuoteErrorHint', async () => {
-    mockReceiveFor.mockImplementation((req: any) =>
-      Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }),
-    );
-    render(<SellScreen />);
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }));
+    render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('quote-error')).toHaveTextContent('KycRequired');
   });
 
   it('shows a balance error when the quote exceeds the wallet balance', async () => {
     mockGetBalances.mockResolvedValue([{ asset: eth, amount: 0.01 }]);
-    render(<SellScreen />);
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
     await flushQuote();
     expect(screen.getByTestId('input-amount-error')).toBeInTheDocument();
   });
 
   it('navigates to profile when ident data is incomplete', async () => {
     mockReceiveFor.mockRejectedValue({ statusCode: 400, message: 'Ident data incomplete' });
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     expect(mockNavigate).toHaveBeenCalledWith('/profile');
   });
@@ -505,7 +472,7 @@ describe('SellScreen', () => {
     mockReceiveFor.mockRejectedValueOnce({ statusCode: 500, message: 'boom' }).mockImplementation((req: any) =>
       Promise.resolve(quoteFor(req)),
     );
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
     await act(async () => {
@@ -517,20 +484,20 @@ describe('SellScreen', () => {
 
   it('maps a KYC HTTP message onto QuoteErrorHint', async () => {
     mockReceiveFor.mockRejectedValue({ statusCode: 400, message: 'KycRequired' });
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('quote-error')).toHaveTextContent('KycRequired');
   });
 
   it('uses Unknown error when the API omits a message', async () => {
     mockReceiveFor.mockRejectedValue({ statusCode: 500 });
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('error-hint')).toHaveTextContent('Unknown error');
   });
 
   it('fills MAX from the available balance', async () => {
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     await act(async () => {
       screen.getByTestId('input-amount-max').click();
@@ -539,90 +506,60 @@ describe('SellScreen', () => {
   });
 
   it('filters assets when an asset filter is set', async () => {
-    mockAssets = [eth, btc];
-    mockUseAppParams.mockReturnValue(baseAppParams({ assets: 'ETH', assetIn: 'ETH' }));
-    render(<SellScreen />);
+    mockUseAppParams.mockReturnValue(baseAppParams({ assets: 'ETH', assetIn: 'ETH', assetOut: 'ETH' }));
+    render(<SwapScreen />);
     await flushQuote();
-    expect(screen.getByTestId('select-asset-ETH')).toBeInTheDocument();
-    expect(screen.queryByTestId('select-asset-BTC')).not.toBeInTheDocument();
+    expect(screen.getByTestId('select-sourceAsset-ETH')).toBeInTheDocument();
+    expect(screen.queryByTestId('select-sourceAsset-BTC')).not.toBeInTheDocument();
   });
 
   it('closes services when the wallet can send but is not connected', async () => {
     mockCanSendTransaction.mockReturnValue(true);
     mockActiveWallet = undefined;
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     await act(async () => {
       screen.getByRole('button', { name: 'Complete transaction in your wallet' }).click();
     });
     expect(mockCloseServices).toHaveBeenCalled();
-    expect(mockUpdateAccount).toHaveBeenCalled();
   });
 
   it('completes after a successful wallet send', async () => {
     mockCanSendTransaction.mockReturnValue(true);
     mockActiveWallet = 'mm';
     mockSendTransaction.mockResolvedValue('0xtx');
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     await act(async () => {
       screen.getByRole('button', { name: 'Complete transaction in your wallet' }).click();
       await Promise.resolve();
     });
-    expect(screen.getByTestId('sell-completion')).toBeInTheDocument();
-  });
-
-  it('swallows a wallet rejection (4001)', async () => {
-    mockCanSendTransaction.mockReturnValue(true);
-    mockActiveWallet = 'mm';
-    mockSendTransaction.mockRejectedValue({ code: 4001 });
-    render(<SellScreen />);
-    await flushQuote();
-    await act(async () => {
-      screen.getByRole('button', { name: 'Complete transaction in your wallet' }).click();
-      await Promise.resolve();
-    });
-    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('sell-completion')).not.toBeInTheDocument();
-  });
-
-  it('shows a retryable error for other send failures', async () => {
-    mockCanSendTransaction.mockReturnValue(true);
-    mockActiveWallet = 'mm';
-    mockSendTransaction.mockRejectedValue({ code: 500, message: 'nope' });
-    render(<SellScreen />);
-    await flushQuote();
-    await act(async () => {
-      screen.getByRole('button', { name: 'Complete transaction in your wallet' }).click();
-      await Promise.resolve();
-    });
-    expect(screen.getByTestId('error-hint')).toBeInTheDocument();
+    expect(screen.getByTestId('swap-completion')).toBeInTheDocument();
   });
 
   it('marks a manual transfer complete without sending', async () => {
     mockCanSendTransaction.mockReturnValue(false);
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     await act(async () => {
       screen.getByRole('button', { name: 'Click here once you have issued the transaction' }).click();
       await Promise.resolve();
     });
-    expect(screen.getByTestId('sell-completion')).toBeInTheDocument();
+    expect(screen.getByTestId('swap-completion')).toBeInTheDocument();
   });
 
   it('shows the private-asset hint', async () => {
-    mockAssets = [usdtPrivate];
+    mockAssets = [usdtPrivate, btc];
     mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT' }));
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('private-asset-hint')).toBeInTheDocument();
   });
 
   it('opens and cancels the address switch', async () => {
-    mockSession = { address: '0xabc' };
     mockHideTarget = false;
     mockUseAppParams.mockReturnValue(baseAppParams({ hideTargetSelection: false }));
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     const addressButtons = screen.getAllByTestId(/select-address-/);
     await act(async () => {
@@ -636,10 +573,9 @@ describe('SellScreen', () => {
   });
 
   it('logs out when the address switch is confirmed', async () => {
-    mockSession = { address: '0xabc' };
     mockHideTarget = false;
     mockUseAppParams.mockReturnValue(baseAppParams({ hideTargetSelection: false }));
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     const addressButtons = screen.getAllByTestId(/select-address-/);
     await act(async () => {
@@ -653,62 +589,24 @@ describe('SellScreen', () => {
   });
 
   it('submits the empty onSubmit handler', async () => {
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     await act(async () => {
       screen.getByTestId('form-submit').click();
     });
   });
 
-  it('toggles the bank-account modal title', async () => {
-    render(<SellScreen />);
-    await flushQuote();
-    await act(async () => {
-      screen.getByTestId('bank-account-toggle').click();
-    });
-    const latest = mockLayoutOptions.mock.calls[mockLayoutOptions.mock.calls.length - 1][0];
-    expect(latest.title).toBe('Select payment account');
-    await act(async () => {
-      latest.onBack();
-    });
-  });
-
   it('uses the exact You get heading when rate is 1', async () => {
     mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), rate: 1, exchangeRate: 1 }));
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByText('You get')).toBeInTheDocument();
   });
 
-  it('uses a non-ETH default of 300', async () => {
-    mockAssets = [usdtPrivate];
-    mockFlags = 'private';
-    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT', flags: 'private' }));
-    render(<SellScreen />);
-    await flushQuote();
-    expect(screen.getByTestId('input-amount')).toHaveValue('300');
-  });
-
-  it('quotes from the target side when spend was never set and get data is complete', async () => {
-    mockUseAppParams.mockReturnValue(baseAppParams({ amountOut: '100' }));
-    render(<SellScreen />);
-    await flushQuote();
-    await act(async () => {
-      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
-    });
-    await act(async () => {
-      screen.getByTestId('select-asset-ETH').click();
-    });
-    await flushQuote();
-    expect(mockReceiveFor.mock.calls.some((call: any) => String(call[0].targetAmount) === '100')).toBe(true);
-  });
-
   it('switches blockchain when another chain address is chosen', async () => {
-    mockAssets = [eth, btc];
-    mockSession = { address: '0xabc' };
     mockHideTarget = false;
-    mockUseAppParams.mockReturnValue(baseAppParams({ hideTargetSelection: false, assetIn: 'ETH' }));
-    render(<SellScreen />);
+    mockUseAppParams.mockReturnValue(baseAppParams({ hideTargetSelection: false, assetOut: undefined }));
+    render(<SwapScreen />);
     await flushQuote();
     await act(async () => {
       screen.getByTestId('select-address-1').click();
@@ -719,11 +617,49 @@ describe('SellScreen', () => {
 
   it('invokes Retry after a generic error', async () => {
     mockReceiveFor.mockRejectedValue({ statusCode: 500, message: 'boom' });
-    render(<SellScreen />);
+    render(<SwapScreen />);
     await flushQuote();
     await act(async () => {
       screen.getByRole('button', { name: 'Retry' }).click();
     });
     expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
+  });
+
+  it('quotes from the target side after spend is cleared and the target asset changes', async () => {
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await act(async () => {
+      screen.getByTestId('select-targetAsset-BTC').click();
+    });
+    await flushQuote();
+    expect(mockReceiveFor.mock.calls.some((call: any) => String(call[0].targetAmount) === '0.01')).toBe(true);
+  });
+
+  it('aligns the blockchain with assetOut when an address exists for that chain', async () => {
+    mockUserAddresses = [{ address: '0xbtc', blockchains: ['Bitcoin'] }];
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({ assetOut: 'Bitcoin/BTC', blockchain: 'Ethereum' }),
+    );
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(mockSetParams).toHaveBeenCalledWith({ blockchain: 'Bitcoin' });
+    expect(mockSwitchBlockchain).toHaveBeenCalledWith('Bitcoin');
+  });
+
+  it('picks the assetOut chain for the default address when blockchain is unset', async () => {
+    mockHideTarget = false;
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({ blockchain: undefined, assetOut: 'Bitcoin/BTC', hideTargetSelection: false }),
+    );
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('dropdown-address')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -392,9 +392,11 @@ describe('SwapScreen', () => {
       fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
     });
     await flushQuote();
+    expect(screen.getByTestId('input-amount')).toBeDisabled();
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
     });
+    expect(screen.getByTestId('input-amount')).not.toBeDisabled();
     await act(async () => {
       resolveExact(quoteFor({ targetAmount: 0.01, exactPrice: true }));
       await Promise.resolve();

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -373,6 +373,62 @@ describe('SwapScreen', () => {
     jest.useRealTimers();
   });
 
+  it('does not write exact-price into a spend field cleared while a spend-side quote is in flight', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SwapScreen />);
+    await flushQuote();
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      resolveExact(quoteFor({ targetAmount: 0.01, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+  });
+
+  it('does not write exact-price into a target field cleared while a get-side quote is in flight', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SwapScreen />);
+    await flushQuote();
+    hangExact = true;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await act(async () => {
+      resolveExact(quoteFor({ amount: 0.2, exactPrice: true }));
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+  });
+
   it('keeps a cleared amount field empty and accepts the retyped amount', async () => {
     render(<SwapScreen />);
     await flushQuote();

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -803,6 +803,22 @@ describe('SwapScreen', () => {
     expect(mockSwitchBlockchain).toHaveBeenCalled();
   });
 
+  it('keeps the typed spend amount when only the receive address changes on the same chain', async () => {
+    mockHideTarget = false;
+    mockUserAddresses = [{ address: '0xdef', blockchains: ['Ethereum'] }];
+    mockUseAppParams.mockReturnValue(baseAppParams({ hideTargetSelection: false }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.1');
+    await act(async () => {
+      screen.getByTestId('select-address-1').click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.1');
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    expect(mockReceiveFor.mock.calls.some((call: any) => call[0]?.receiverAddress === '0xdef')).toBe(true);
+  });
+
   it('invokes Retry after a generic error', async () => {
     mockReceiveFor
       .mockRejectedValueOnce({ statusCode: 500, message: 'boom' })

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -1164,7 +1164,7 @@ describe('SwapScreen', () => {
     expect(after.every((call: any) => String(call[0].amount) === '0.2')).toBe(true);
   });
 
-  it('falls back to the target side after spend is cleared and the source asset changes', async () => {
+  it('keeps leftover target and does not quote after spend is cleared and the source asset changes', async () => {
     render(<SwapScreen />);
     await flushQuote();
     const targetBefore = (screen.getByTestId('input-targetAmount') as HTMLInputElement).value;
@@ -1173,11 +1173,14 @@ describe('SwapScreen', () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
     });
     await flushQuote();
+    const callsBefore = mockReceiveFor.mock.calls.length;
     await act(async () => {
       screen.getByTestId('select-sourceAsset-BTC').click();
     });
     await flushQuote();
     expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue(targetBefore);
+    expect(mockReceiveFor.mock.calls.slice(callsBefore)).toEqual([]);
   });
 
   it('skips the exact-price request when the first quote is empty', async () => {

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -480,6 +480,39 @@ describe('SwapScreen', () => {
     expect(screen.getByTestId('input-amount')).toHaveValue('0.3');
   });
 
+  it('still invalidates quotes when target is cleared after an exact-price no-op write', async () => {
+    render(<SwapScreen />);
+    await flushQuote();
+    const targetBefore = (screen.getByTestId('input-targetAmount') as HTMLInputElement).value;
+    await act(async () => {
+      screen.getByTestId('select-sourceAsset-BTC').click();
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+    expect(targetBefore).not.toBe('');
+  });
+
+  it('still invalidates quotes when spend is cleared after an exact-price no-op write', async () => {
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.1');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
+  });
+
   it('clears a KYC quote error when the user empties the spend field', async () => {
     mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error: 'KycRequired' }));
     render(<SwapScreen />);

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -695,7 +695,7 @@ describe('SwapScreen', () => {
       screen.getByTestId('select-sourceAsset-BTC').click();
     });
     await flushQuote();
-    expect(screen.getByTestId('select-sourceAsset-BTC')).toBeInTheDocument();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
   });
 
   it('skips the exact-price request when the first quote is empty', async () => {

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -810,6 +810,12 @@ describe('SwapScreen', () => {
       await Promise.resolve();
     });
     expect(screen.getByTestId('error-hint')).toBeInTheDocument();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Retry' }).click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
   });
 
   it('marks a manual transfer complete without sending', async () => {
@@ -1050,9 +1056,6 @@ describe('SwapScreen', () => {
     expect(screen.getByTestId('error-hint')).toHaveTextContent('boom');
     await act(async () => {
       screen.getByRole('button', { name: 'Retry' }).click();
-    });
-    await act(async () => {
-      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
     });
     await flushQuote();
     expect(screen.getByTestId('payment-info')).toBeInTheDocument();

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -40,6 +40,7 @@ let mockSession: { address: string; blockchains: string[] } | undefined;
 let mockActiveWallet: string | undefined;
 let mockFlags: string | undefined;
 let mockHideTarget = true;
+let mockWalletBlockchain: string | undefined = 'Ethereum';
 const mockGetAsset = (list: any[], name?: string) =>
   name ? (list ?? []).find((a: any) => a.name === name || a.uniqueName === name) : undefined;
 const mockGetAssets = () => mockAssets;
@@ -265,7 +266,7 @@ jest.mock('../contexts/settings.context', () => ({
 }));
 jest.mock('../contexts/wallet.context', () => ({
   useWalletContext: () => ({
-    blockchain: 'Ethereum',
+    blockchain: mockWalletBlockchain,
     activeWallet: mockActiveWallet,
     switchBlockchain: mockSwitchBlockchain,
   }),
@@ -351,6 +352,7 @@ describe('SwapScreen', () => {
     mockActiveWallet = undefined;
     mockFlags = undefined;
     mockHideTarget = true;
+    mockWalletBlockchain = 'Ethereum';
     mockCanSendTransaction.mockReturnValue(false);
     mockGetBalances.mockResolvedValue([
       { asset: eth, amount: 10 },
@@ -728,5 +730,202 @@ describe('SwapScreen', () => {
     render(<SwapScreen />);
     await flushQuote();
     expect(screen.getByTestId('select-sourceAsset-ETH')).toBeInTheDocument();
+  });
+
+  it('quotes spend from leftover get data after a typed target and a source-asset change', async () => {
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice) return Promise.resolve(undefined);
+      return Promise.resolve(quoteFor(req));
+    });
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+    await act(async () => {
+      screen.getByTestId('select-sourceAsset-BTC').click();
+    });
+    await flushQuote();
+    expect(mockReceiveFor.mock.calls.some((call: any) => String(call[0].targetAmount) === '0.01')).toBe(true);
+  });
+
+  it('groups multiple source assets on the same chain when loading balances', async () => {
+    const usdc = {
+      id: 4,
+      name: 'USDC',
+      uniqueName: 'Ethereum/USDC',
+      category: 'Public',
+      blockchain: 'Ethereum',
+      description: 'USD Coin',
+    };
+    mockAssets = [eth, usdc, btc];
+    mockGetBalances.mockResolvedValue([
+      { asset: eth, amount: 10 },
+      { asset: usdc, amount: 20 },
+      { asset: btc, amount: 1 },
+    ]);
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('select-sourceAsset-ETH')).toBeInTheDocument();
+    expect(screen.getByTestId('select-sourceAsset-USDC')).toBeInTheDocument();
+  });
+
+  it('does not restore amountIn after the user clears spend and the source asset changes', async () => {
+    mockUseAppParams.mockReturnValue(baseAppParams({ amountIn: '0.2' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.2');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    await act(async () => {
+      screen.getByTestId('select-sourceAsset-BTC').click();
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
+  });
+
+  it('does not quote a zero spend amount', async () => {
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0');
+  });
+
+  it('shows the private-asset hint for a private target asset', async () => {
+    mockAssets = [eth, usdtPrivate];
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetOut: 'USDT' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('private-asset-hint')).toBeInTheDocument();
+  });
+
+  it('shows payment details when the private flag is set', async () => {
+    mockAssets = [usdtPrivate];
+    mockFlags = 'private';
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'USDT', flags: 'private' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('payment-info')).toBeInTheDocument();
+  });
+
+  it('falls back to the first address when the assetOut chain is missing', async () => {
+    mockHideTarget = false;
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({
+        blockchain: undefined,
+        assetOut: 'Monero/XMR',
+        hideTargetSelection: false,
+      }),
+    );
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('form-submit')).toBeInTheDocument();
+  });
+
+  it.each([
+    'LimitExceeded',
+    'KycDataRequired',
+    'KycRequiredInstant',
+    'BankTransactionMissing',
+    'BankTransactionOrVideoMissing',
+    'VideoIdentRequired',
+    'NationalityNotAllowed',
+    'IbanCurrencyMismatch',
+    'PaymentMethodNotAllowed',
+    'TradingNotAllowed',
+    'RecommendationRequired',
+    'EmailRequired',
+  ])('routes %s through QuoteErrorHint', async (error) => {
+    mockReceiveFor.mockImplementation((req: any) => Promise.resolve({ ...quoteFor(req), error }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('quote-error')).toHaveTextContent(error);
+  });
+
+  it('renders without address items when the session is missing', async () => {
+    mockSession = undefined;
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('form-submit')).toBeInTheDocument();
+  });
+
+  it('falls back to no source asset when the wallet chain is unset and assetIn does not match', async () => {
+    mockWalletBlockchain = undefined;
+    mockUseAppParams.mockReturnValue(baseAppParams({ assetIn: 'NOPE' }));
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(screen.getByTestId('form-submit')).toBeInTheDocument();
+  });
+
+  it('keeps the blockchain when it already matches assetOut', async () => {
+    mockUserAddresses = [{ address: '0xbtc', blockchains: ['Bitcoin'] }];
+    mockUseAppParams.mockReturnValue(
+      baseAppParams({ assetOut: 'Bitcoin/BTC', blockchain: 'Bitcoin' }),
+    );
+    render(<SwapScreen />);
+    await flushQuote();
+    expect(mockSetParams).not.toHaveBeenCalledWith({ blockchain: 'Bitcoin' });
+  });
+
+  it('drops a quote error that rejects after unmount', async () => {
+    let rejectQuote: (err: unknown) => void = () => undefined;
+    mockReceiveFor.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectQuote = reject;
+        }),
+    );
+    const { unmount } = render(<SwapScreen />);
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    unmount();
+    await act(async () => {
+      rejectQuote({ statusCode: 500, message: 'late' });
+      await Promise.resolve();
+    });
+  });
+
+  it('drops a quote that resolves after unmount', async () => {
+    let resolveQuote: (value: unknown) => void = () => undefined;
+    mockReceiveFor.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveQuote = resolve;
+        }),
+    );
+    const { unmount } = render(<SwapScreen />);
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+    unmount();
+    await act(async () => {
+      resolveQuote({
+        id: 10,
+        amount: 0.1,
+        estimatedAmount: 0.01,
+        sourceAsset: eth,
+        targetAsset: btc,
+        minVolume: 0.001,
+        maxVolume: 100,
+        isValid: true,
+        exchangeRate: 1,
+        rate: 1,
+        feesTarget: {},
+        priceSteps: [],
+      });
+      await Promise.resolve();
+    });
   });
 });

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -1217,6 +1217,7 @@ describe('SwapScreen', () => {
       screen.getByTestId('select-sourceAsset-BTC').click();
     });
     await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('');
     expect(mockReceiveFor.mock.calls.some((call: any) => String(call[0].targetAmount) === '0.01')).toBe(true);
   });
 

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -481,25 +481,51 @@ describe('SwapScreen', () => {
   });
 
   it('still invalidates quotes when target is cleared after an exact-price no-op write', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
     render(<SwapScreen />);
     await flushQuote();
     const targetBefore = (screen.getByTestId('input-targetAmount') as HTMLInputElement).value;
+    expect(targetBefore).not.toBe('');
+    hangExact = true;
     await act(async () => {
       screen.getByTestId('select-sourceAsset-BTC').click();
     });
     await flushQuote();
+    expect(screen.getByTestId('input-targetAmount')).toHaveValue(targetBefore);
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
     });
-    await flushQuote();
+    await act(async () => {
+      resolveExact(quoteFor({ amount: 0.1, exactPrice: true }));
+      await Promise.resolve();
+    });
     expect(screen.getByTestId('input-targetAmount')).toHaveValue('');
     expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
-    expect(targetBefore).not.toBe('');
   });
 
   it('still invalidates quotes when spend is cleared after an exact-price no-op write', async () => {
+    let resolveExact: (value: unknown) => void = () => undefined;
+    let hangExact = false;
+    mockReceiveFor.mockImplementation((req: any) => {
+      if (req.exactPrice && hangExact) {
+        return new Promise((resolve) => {
+          resolveExact = resolve;
+        });
+      }
+      return Promise.resolve(quoteFor(req));
+    });
     render(<SwapScreen />);
     await flushQuote();
+    hangExact = true;
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '0.01' } });
     });
@@ -508,7 +534,10 @@ describe('SwapScreen', () => {
     await act(async () => {
       fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '' } });
     });
-    await flushQuote();
+    await act(async () => {
+      resolveExact(quoteFor({ targetAmount: 0.01, exactPrice: true }));
+      await Promise.resolve();
+    });
     expect(screen.getByTestId('input-amount')).toHaveValue('');
     expect(screen.queryByTestId('payment-info')).not.toBeInTheDocument();
   });

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -869,6 +869,20 @@ describe('SwapScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/connect', { setRedirect: true });
   });
 
+  it('does not complete from form submit after the spend amount changes before the new quote', async () => {
+    mockCanSendTransaction.mockReturnValue(false);
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
+  });
+
   it('does not complete from form submit while the quote is not final', async () => {
     mockCanSendTransaction.mockReturnValue(false);
     mockReceiveFor.mockImplementation((req: any) => {

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -682,6 +682,24 @@ describe('SwapScreen', () => {
     expect(mockReceiveFor.mock.calls.some((call: any) => String(call[0].targetAmount) === '0.01')).toBe(true);
   });
 
+  it('quotes from a new spend amount after the target field was cleared', async () => {
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-targetAmount'), { target: { value: '' } });
+    });
+    await flushQuote();
+    const callsBefore = mockReceiveFor.mock.calls.length;
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('input-amount'), { target: { value: '0.2' } });
+    });
+    await flushQuote();
+    expect(screen.getByTestId('input-amount')).toHaveValue('0.2');
+    const after = mockReceiveFor.mock.calls.slice(callsBefore);
+    expect(after.length).toBeGreaterThan(0);
+    expect(after.every((call: any) => String(call[0].amount) === '0.2')).toBe(true);
+  });
+
   it('falls back to the target side after spend is cleared and the source asset changes', async () => {
     render(<SwapScreen />);
     await flushQuote();

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -868,7 +868,7 @@ describe('SwapScreen', () => {
     render(<SwapScreen />);
     await flushQuote();
     await act(async () => {
-      screen.getByTestId('form-submit').click();
+      fireEvent.submit(screen.getByTestId('form-submit').closest('form') as HTMLFormElement);
       await Promise.resolve();
     });
     expect(screen.getByTestId('swap-completion')).toBeInTheDocument();

--- a/src/__tests__/swap-screen-cleared-amount.test.tsx
+++ b/src/__tests__/swap-screen-cleared-amount.test.tsx
@@ -780,6 +780,33 @@ describe('SwapScreen', () => {
     expect(screen.getByTestId('swap-completion')).toBeInTheDocument();
   });
 
+  it('swallows a wallet rejection (4001)', async () => {
+    mockCanSendTransaction.mockReturnValue(true);
+    mockActiveWallet = 'mm';
+    mockSendTransaction.mockRejectedValue({ code: 4001 });
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Complete transaction in your wallet' }).click();
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('swap-completion')).not.toBeInTheDocument();
+  });
+
+  it('shows a retryable error for other send failures', async () => {
+    mockCanSendTransaction.mockReturnValue(true);
+    mockActiveWallet = 'mm';
+    mockSendTransaction.mockRejectedValue({ code: 500, message: 'nope' });
+    render(<SwapScreen />);
+    await flushQuote();
+    await act(async () => {
+      screen.getByRole('button', { name: 'Complete transaction in your wallet' }).click();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('error-hint')).toBeInTheDocument();
+  });
+
   it('marks a manual transfer complete without sending', async () => {
     mockCanSendTransaction.mockReturnValue(false);
     render(<SwapScreen />);

--- a/src/components/order/bank-account-selector.tsx
+++ b/src/components/order/bank-account-selector.tsx
@@ -59,6 +59,7 @@ export const BankAccountSelector: React.FC<BankAccountSelectorProps> = ({
       setIsCreatingAccount(true);
       createAccount({ iban: bankAccount })
         .then((b) => onChange(b))
+        .catch(() => undefined)
         .finally(() => setIsCreatingAccount(false));
     }
   }, [bankAccount, getAccount, bankAccounts, allowedCountries, value, onChange, isCreatingAccount, createAccount]);

--- a/src/components/order/bank-account-selector.tsx
+++ b/src/components/order/bank-account-selector.tsx
@@ -1,6 +1,6 @@
 import { BankAccount, useBankAccount, useBankAccountContext, Utils, Validations } from '@dfx.swiss/react';
 import { StyledModalButton, StyledVerticalStack } from '@dfx.swiss/react-components';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { AddBankAccount } from 'src/components/payment/add-bank-account';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useWindowContext } from 'src/contexts/window.context';
@@ -34,27 +34,34 @@ export const BankAccountSelector: React.FC<BankAccountSelectorProps> = ({
   const { width } = useWindowContext();
 
   const [isCreatingAccount, setIsCreatingAccount] = useState(false);
+  const requestedCreateIbanRef = useRef<string>();
 
   useEffect(() => {
-    if (bankAccounts) {
-      const account =
-        getAccount(bankAccounts, bankAccount) ??
-        bankAccounts.find((a) => a.default) ??
-        (bankAccounts.length === 1 ? bankAccounts[0] : undefined);
-      if (account && !value) {
-        onChange(account);
-      } else if (
-        bankAccount &&
-        !isCreatingAccount &&
-        Validations.Iban(allowedCountries).validate(bankAccount) === true
-      ) {
-        setIsCreatingAccount(true);
-        createAccount({ iban: bankAccount })
-          .then((b) => onChange(b))
-          .finally(() => setIsCreatingAccount(false));
-      }
+    if (!bankAccounts) return;
+
+    const fromParam = bankAccount ? getAccount(bankAccounts, bankAccount) : undefined;
+    const fallback =
+      bankAccounts.find((a) => a.default) ?? (bankAccounts.length === 1 ? bankAccounts[0] : undefined);
+    const account = fromParam ?? (bankAccount ? undefined : fallback);
+
+    if (account) {
+      if (value?.id !== account.id) onChange(account);
+      return;
     }
-  }, [bankAccount, getAccount, bankAccounts, allowedCountries, value, onChange]);
+
+    if (
+      bankAccount &&
+      !isCreatingAccount &&
+      requestedCreateIbanRef.current !== bankAccount &&
+      Validations.Iban(allowedCountries).validate(bankAccount) === true
+    ) {
+      requestedCreateIbanRef.current = bankAccount;
+      setIsCreatingAccount(true);
+      createAccount({ iban: bankAccount })
+        .then((b) => onChange(b))
+        .finally(() => setIsCreatingAccount(false));
+    }
+  }, [bankAccount, getAccount, bankAccounts, allowedCountries, value, onChange, isCreatingAccount, createAccount]);
 
   return (
     <>

--- a/src/components/order/bank-account-selector.tsx
+++ b/src/components/order/bank-account-selector.tsx
@@ -35,6 +35,16 @@ export const BankAccountSelector: React.FC<BankAccountSelectorProps> = ({
 
   const [isCreatingAccount, setIsCreatingAccount] = useState(false);
   const requestedCreateIbanRef = useRef<string>();
+  const bankAccountLiveRef = useRef(bankAccount);
+  const mountedRef = useRef(true);
+  bankAccountLiveRef.current = bankAccount;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!bankAccounts) return;
@@ -59,12 +69,18 @@ export const BankAccountSelector: React.FC<BankAccountSelectorProps> = ({
       requestedCreateIbanRef.current !== bankAccount &&
       Validations.Iban(allowedCountries).validate(bankAccount) === true
     ) {
-      requestedCreateIbanRef.current = bankAccount;
+      const requestedIban = bankAccount;
+      requestedCreateIbanRef.current = requestedIban;
       setIsCreatingAccount(true);
-      createAccount({ iban: bankAccount })
-        .then((b) => onChange(b))
+      createAccount({ iban: requestedIban })
+        .then((b) => {
+          if (!mountedRef.current || bankAccountLiveRef.current !== requestedIban) return;
+          onChange(b);
+        })
         .catch(() => undefined)
-        .finally(() => setIsCreatingAccount(false));
+        .finally(() => {
+          if (mountedRef.current) setIsCreatingAccount(false);
+        });
     }
   }, [bankAccount, getAccount, bankAccounts, allowedCountries, value, onChange, isCreatingAccount, createAccount]);
 

--- a/src/components/order/bank-account-selector.tsx
+++ b/src/components/order/bank-account-selector.tsx
@@ -45,7 +45,11 @@ export const BankAccountSelector: React.FC<BankAccountSelectorProps> = ({
     const account = fromParam ?? (bankAccount ? undefined : fallback);
 
     if (account) {
-      if (value?.id !== account.id) onChange(account);
+      if (bankAccount) {
+        if (value?.id !== account.id) onChange(account);
+      } else if (!value) {
+        onChange(account);
+      }
       return;
     }
 

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -675,11 +675,18 @@ export default function BuyScreen(): JSX.Element {
     }
 
     // Live clear invalidates immediately; debounce can still hold the previous request.
-    // Extra effect deps (personal-IBAN rows, provider, retry) must not restart that request.
+    // Extra effect deps (personal-IBAN rows, provider, retry) must not restart that request,
+    // including when the user already typed a new non-empty amount.
     if (
       !validatedData ||
       spendClearedByUserRef.current ||
-      targetClearedByUserRef.current
+      targetClearedByUserRef.current ||
+      validatedData.sideToUpdate !== debouncedValidatedData.sideToUpdate ||
+      validatedData.amount !== debouncedValidatedData.amount ||
+      validatedData.targetAmount !== debouncedValidatedData.targetAmount ||
+      validatedData.currency?.name !== debouncedValidatedData.currency?.name ||
+      validatedData.asset?.uniqueName !== debouncedValidatedData.asset?.uniqueName ||
+      validatedData.paymentMethod !== debouncedValidatedData.paymentMethod
     ) {
       setIsLoading(undefined);
       return () => {

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -683,16 +683,11 @@ export default function BuyScreen(): JSX.Element {
     }
 
     if (hasUnsupportedPersonalIbanRequest) {
-      const personalIbanErrorText = getPersonalIbanErrorMessage('PersonalIbanProviderUnsupported');
-      if (generation === quoteGeneration.current) {
-        setPaymentInfoState(undefined);
-        setErrorMessage(
-          personalIbanErrorText
-            ? translate('screens/payment', personalIbanErrorText)
-            : translate('screens/payment', 'The requested personal IBAN provider is not recognized.'),
-        );
-        setIsLoading(undefined);
-      }
+      setPaymentInfoState(undefined);
+      setErrorMessage(
+        translate('screens/payment', 'The requested personal IBAN provider is not recognized.'),
+      );
+      setIsLoading(undefined);
       return () => {
         isRunning = false;
       };
@@ -706,19 +701,18 @@ export default function BuyScreen(): JSX.Element {
         : {}),
     };
 
-    if (generation === quoteGeneration.current) {
-      setErrorMessage(undefined);
-      setKycError(undefined);
-      setKycMessageOverride(undefined);
-      setPaymentInfoState(undefined);
-      setIsLoading(debouncedValidatedData.sideToUpdate);
-    }
+    setErrorMessage(undefined);
+    setKycError(undefined);
+    setKycMessageOverride(undefined);
+    setPaymentInfoState(undefined);
+    setIsLoading(debouncedValidatedData.sideToUpdate);
     receiveFor(data)
       .then((buy) => {
         if (
           !isRunning ||
           generation !== quoteGeneration.current ||
-          customerIdentityRef.current !== loadingCustomerIdentity
+          customerIdentityRef.current !== loadingCustomerIdentity ||
+          !buy
         )
           return;
         validateBuy(buy);
@@ -731,10 +725,7 @@ export default function BuyScreen(): JSX.Element {
         });
         committedQuoteGeneration.current = generation;
 
-        // load exact price
-        if (buy) {
-          return receiveFor({ ...data, exactPrice: true });
-        }
+        return receiveFor({ ...data, exactPrice: true });
       })
       .then((info) => {
         if (
@@ -762,8 +753,8 @@ export default function BuyScreen(): JSX.Element {
           customerIdentity: loadingCustomerIdentity,
         });
         if (debouncedValidatedData.sideToUpdate === Side.SPEND) {
-          if (!spendClearedByUserRef.current) setVal('amount', info.amount.toString());
-        } else if (!targetClearedByUserRef.current) {
+          setVal('amount', info.amount.toString());
+        } else {
           setVal('targetAmount', info.estimatedAmount.toString());
         }
         setPaymentInfoState({
@@ -915,7 +906,7 @@ export default function BuyScreen(): JSX.Element {
     asset,
     targetAmount: targetAmountStr,
     paymentMethod,
-  }: Partial<FormData> = {}): BuyPaymentInfo | undefined {
+  }: Partial<FormData>): BuyPaymentInfo | undefined {
     const amount = Number(amountStr);
     const targetAmount = Number(targetAmountStr);
     if (asset != null && currency != null && paymentMethod != null) {
@@ -936,7 +927,7 @@ export default function BuyScreen(): JSX.Element {
   }
 
   function onSubmit(_data: FormData) {
-    // TODO: (Krysh fix broken form validation and onSubmit
+    return;
   }
 
   function setAddress() {
@@ -953,8 +944,6 @@ export default function BuyScreen(): JSX.Element {
 
   function confirm(id: number) {
     const confirmingGeneration = quoteGeneration.current;
-    // Refuse confirmation against a quote that no longer matches the live form generation (B4).
-    if (committedQuoteGeneration.current !== quoteGeneration.current) return;
     if (activePaymentInfoState?.isFinalQuote !== true || activePaymentInfoState.info.id !== id)
       return;
 
@@ -1006,9 +995,8 @@ export default function BuyScreen(): JSX.Element {
       });
   }
 
-  function onCreatePersonalIban() {
-    if (!selectedCurrency) return;
-    navigate({ pathname: '/buy/personal-iban', search: `?currency=${selectedCurrency.name}` }, { setRedirect: true });
+  function onCreatePersonalIban(currencyName: string) {
+    navigate({ pathname: '/buy/personal-iban', search: `?currency=${currencyName}` }, { setRedirect: true });
   }
 
   function onSwitchPersonalIbanProvider(provider: PersonalIbanProvider) {
@@ -1023,9 +1011,7 @@ export default function BuyScreen(): JSX.Element {
     setPersonalIbanProviderUnavailable(undefined);
     setContinueWithoutPersonalIban(undefined);
     setProviderOverride(undefined);
-    if (requestedPersonalIban !== undefined) {
-      setSuppressPersonalIban({ value: true, identity: customerIdentity });
-    }
+    setSuppressPersonalIban({ value: true, identity: customerIdentity });
     setAutomaticFrickSuppressed({ value: true, identity: customerIdentity });
   }
 
@@ -1320,7 +1306,7 @@ export default function BuyScreen(): JSX.Element {
                                 <StyledButton
                                   width={StyledButtonWidth.FULL}
                                   label={translate('screens/payment', 'Generate personal IBAN')}
-                                  onClick={onCreatePersonalIban}
+                                  onClick={() => onCreatePersonalIban(paymentInfo.currency.name)}
                                   color={StyledButtonColor.STURDY_WHITE}
                                 />
                               </StyledVerticalStack>

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -674,6 +674,19 @@ export default function BuyScreen(): JSX.Element {
       };
     }
 
+    // Live clear invalidates immediately; debounce can still hold the previous request.
+    // Extra effect deps (personal-IBAN rows, provider, retry) must not restart that request.
+    if (
+      !validatedData ||
+      spendClearedByUserRef.current ||
+      targetClearedByUserRef.current
+    ) {
+      setIsLoading(undefined);
+      return () => {
+        isRunning = false;
+      };
+    }
+
     if (shouldWaitForApplicableExplicitCustomer || shouldWaitForPersonalIbanRows) {
       setPaymentInfoState(undefined);
       setErrorMessage(undefined);

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -44,7 +44,6 @@ import { PaymentInformationContent } from 'src/components/payment/payment-info-b
 import { useWindowContext } from 'src/contexts/window.context';
 import { getKycErrorFromMessage } from 'src/util/api-error';
 import { blankedAddress } from 'src/util/utils';
-import { NameEdit } from '../components/edit/name.edit';
 import { ErrorHint } from '../components/error-hint';
 import { ExchangeRate } from '../components/exchange-rate';
 import { AddressSwitch } from '../components/payment/address-switch';
@@ -209,9 +208,7 @@ export default function BuyScreen(): JSX.Element {
     identity: number | undefined;
   }>();
   const [showsSwitchScreen, setShowsSwitchScreen] = useState(false);
-  const [showsNameForm, setShowsNameForm] = useState(false);
   const [isLoading, setIsLoading] = useState<Side>();
-  const [isContinue, setIsContinue] = useState(false);
   const [isConfirming, setIsConfirming] = useState(false);
   const [validatedData, setValidatedData] = useState<ValidatedData>();
   // Re-run the guarded quote effect when Retry is clicked even if the canonical request is equal.
@@ -359,13 +356,7 @@ export default function BuyScreen(): JSX.Element {
   //   (!selectedAsset || selectedAsset?.cardBuyable) &&
   //   availablePaymentMethods.push(FiatPaymentMethod.CARD);
 
-  const availableCurrencies = currencies?.filter((c) =>
-    selectedPaymentMethod === FiatPaymentMethod.CARD
-      ? c.cardSellable
-      : selectedPaymentMethod === FiatPaymentMethod.INSTANT
-      ? c.instantSellable
-      : c.sellable,
-  );
+  const availableCurrencies = currencies?.filter((c) => c.sellable);
 
   useEffect(() => {
     const activeBlockchain = walletBlockchain ?? blockchain;
@@ -532,13 +523,6 @@ export default function BuyScreen(): JSX.Element {
 
     data && setValidatedData({ ...data, sideToUpdate });
   }
-
-  // name edited
-  useEffect(() => {
-    if (showsNameForm && paymentInfo?.isValid) {
-      openPaymentLink();
-    }
-  }, [showsNameForm, paymentInfo?.isValid]);
 
   const hasCompleteSpendSide = Boolean(selectedAmount && selectedCurrency && selectedPaymentMethod);
   const hasCompleteGetSide = Boolean(selectedTargetAmount && selectedAsset);
@@ -1032,21 +1016,6 @@ export default function BuyScreen(): JSX.Element {
       });
   }
 
-  function onCardBuy(info: Buy) {
-    if (info.error === TransactionError.NAME_REQUIRED) {
-      setShowsNameForm(true);
-    } else {
-      openPaymentLink();
-    }
-  }
-
-  function openPaymentLink() {
-    if (!paymentInfo?.paymentLink) return;
-
-    setIsContinue(true);
-    window.location.href = paymentInfo.paymentLink;
-  }
-
   function onCreatePersonalIban() {
     if (!selectedCurrency) return;
     navigate({ pathname: '/buy/personal-iban', search: `?currency=${selectedCurrency.name}` }, { setRedirect: true });
@@ -1085,7 +1054,6 @@ export default function BuyScreen(): JSX.Element {
   useLayoutOptions({
     title,
     backButton: !showsActiveCompletion,
-    onBack: showsNameForm ? () => setShowsNameForm(false) : undefined,
     textStart: true,
   });
 
@@ -1142,8 +1110,6 @@ export default function BuyScreen(): JSX.Element {
           paymentInfo={activeCompletedPaymentInfo}
           navigateOnClose
         />
-      ) : showsNameForm ? (
-        <NameEdit onSuccess={() => updateData(Side.GET)} />
       ) : (
         <Form control={control} rules={rules} errors={{}} onSubmit={handleSubmit(onSubmit)} translate={translateError}>
           <StyledVerticalStack gap={8} full center>
@@ -1311,110 +1277,84 @@ export default function BuyScreen(): JSX.Element {
                             type={TransactionType.BUY}
                           />
 
-                          {selectedPaymentMethod !== FiatPaymentMethod.CARD ? (
-                            <>
-                              <div>
-                                <PaymentInformationContent
-                                  info={paymentInfo}
-                                  showBank={showBank}
-                                  personalIbanProviderSwitch={
-                                    switchTarget === undefined
-                                      ? undefined
-                                      : {
-                                          target: switchTarget,
-                                          onSwitch: onSwitchPersonalIbanProvider,
-                                        }
-                                  }
-                                />
-                              </div>
-                              <SanctionHint />
-                              {activeFrickKycFallbackHint && (
+                          <div>
+                            <PaymentInformationContent
+                              info={paymentInfo}
+                              showBank={showBank}
+                              personalIbanProviderSwitch={
+                                switchTarget === undefined
+                                  ? undefined
+                                  : {
+                                      target: switchTarget,
+                                      onSwitch: onSwitchPersonalIbanProvider,
+                                    }
+                              }
+                            />
+                          </div>
+                          <SanctionHint />
+                          {activeFrickKycFallbackHint && (
+                            <StyledInfoText iconColor={IconColor.BLUE}>
+                              {translate(
+                                'screens/payment',
+                                'Your new Bank Frick IBAN requires KYC level 50 - we are showing your existing IBAN instead.',
+                              )}
+                            </StyledInfoText>
+                          )}
+                          {effectivePersonalIban !== undefined &&
+                            paymentInfoPaymentMethod !== undefined &&
+                            !isPersonalIbanApplicable(
+                              paymentInfo.currency.name,
+                              paymentInfoPaymentMethod,
+                            ) && (
+                              <StyledInfoText iconColor={IconColor.BLUE}>
+                                {translate(
+                                  'screens/payment',
+                                  'Your requested personal IBAN is only available for EUR and CHF bank transfers, so it was not used for this offer.',
+                                )}
+                              </StyledInfoText>
+                            )}
+                          {!paymentInfo.isPersonalIban &&
+                            (selectedCurrency?.name === undefined ||
+                              !FRICK_CURRENCIES.includes(selectedCurrency.name)) &&
+                            effectivePersonalIban === undefined && (
+                              <StyledVerticalStack gap={4}>
+                                <h2 className="text-dfxBlue-800 text-center">
+                                  {translate('screens/payment', 'New: Personal IBAN in your own name!')}
+                                </h2>
                                 <StyledInfoText iconColor={IconColor.BLUE}>
                                   {translate(
                                     'screens/payment',
-                                    'Your new Bank Frick IBAN requires KYC level 50 - we are showing your existing IBAN instead.',
+                                    'Personal IBANs are in your own name, which means you make the transfer to yourself instead of DFX AG. Such transactions are often processed faster and more reliably by banks.',
                                   )}
                                 </StyledInfoText>
+                                <StyledButton
+                                  width={StyledButtonWidth.FULL}
+                                  label={translate('screens/payment', 'Generate personal IBAN')}
+                                  onClick={onCreatePersonalIban}
+                                  color={StyledButtonColor.STURDY_WHITE}
+                                />
+                              </StyledVerticalStack>
+                            )}
+                          <div className="w-full leading-none">
+                            <StyledLink
+                              label={translate(
+                                'screens/payment',
+                                'Please note that by using this service you automatically accept our terms and conditions. The effective exchange rate is fixed when the money is received and processed by DFX.',
                               )}
-                              {effectivePersonalIban !== undefined &&
-                                paymentInfoPaymentMethod !== undefined &&
-                                !isPersonalIbanApplicable(
-                                  paymentInfo.currency.name,
-                                  paymentInfoPaymentMethod,
-                                ) && (
-                                  <StyledInfoText iconColor={IconColor.BLUE}>
-                                    {translate(
-                                      'screens/payment',
-                                      'Your requested personal IBAN is only available for EUR and CHF bank transfers, so it was not used for this offer.',
-                                    )}
-                                  </StyledInfoText>
-                                )}
-                              {!paymentInfo.isPersonalIban &&
-                                (selectedCurrency?.name === undefined ||
-                                  !FRICK_CURRENCIES.includes(selectedCurrency.name)) &&
-                                effectivePersonalIban === undefined && (
-                                  <StyledVerticalStack gap={4}>
-                                    <h2 className="text-dfxBlue-800 text-center">
-                                      {translate('screens/payment', 'New: Personal IBAN in your own name!')}
-                                    </h2>
-                                    <StyledInfoText iconColor={IconColor.BLUE}>
-                                      {translate(
-                                        'screens/payment',
-                                        'Personal IBANs are in your own name, which means you make the transfer to yourself instead of DFX AG. Such transactions are often processed faster and more reliably by banks.',
-                                      )}
-                                    </StyledInfoText>
-                                    <StyledButton
-                                      width={StyledButtonWidth.FULL}
-                                      label={translate('screens/payment', 'Generate personal IBAN')}
-                                      onClick={onCreatePersonalIban}
-                                      color={StyledButtonColor.STURDY_WHITE}
-                                    />
-                                  </StyledVerticalStack>
-                                )}
-                              <div className="w-full leading-none">
-                                <StyledLink
-                                  label={translate(
-                                    'screens/payment',
-                                    'Please note that by using this service you automatically accept our terms and conditions. The effective exchange rate is fixed when the money is received and processed by DFX.',
-                                  )}
-                                  url={Urls.termsAndConditions}
-                                  small
-                                  dark
-                                />
-                                <StyledButton
-                                  width={StyledButtonWidth.FULL}
-                                  label={translate('screens/buy', 'Click here once you have issued the transfer')}
-                                  onClick={() => confirm(paymentInfo.id)}
-                                  disabled={!isQuoteFinal}
-                                  isLoading={isConfirming}
-                                  caps={false}
-                                  className="mt-4"
-                                />
-                              </div>
-                            </>
-                          ) : (
-                            <>
-                              <SanctionHint />
-                              <div className="leading-none">
-                                <StyledLink
-                                  label={translate(
-                                    'screens/payment',
-                                    'Please note that by using this service you automatically accept our terms and conditions and authorize DFX.swiss to collect the above amount via your chosen payment method and agree that this amount cannot be canceled, recalled or refunded.',
-                                  )}
-                                  url={Urls.termsAndConditions}
-                                  small
-                                  dark
-                                />
-                                <StyledButton
-                                  width={StyledButtonWidth.FULL}
-                                  label={translate('general/actions', 'Next')}
-                                  onClick={() => onCardBuy(paymentInfo)}
-                                  isLoading={isContinue}
-                                  className="mt-4"
-                                />
-                              </div>
-                            </>
-                          )}
+                              url={Urls.termsAndConditions}
+                              small
+                              dark
+                            />
+                            <StyledButton
+                              width={StyledButtonWidth.FULL}
+                              label={translate('screens/buy', 'Click here once you have issued the transfer')}
+                              onClick={() => confirm(paymentInfo.id)}
+                              disabled={!isQuoteFinal}
+                              isLoading={isConfirming}
+                              caps={false}
+                              className="mt-4"
+                            />
+                          </div>
                         </>
                       ))}
                   </>

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -516,7 +516,7 @@ export default function BuyScreen(): JSX.Element {
       paymentMethod: selectedPaymentMethod,
     });
 
-    data && setValidatedData({ ...data, sideToUpdate });
+    setValidatedData(data ? { ...data, sideToUpdate } : undefined);
   }
 
   const hasCompleteSpendSide = Boolean(selectedAmount && selectedCurrency && selectedPaymentMethod);

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -368,7 +368,7 @@ export default function BuyScreen(): JSX.Element {
       getCurrency(availableCurrencies, prefCurrency?.name) ??
       getDefaultCurrency(availableCurrencies);
     if (prefCurrency && currency) setVal('currency', currency);
-  }, [assetIn, getCurrency, prefCurrency, currencies, selectedPaymentMethod]);
+  }, [assetIn, getCurrency, prefCurrency, currencies]);
 
   useEffect(() => {
     const selectedMethod =
@@ -465,6 +465,7 @@ export default function BuyScreen(): JSX.Element {
       } else if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
         // the user is retyping — never refill the emptied field from the opposite side
         setValidatedData(undefined);
+        setIsLoading(undefined);
       } else if (hasGetData) {
         updateData(Side.SPEND);
       }
@@ -495,6 +496,7 @@ export default function BuyScreen(): JSX.Element {
       } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
         // the user is retyping — never refill the emptied field from the opposite side
         setValidatedData(undefined);
+        setIsLoading(undefined);
       } else if (hasSpendData) {
         updateData(Side.GET);
       }
@@ -582,7 +584,9 @@ export default function BuyScreen(): JSX.Element {
     setPaymentInfoState(undefined);
     setIsConfirming(false);
     setContinueWithoutPersonalIban(undefined);
-    if (!hasCompleteSpendSide && !hasCompleteGetSide) {
+    if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
+      setIsLoading(undefined);
+    } else if (!hasCompleteSpendSide && !hasCompleteGetSide) {
       setValidatedData(undefined);
       setIsLoading(undefined);
     } else {

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -346,16 +346,6 @@ export default function BuyScreen(): JSX.Element {
       : [];
   const availablePaymentMethods = [FiatPaymentMethod.BANK];
 
-  // no instant payments ATM
-  // (!selectedAsset || selectedAsset.instantBuyable) && availablePaymentMethods.push(FiatPaymentMethod.INSTANT);
-
-  // Credit card payments disabled
-  // (isDfxHosted || !isEmbedded) &&
-  //   wallet !== EmbeddedWallet &&
-  //   user?.activeAddress?.wallet !== EmbeddedWallet &&
-  //   (!selectedAsset || selectedAsset?.cardBuyable) &&
-  //   availablePaymentMethods.push(FiatPaymentMethod.CARD);
-
   const availableCurrencies = currencies?.filter((c) => c.sellable);
 
   useEffect(() => {

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -754,8 +754,7 @@ export default function BuyScreen(): JSX.Element {
       })
       .then((info) => {
         if (!isRunning || !info) return;
-        if (debouncedValidatedData.sideToUpdate === Side.SPEND && spendClearedByUserRef.current) return;
-        if (debouncedValidatedData.sideToUpdate === Side.GET && targetClearedByUserRef.current) return;
+        if (spendClearedByUserRef.current || targetClearedByUserRef.current) return;
         if (generation !== quoteGeneration.current || customerIdentityRef.current !== loadingCustomerIdentity) return;
         const synchronizedAmount =
           debouncedValidatedData.sideToUpdate === Side.SPEND
@@ -955,7 +954,6 @@ export default function BuyScreen(): JSX.Element {
       errorMessage ||
       customAmountError ||
       needsPersonalIbanAcknowledgement ||
-      !isQuoteFinal ||
       isConfirming
     ) {
       return;
@@ -1372,7 +1370,7 @@ export default function BuyScreen(): JSX.Element {
                             <StyledButton
                               width={StyledButtonWidth.FULL}
                               label={translate('screens/buy', 'Click here once you have issued the transfer')}
-                              onClick={() => confirm(paymentInfo.id)}
+                              onClick={() => onSubmit()}
                               disabled={!isQuoteFinal}
                               isLoading={isConfirming}
                               caps={false}

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -1121,7 +1121,15 @@ export default function BuyScreen(): JSX.Element {
           navigateOnClose
         />
       ) : (
-        <Form control={control} rules={rules} errors={{}} onSubmit={handleSubmit(onSubmit)} translate={translateError}>
+        <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
+        <Form
+          control={control}
+          rules={rules}
+          errors={{}}
+          onSubmit={handleSubmit(onSubmit)}
+          translate={translateError}
+          hasFormElement={false}
+        >
           <StyledVerticalStack gap={8} full center>
             {availableCurrencies && availableAssets && (
               <>
@@ -1373,6 +1381,7 @@ export default function BuyScreen(): JSX.Element {
             )}
           </StyledVerticalStack>
         </Form>
+        </form>
       )}
     </>
   );

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -302,6 +302,12 @@ export default function BuyScreen(): JSX.Element {
   const activePaymentInfoIdRef = useRef<number>();
   activePaymentInfoIdRef.current = paymentInfo?.id;
   const isMountedRef = useRef(true);
+  // A non-empty → empty transition of an amount field is an edit in progress: the cross-side
+  // fallbacks below must not recompute into a field the user just emptied to retype — the
+  // exact-price echo would overwrite their input mid-typing. A field that was never set (deep
+  // links, first render) still resolves over the fallbacks.
+  const previousAmountRef = useRef<string>();
+  const previousTargetAmountRef = useRef<string>();
 
   const effectivePersonalIban = activeSuppressPersonalIban ? undefined : personalIban;
   const personalIbanSelector = activeSuppressPersonalIban
@@ -444,6 +450,9 @@ export default function BuyScreen(): JSX.Element {
 
   // SPEND data changed
   useEffect(() => {
+    const amountCleared = !selectedAmount && !!previousAmountRef.current;
+    previousAmountRef.current = selectedAmount;
+
     const requiresUpdate =
       selectedAmount !== paymentInfo?.amount?.toString() ||
       selectedCurrency?.name !== paymentInfo?.currency.name ||
@@ -455,6 +464,9 @@ export default function BuyScreen(): JSX.Element {
     if (requiresUpdate) {
       if (hasSpendData) {
         updateData(Side.GET);
+      } else if (amountCleared) {
+        // the user is retyping the amount — never refill the field from the target side
+        setValidatedData(undefined);
       } else if (hasGetData) {
         updateData(Side.SPEND);
       }
@@ -463,6 +475,9 @@ export default function BuyScreen(): JSX.Element {
 
   // GET data changed
   useEffect(() => {
+    const targetAmountCleared = !selectedTargetAmount && !!previousTargetAmountRef.current;
+    previousTargetAmountRef.current = selectedTargetAmount;
+
     const isSameTargetAmount = selectedTargetAmount === paymentInfo?.estimatedAmount?.toString();
     const requiresUpdate = !isSameTargetAmount || selectedAsset?.uniqueName !== paymentInfo?.asset?.uniqueName;
 
@@ -472,6 +487,9 @@ export default function BuyScreen(): JSX.Element {
     if (requiresUpdate) {
       if (hasGetData) {
         updateData(Side.SPEND);
+      } else if (targetAmountCleared) {
+        // the user is retyping the target amount — never refill the field from the spend side
+        setValidatedData(undefined);
       } else if (hasSpendData) {
         updateData(Side.GET);
       }

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -400,9 +400,9 @@ export default function BuyScreen(): JSX.Element {
   }, [availablePaymentMethods, paymentMethod]);
 
   useEffect(() => {
-    if (amountIn) {
+    if (amountIn && !spendClearedByUserRef.current) {
       setVal('amount', amountIn);
-    } else if (amountOut) {
+    } else if (amountOut && !targetClearedByUserRef.current) {
       setVal('targetAmount', amountOut);
     } else if (
       selectedAsset &&
@@ -461,6 +461,11 @@ export default function BuyScreen(): JSX.Element {
   useEffect(() => {
     if (selectedAmount) {
       spendClearedByUserRef.current = false;
+      // A newly typed spend amount starts a spend-side quote. Exact-price echo must not
+      // look like typing: it sets pendingFormSynchronization before writing the field.
+      if (selectedAmount !== previousAmountRef.current && pendingFormSynchronization.current == null) {
+        targetClearedByUserRef.current = false;
+      }
     } else if (previousAmountRef.current) {
       spendClearedByUserRef.current = true;
     }
@@ -490,6 +495,9 @@ export default function BuyScreen(): JSX.Element {
   useEffect(() => {
     if (selectedTargetAmount) {
       targetClearedByUserRef.current = false;
+      if (selectedTargetAmount !== previousTargetAmountRef.current && pendingFormSynchronization.current == null) {
+        spendClearedByUserRef.current = false;
+      }
     } else if (previousTargetAmountRef.current) {
       targetClearedByUserRef.current = true;
     }

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -302,12 +302,14 @@ export default function BuyScreen(): JSX.Element {
   const activePaymentInfoIdRef = useRef<number>();
   activePaymentInfoIdRef.current = paymentInfo?.id;
   const isMountedRef = useRef(true);
-  // A non-empty → empty transition of an amount field is an edit in progress: the cross-side
-  // fallbacks below must not recompute into a field the user just emptied to retype — the
-  // exact-price echo would overwrite their input mid-typing. A field that was never set (deep
-  // links, first render) still resolves over the fallbacks.
+  // A field the user emptied stays an edit in progress until they type again. The one-frame
+  // non-empty → empty edge is not enough: a later currency/asset effect would otherwise take
+  // the cross-side fallback and the exact-price echo would write back into the empty field.
+  // Never-set fields (deep links, first render) still resolve over the fallbacks.
   const previousAmountRef = useRef<string>();
   const previousTargetAmountRef = useRef<string>();
+  const spendClearedByUserRef = useRef(false);
+  const targetClearedByUserRef = useRef(false);
 
   const effectivePersonalIban = activeSuppressPersonalIban ? undefined : personalIban;
   const personalIbanSelector = activeSuppressPersonalIban
@@ -402,8 +404,15 @@ export default function BuyScreen(): JSX.Element {
       setVal('amount', amountIn);
     } else if (amountOut) {
       setVal('targetAmount', amountOut);
-    } else if (selectedAsset && !selectedAmount && !selectedTargetAmount) {
-      // Always set amount (input field) - backend calculates targetAmount
+    } else if (
+      selectedAsset &&
+      !selectedAmount &&
+      !selectedTargetAmount &&
+      !spendClearedByUserRef.current &&
+      !targetClearedByUserRef.current
+    ) {
+      // Always set amount (input field) - backend calculates targetAmount.
+      // Do not restore the default into a field the user just emptied.
       setVal('amount', '300');
     }
   }, [amountIn, amountOut, selectedAsset]);
@@ -450,7 +459,11 @@ export default function BuyScreen(): JSX.Element {
 
   // SPEND data changed
   useEffect(() => {
-    const amountCleared = !selectedAmount && !!previousAmountRef.current;
+    if (selectedAmount) {
+      spendClearedByUserRef.current = false;
+    } else if (previousAmountRef.current) {
+      spendClearedByUserRef.current = true;
+    }
     previousAmountRef.current = selectedAmount;
 
     const requiresUpdate =
@@ -462,10 +475,10 @@ export default function BuyScreen(): JSX.Element {
     const hasGetData = selectedTargetAmount && selectedAsset;
 
     if (requiresUpdate) {
-      if (hasSpendData) {
+      if (hasSpendData && !targetClearedByUserRef.current) {
         updateData(Side.GET);
-      } else if (amountCleared) {
-        // the user is retyping the amount — never refill the field from the target side
+      } else if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
+        // the user is retyping — never refill the emptied field from the opposite side
         setValidatedData(undefined);
       } else if (hasGetData) {
         updateData(Side.SPEND);
@@ -475,7 +488,11 @@ export default function BuyScreen(): JSX.Element {
 
   // GET data changed
   useEffect(() => {
-    const targetAmountCleared = !selectedTargetAmount && !!previousTargetAmountRef.current;
+    if (selectedTargetAmount) {
+      targetClearedByUserRef.current = false;
+    } else if (previousTargetAmountRef.current) {
+      targetClearedByUserRef.current = true;
+    }
     previousTargetAmountRef.current = selectedTargetAmount;
 
     const isSameTargetAmount = selectedTargetAmount === paymentInfo?.estimatedAmount?.toString();
@@ -485,10 +502,10 @@ export default function BuyScreen(): JSX.Element {
     const hasGetData = selectedTargetAmount && selectedAsset;
 
     if (requiresUpdate) {
-      if (hasGetData) {
+      if (hasGetData && !spendClearedByUserRef.current) {
         updateData(Side.SPEND);
-      } else if (targetAmountCleared) {
-        // the user is retyping the target amount — never refill the field from the spend side
+      } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
+        // the user is retyping — never refill the emptied field from the opposite side
         setValidatedData(undefined);
       } else if (hasSpendData) {
         updateData(Side.GET);
@@ -762,9 +779,11 @@ export default function BuyScreen(): JSX.Element {
           personalIbanProvider: data.personalIbanProvider,
           customerIdentity: loadingCustomerIdentity,
         });
-        debouncedValidatedData.sideToUpdate === Side.SPEND
-          ? setVal('amount', info.amount.toString())
-          : setVal('targetAmount', info.estimatedAmount.toString());
+        if (debouncedValidatedData.sideToUpdate === Side.SPEND) {
+          if (!spendClearedByUserRef.current) setVal('amount', info.amount.toString());
+        } else if (!targetClearedByUserRef.current) {
+          setVal('targetAmount', info.estimatedAmount.toString());
+        }
         setPaymentInfoState({
           info,
           paymentMethod: data.paymentMethod,

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -322,6 +322,10 @@ export default function BuyScreen(): JSX.Element {
   const selectedPaymentMethod = useWatch({ control, name: 'paymentMethod' });
   const selectedAddress = useWatch({ control, name: 'address' });
 
+  // Same-turn clear+resolveExact: the amount effect has not run yet, so latch here.
+  if (!selectedAmount && previousAmountRef.current) spendClearedByUserRef.current = true;
+  if (!selectedTargetAmount && previousTargetAmountRef.current) targetClearedByUserRef.current = true;
+
   function setVal(field: FieldPath<FormData>, value: FieldPathValue<FormData, FieldPath<FormData>>) {
     setValue(field, value, { shouldValidate: true });
   }
@@ -749,13 +753,10 @@ export default function BuyScreen(): JSX.Element {
         return receiveFor({ ...data, exactPrice: true });
       })
       .then((info) => {
-        if (
-          !isRunning ||
-          generation !== quoteGeneration.current ||
-          customerIdentityRef.current !== loadingCustomerIdentity ||
-          !info
-        )
-          return;
+        if (!isRunning || !info) return;
+        if (debouncedValidatedData.sideToUpdate === Side.SPEND && spendClearedByUserRef.current) return;
+        if (debouncedValidatedData.sideToUpdate === Side.GET && targetClearedByUserRef.current) return;
+        if (generation !== quoteGeneration.current || customerIdentityRef.current !== loadingCustomerIdentity) return;
         const synchronizedAmount =
           debouncedValidatedData.sideToUpdate === Side.SPEND
             ? info.amount.toString()

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -291,7 +291,6 @@ export default function BuyScreen(): JSX.Element {
   // Live-input generation: bumps immediately when form inputs or selector change so stale
   // debounced responses and confirm actions never commit against a newer form state (B4).
   const quoteGeneration = useRef(0);
-  const committedQuoteGeneration = useRef(0);
   const lastQuoteRequestSignature = useRef<string>();
   const pendingFormSynchronization = useRef<string>();
   const customerIdentityRef = useRef(customerIdentity);
@@ -723,8 +722,6 @@ export default function BuyScreen(): JSX.Element {
           identity: loadingCustomerIdentity,
           isFinalQuote: false,
         });
-        committedQuoteGeneration.current = generation;
-
         return receiveFor({ ...data, exactPrice: true });
       })
       .then((info) => {
@@ -764,7 +761,6 @@ export default function BuyScreen(): JSX.Element {
           identity: loadingCustomerIdentity,
           isFinalQuote: true,
         });
-        committedQuoteGeneration.current = generation;
       })
       .catch((error: ApiError) => {
         if (

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -947,7 +947,7 @@ export default function BuyScreen(): JSX.Element {
     return assets.filter((a) => allowedAssets.some((f) => isSameAsset(a, f)));
   }
 
-  function onSubmit(_data: FormData) {
+  function onSubmit(_data?: FormData) {
     if (spendClearedByUserRef.current || targetClearedByUserRef.current) return;
     if (
       !paymentInfo ||
@@ -1121,7 +1121,13 @@ export default function BuyScreen(): JSX.Element {
           navigateOnClose
         />
       ) : (
-        <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
+        <form
+          className="w-full"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmit();
+          }}
+        >
         <Form
           control={control}
           rules={rules}

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -948,7 +948,20 @@ export default function BuyScreen(): JSX.Element {
   }
 
   function onSubmit(_data: FormData) {
-    return;
+    if (spendClearedByUserRef.current || targetClearedByUserRef.current) return;
+    if (
+      !paymentInfo ||
+      kycError ||
+      errorMessage ||
+      customAmountError ||
+      needsPersonalIbanAcknowledgement ||
+      !isQuoteFinal ||
+      isConfirming
+    ) {
+      return;
+    }
+    if (selectedAsset?.category === AssetCategory.PRIVATE && !flags?.includes('private')) return;
+    confirm(paymentInfo.id);
   }
 
   function setAddress() {

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -381,10 +381,10 @@ export default function BuyScreen(): JSX.Element {
   }, [availablePaymentMethods, paymentMethod]);
 
   useEffect(() => {
-    if (amountIn && !spendClearedByUserRef.current) {
-      setVal('amount', amountIn);
-    } else if (amountOut && !targetClearedByUserRef.current) {
-      setVal('targetAmount', amountOut);
+    if (amountIn) {
+      if (!spendClearedByUserRef.current) setVal('amount', amountIn);
+    } else if (amountOut) {
+      if (!targetClearedByUserRef.current) setVal('targetAmount', amountOut);
     } else if (
       selectedAsset &&
       !selectedAmount &&

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -344,25 +344,17 @@ export default function SellScreen(): JSX.Element {
     setIsLoading(validatedData.sideToUpdate);
     receiveFor(data)
       .then((sell) => {
-        if (isRunning) {
-          validateSell(sell);
-          setPaymentInfo(sell);
-
-          // load exact price
-          if (sell) {
-            return receiveFor({ ...data, exactPrice: true });
-          }
-        }
+        if (!isRunning || !sell) return;
+        validateSell(sell);
+        setPaymentInfo(sell);
+        return receiveFor({ ...data, exactPrice: true });
       })
       .then((info) => {
         if (isRunning && info) {
+          isExactPriceWriteRef.current = true;
           if (validatedData.sideToUpdate === Side.SPEND) {
-            if (!spendClearedByUserRef.current) {
-              isExactPriceWriteRef.current = true;
-              setVal('amount', info.amount.toString());
-            }
-          } else if (!targetClearedByUserRef.current) {
-            isExactPriceWriteRef.current = true;
+            setVal('amount', info.amount.toString());
+          } else {
             setVal('targetAmount', info.estimatedAmount.toString());
           }
           setPaymentInfo(info);
@@ -459,7 +451,7 @@ export default function SellScreen(): JSX.Element {
     asset,
     targetAmount: targetAmountStr,
     bankAccount,
-  }: Partial<FormData> = {}): SellPaymentInfo | undefined {
+  }: Partial<FormData>): SellPaymentInfo | undefined {
     const amount = Number(amountStr);
     const targetAmount = Number(targetAmountStr);
     if (asset != null && currency != null && bankAccount != null) {
@@ -509,7 +501,7 @@ export default function SellScreen(): JSX.Element {
   }
 
   function onSubmit(_data: FormData) {
-    // TODO: (Krysh fix broken form validation and onSubmit
+    return;
   }
 
   function setAddress() {

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -225,6 +225,7 @@ export default function SellScreen(): JSX.Element {
     } else if (
       selectedAsset &&
       !enteredAmount &&
+      !selectedTargetAmount &&
       !spendClearedByUserRef.current &&
       !targetClearedByUserRef.current
     ) {

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -391,8 +391,7 @@ export default function SellScreen(): JSX.Element {
       })
       .then((info) => {
         if (!isRunning || !info) return;
-        if (validatedData.sideToUpdate === Side.SPEND && spendClearedByUserRef.current) return;
-        if (validatedData.sideToUpdate === Side.GET && targetClearedByUserRef.current) return;
+        if (spendClearedByUserRef.current || targetClearedByUserRef.current) return;
         if (generation !== quoteGeneration.current) return;
         if (validatedData.sideToUpdate === Side.SPEND) {
           const nextAmount = info.amount.toString();
@@ -809,7 +808,7 @@ export default function SellScreen(): JSX.Element {
                                 ? 'Complete transaction in your wallet'
                                 : 'Click here once you have issued the transaction',
                             )}
-                            onClick={() => handleNext(paymentInfo)}
+                            onClick={() => onSubmit()}
                             caps={false}
                             className="mt-4"
                             isLoading={isProcessing}

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -374,7 +374,7 @@ export default function SellScreen(): JSX.Element {
       bankAccount: selectedBankAccount,
     });
 
-    data && setValidatedData({ ...data, sideToUpdate });
+    setValidatedData(data ? { ...data, sideToUpdate } : undefined);
   }
 
   useEffect(() => {

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -621,6 +621,7 @@ export default function SellScreen(): JSX.Element {
       ) : paymentInfo && isTxDone ? (
         <SellCompletion paymentInfo={paymentInfo} navigateOnClose={true} txId={sellTxId} />
       ) : (
+        <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
         <Form
           control={control}
           rules={rules}
@@ -815,6 +816,7 @@ export default function SellScreen(): JSX.Element {
             </StyledVerticalStack>
           )}
         </Form>
+        </form>
       )}
     </>
   );

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -285,6 +285,10 @@ export default function SellScreen(): JSX.Element {
       } else if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
         setValidatedData(undefined);
         setPaymentInfo(undefined);
+        setKycError(undefined);
+        setErrorMessage(undefined);
+        setCustomAmountError(undefined);
+        setIsLoading(undefined);
       } else if (hasGetData) {
         updateData(Side.SPEND);
       }
@@ -323,6 +327,10 @@ export default function SellScreen(): JSX.Element {
       } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
         setValidatedData(undefined);
         setPaymentInfo(undefined);
+        setKycError(undefined);
+        setErrorMessage(undefined);
+        setCustomAmountError(undefined);
+        setIsLoading(undefined);
       } else if (hasSpendData) {
         updateData(Side.GET);
       }
@@ -345,6 +353,7 @@ export default function SellScreen(): JSX.Element {
     let isRunning = true;
 
     setErrorMessage(undefined);
+    setKycError(undefined);
     setPaymentInfo(undefined);
     setIsLoading(undefined);
 

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -157,6 +157,12 @@ export default function SellScreen(): JSX.Element {
   const targetClearedByUserRef = useRef(false);
   const isExactPriceWriteRef = useRef(false);
   const quoteGeneration = useRef(0);
+  const enteredAmountLiveRef = useRef(enteredAmount);
+  const selectedTargetAmountLiveRef = useRef(selectedTargetAmount);
+  enteredAmountLiveRef.current = enteredAmount;
+  selectedTargetAmountLiveRef.current = selectedTargetAmount;
+  if (!enteredAmount && previousAmountRef.current) spendClearedByUserRef.current = true;
+  if (!selectedTargetAmount && previousTargetAmountRef.current) targetClearedByUserRef.current = true;
 
   const availableBalance = selectedAsset && findBalance(selectedAsset);
 
@@ -245,9 +251,10 @@ export default function SellScreen(): JSX.Element {
   }, [selectedAddress]);
 
   useEffect(() => {
-    if (selectedBankAccount && selectedBankAccount.preferredCurrency)
-      setVal('currency', selectedBankAccount.preferredCurrency);
-  }, [selectedBankAccount]);
+    if (!selectedBankAccount?.preferredCurrency) return;
+    const currency = getCurrency(sellableCurrencies, selectedBankAccount.preferredCurrency.name);
+    if (currency) setVal('currency', currency);
+  }, [selectedBankAccount, sellableCurrencies, getCurrency]);
 
   useEffect(() => {
     if (!enteredAmount) {
@@ -383,10 +390,13 @@ export default function SellScreen(): JSX.Element {
         return receiveFor({ ...data, exactPrice: true });
       })
       .then((info) => {
-        if (!isRunning || !info || generation !== quoteGeneration.current) return;
+        if (!isRunning || !info) return;
+        if (validatedData.sideToUpdate === Side.SPEND && spendClearedByUserRef.current) return;
+        if (validatedData.sideToUpdate === Side.GET && targetClearedByUserRef.current) return;
+        if (generation !== quoteGeneration.current) return;
         if (validatedData.sideToUpdate === Side.SPEND) {
           const nextAmount = info.amount.toString();
-          if (enteredAmount !== nextAmount) {
+          if (enteredAmountLiveRef.current !== nextAmount) {
             isExactPriceWriteRef.current = true;
             setVal('amount', nextAmount);
           } else {
@@ -394,7 +404,7 @@ export default function SellScreen(): JSX.Element {
           }
         } else {
           const nextTarget = info.estimatedAmount.toString();
-          if (selectedTargetAmount !== nextTarget) {
+          if (selectedTargetAmountLiveRef.current !== nextTarget) {
             isExactPriceWriteRef.current = true;
             setVal('targetAmount', nextTarget);
           } else {

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -154,6 +154,7 @@ export default function SellScreen(): JSX.Element {
   const previousTargetAmountRef = useRef<string>();
   const spendClearedByUserRef = useRef(false);
   const targetClearedByUserRef = useRef(false);
+  const isExactPriceWriteRef = useRef(false);
 
   const availableBalance = selectedAsset && findBalance(selectedAsset);
 
@@ -255,12 +256,16 @@ export default function SellScreen(): JSX.Element {
   // A field the user emptied stays an edit in progress until they type again.
   // SPEND data changed
   useEffect(() => {
+    const exactPriceWrite = isExactPriceWriteRef.current;
     if (enteredAmount) {
       spendClearedByUserRef.current = false;
-      if (!previousAmountRef.current) targetClearedByUserRef.current = false;
+      if (enteredAmount !== previousAmountRef.current && !exactPriceWrite) {
+        targetClearedByUserRef.current = false;
+      }
     } else if (previousAmountRef.current) {
       spendClearedByUserRef.current = true;
     }
+    if (enteredAmount !== previousAmountRef.current) isExactPriceWriteRef.current = false;
     previousAmountRef.current = enteredAmount;
 
     const requiresUpdate =
@@ -282,12 +287,16 @@ export default function SellScreen(): JSX.Element {
 
   // GET data changed
   useEffect(() => {
+    const exactPriceWrite = isExactPriceWriteRef.current;
     if (selectedTargetAmount) {
       targetClearedByUserRef.current = false;
-      if (!previousTargetAmountRef.current) spendClearedByUserRef.current = false;
+      if (selectedTargetAmount !== previousTargetAmountRef.current && !exactPriceWrite) {
+        spendClearedByUserRef.current = false;
+      }
     } else if (previousTargetAmountRef.current) {
       targetClearedByUserRef.current = true;
     }
+    if (selectedTargetAmount !== previousTargetAmountRef.current) isExactPriceWriteRef.current = false;
     previousTargetAmountRef.current = selectedTargetAmount;
 
     const requiresUpdate =
@@ -299,12 +308,12 @@ export default function SellScreen(): JSX.Element {
     const hasGetData = selectedTargetAmount && selectedCurrency && selectedBankAccount;
 
     if (requiresUpdate) {
-      if (hasGetData) {
+      if (hasGetData && !spendClearedByUserRef.current) {
         updateData(Side.SPEND);
-      } else if (hasSpendData && !targetClearedByUserRef.current) {
-        updateData(Side.GET);
       } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
         setValidatedData(undefined);
+      } else if (hasSpendData) {
+        updateData(Side.GET);
       }
     }
   }, [selectedTargetAmount, selectedCurrency, selectedBankAccount]);
@@ -348,8 +357,12 @@ export default function SellScreen(): JSX.Element {
       .then((info) => {
         if (isRunning && info) {
           if (validatedData.sideToUpdate === Side.SPEND) {
-            if (!spendClearedByUserRef.current) setVal('amount', info.amount.toString());
+            if (!spendClearedByUserRef.current) {
+              isExactPriceWriteRef.current = true;
+              setVal('amount', info.amount.toString());
+            }
           } else if (!targetClearedByUserRef.current) {
+            isExactPriceWriteRef.current = true;
             setVal('targetAmount', info.estimatedAmount.toString());
           }
           setPaymentInfo(info);

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -577,14 +577,14 @@ export default function SellScreen(): JSX.Element {
     setIsProcessing(true);
     setErrorMessage(undefined);
 
-    await updateBankAccount();
-
-    if (canSendTransaction() && !activeWallet) {
-      closeServices({ type: CloseType.SELL, isComplete: false, sell: paymentInfo }, false);
-      return;
-    }
-
     try {
+      await updateBankAccount();
+
+      if (canSendTransaction() && !activeWallet) {
+        closeServices({ type: CloseType.SELL, isComplete: false, sell: paymentInfo }, false);
+        return;
+      }
+
       if (canSendTransaction()) {
         await sendTransaction(paymentInfo).then(setSellTxId);
       }

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -140,6 +140,7 @@ export default function SellScreen(): JSX.Element {
   const [bankAccountSelection, setBankAccountSelection] = useState(false);
   const [showsSwitchScreen, setShowsSwitchScreen] = useState(false);
   const [validatedData, setValidatedData] = useState<ValidatedData>();
+  const [retryToken, setRetryToken] = useState(0);
 
   // form
   const { control, handleSubmit, setValue, resetField } = useForm<FormData>({ mode: 'onTouched' });
@@ -433,7 +434,7 @@ export default function SellScreen(): JSX.Element {
     return () => {
       isRunning = false;
     };
-  }, [useDebounce(validatedData, 500)]);
+  }, [useDebounce(validatedData, 500), retryToken]);
 
   function validateSell(sell: Sell): void {
     setCustomAmountError(undefined);
@@ -755,7 +756,7 @@ export default function SellScreen(): JSX.Element {
                       <StyledButton
                         width={StyledButtonWidth.MIN}
                         label={translate('general/actions', 'Retry')}
-                        onClick={() => updateData(Side.GET)} // re-trigger
+                        onClick={() => setRetryToken((token) => token + 1)}
                         className="mt-4"
                         color={StyledButtonColor.STURDY_WHITE}
                       />

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -34,7 +34,7 @@ import {
   StyledSearchDropdown,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FieldPath, FieldPathValue, useForm, useWatch } from 'react-hook-form';
 import { BankAccountSelector } from 'src/components/order/bank-account-selector';
 import { AddressSwitch } from 'src/components/payment/address-switch';
@@ -243,8 +243,18 @@ export default function SellScreen(): JSX.Element {
     }
   }, [enteredAmount]);
 
+  // A non-empty → empty transition of an amount field is an edit in progress: the cross-side
+  // fallbacks below must not recompute into a field the user just emptied to retype — the
+  // exact-price echo would overwrite their input mid-typing. A field that was never set (deep
+  // links, first render) still resolves over the fallbacks.
+  const previousAmountRef = useRef<string>();
+  const previousTargetAmountRef = useRef<string>();
+
   // SPEND data changed
   useEffect(() => {
+    const amountCleared = !enteredAmount && !!previousAmountRef.current;
+    previousAmountRef.current = enteredAmount;
+
     const requiresUpdate =
       enteredAmount !== paymentInfo?.amount?.toString() || selectedAsset?.uniqueName !== paymentInfo?.asset.uniqueName;
 
@@ -254,16 +264,20 @@ export default function SellScreen(): JSX.Element {
     if (requiresUpdate) {
       if (hasSpendData) {
         updateData(Side.GET);
+      } else if (amountCleared) {
+        // the user is retyping the amount — never refill the field from the target side
+        setValidatedData(undefined);
       } else if (hasGetData) {
         updateData(Side.SPEND);
       }
     }
-
-    // requiresUpdate && updateData(Side.GET);
   }, [enteredAmount, selectedAsset]);
 
   // GET data changed
   useEffect(() => {
+    const targetAmountCleared = !selectedTargetAmount && !!previousTargetAmountRef.current;
+    previousTargetAmountRef.current = selectedTargetAmount;
+
     const requiresUpdate =
       selectedTargetAmount !== paymentInfo?.estimatedAmount?.toString() ||
       selectedCurrency?.name !== paymentInfo?.currency?.name ||
@@ -275,12 +289,13 @@ export default function SellScreen(): JSX.Element {
     if (requiresUpdate) {
       if (hasGetData) {
         updateData(Side.SPEND);
+      } else if (targetAmountCleared) {
+        // the user is retyping the target amount — never refill the field from the spend side
+        setValidatedData(undefined);
       } else if (hasSpendData) {
         updateData(Side.GET);
       }
     }
-
-    // requiresUpdate && updateData(isSameTargetAmount && enteredAmount ? Side.GET : Side.SPEND);
   }, [selectedTargetAmount, selectedCurrency, selectedBankAccount]);
 
   function updateData(sideToUpdate: Side) {

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -275,7 +275,10 @@ export default function SellScreen(): JSX.Element {
     const hasSpendData = enteredAmount && selectedAsset;
     const hasGetData = selectedTargetAmount && selectedCurrency && selectedBankAccount;
 
-    if (requiresUpdate && !exactPriceWrite) {
+    if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
+      quoteGeneration.current += 1;
+      isExactPriceWriteRef.current = false;
+    } else if (requiresUpdate && !exactPriceWrite) {
       quoteGeneration.current += 1;
     }
 
@@ -317,7 +320,10 @@ export default function SellScreen(): JSX.Element {
     const hasSpendData = enteredAmount && selectedAsset;
     const hasGetData = selectedTargetAmount && selectedCurrency && selectedBankAccount;
 
-    if (requiresUpdate && !exactPriceWrite) {
+    if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
+      quoteGeneration.current += 1;
+      isExactPriceWriteRef.current = false;
+    } else if (requiresUpdate && !exactPriceWrite) {
       quoteGeneration.current += 1;
     }
 

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -554,7 +554,7 @@ export default function SellScreen(): JSX.Element {
     return assets.filter((a) => allowedAssets.some((f) => isSameAsset(a, f)));
   }
 
-  function onSubmit(_data: FormData) {
+  function onSubmit(_data?: FormData) {
     if (spendClearedByUserRef.current || targetClearedByUserRef.current) return;
     if (!paymentInfo || kycError || errorMessage || customAmountError?.hideInfos || isProcessing) return;
     if (selectedAsset?.category === AssetCategory.PRIVATE && !flags?.includes('private')) return;
@@ -621,7 +621,13 @@ export default function SellScreen(): JSX.Element {
       ) : paymentInfo && isTxDone ? (
         <SellCompletion paymentInfo={paymentInfo} navigateOnClose={true} txId={sellTxId} />
       ) : (
-        <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
+        <form
+          className="w-full"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmit();
+          }}
+        >
         <Form
           control={control}
           rules={rules}

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -288,8 +288,11 @@ export default function SellScreen(): JSX.Element {
     if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
       quoteGeneration.current += 1;
       isExactPriceWriteRef.current = false;
+      setIsQuoteFinal(false);
     } else if (requiresUpdate && !exactPriceWrite) {
       quoteGeneration.current += 1;
+      setIsQuoteFinal(false);
+      setPaymentInfo(undefined);
     }
 
     if (requiresUpdate) {
@@ -333,8 +336,11 @@ export default function SellScreen(): JSX.Element {
     if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
       quoteGeneration.current += 1;
       isExactPriceWriteRef.current = false;
+      setIsQuoteFinal(false);
     } else if (requiresUpdate && !exactPriceWrite) {
       quoteGeneration.current += 1;
+      setIsQuoteFinal(false);
+      setPaymentInfo(undefined);
     }
 
     if (requiresUpdate) {

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -155,6 +155,7 @@ export default function SellScreen(): JSX.Element {
   const spendClearedByUserRef = useRef(false);
   const targetClearedByUserRef = useRef(false);
   const isExactPriceWriteRef = useRef(false);
+  const quoteGeneration = useRef(0);
 
   const availableBalance = selectedAsset && findBalance(selectedAsset);
 
@@ -274,11 +275,16 @@ export default function SellScreen(): JSX.Element {
     const hasSpendData = enteredAmount && selectedAsset;
     const hasGetData = selectedTargetAmount && selectedCurrency && selectedBankAccount;
 
+    if (requiresUpdate && !exactPriceWrite) {
+      quoteGeneration.current += 1;
+    }
+
     if (requiresUpdate) {
       if (hasSpendData && !targetClearedByUserRef.current) {
         updateData(Side.GET);
       } else if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
         setValidatedData(undefined);
+        setPaymentInfo(undefined);
       } else if (hasGetData) {
         updateData(Side.SPEND);
       }
@@ -307,11 +313,16 @@ export default function SellScreen(): JSX.Element {
     const hasSpendData = enteredAmount && selectedAsset;
     const hasGetData = selectedTargetAmount && selectedCurrency && selectedBankAccount;
 
+    if (requiresUpdate && !exactPriceWrite) {
+      quoteGeneration.current += 1;
+    }
+
     if (requiresUpdate) {
       if (hasGetData && !spendClearedByUserRef.current) {
         updateData(Side.SPEND);
       } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
         setValidatedData(undefined);
+        setPaymentInfo(undefined);
       } else if (hasSpendData) {
         updateData(Side.GET);
       }
@@ -339,49 +350,44 @@ export default function SellScreen(): JSX.Element {
 
     if (!validatedData) return;
 
+    const generation = quoteGeneration.current;
     const data: SellPaymentInfo = { ...validatedData, externalTransactionId };
 
     setIsLoading(validatedData.sideToUpdate);
     receiveFor(data)
       .then((sell) => {
-        if (!isRunning || !sell) return;
+        if (!isRunning || !sell || generation !== quoteGeneration.current) return;
         validateSell(sell);
         setPaymentInfo(sell);
         return receiveFor({ ...data, exactPrice: true });
       })
       .then((info) => {
-        if (isRunning && info) {
-          const skipWrite =
-            validatedData.sideToUpdate === Side.SPEND
-              ? spendClearedByUserRef.current
-              : targetClearedByUserRef.current;
-          if (!skipWrite) {
-            isExactPriceWriteRef.current = true;
-            if (validatedData.sideToUpdate === Side.SPEND) {
-              setVal('amount', info.amount.toString());
-            } else {
-              setVal('targetAmount', info.estimatedAmount.toString());
-            }
-            setPaymentInfo(info);
-          }
+        if (!isRunning || !info || generation !== quoteGeneration.current) return;
+        isExactPriceWriteRef.current = true;
+        if (validatedData.sideToUpdate === Side.SPEND) {
+          setVal('amount', info.amount.toString());
+        } else {
+          setVal('targetAmount', info.estimatedAmount.toString());
         }
+        setPaymentInfo(info);
       })
       .catch((error: ApiError) => {
-        if (isRunning) {
-          if (error.statusCode === 400 && error.message === 'Ident data incomplete') {
-            navigate('/profile');
+        if (!isRunning || generation !== quoteGeneration.current) return;
+        if (error.statusCode === 400 && error.message === 'Ident data incomplete') {
+          navigate('/profile');
+        } else {
+          setPaymentInfo(undefined);
+          const kycErrorFromMessage = getKycErrorFromMessage(error.message);
+          if (kycErrorFromMessage) {
+            setKycError(kycErrorFromMessage);
           } else {
-            setPaymentInfo(undefined);
-            const kycErrorFromMessage = getKycErrorFromMessage(error.message);
-            if (kycErrorFromMessage) {
-              setKycError(kycErrorFromMessage);
-            } else {
-              setErrorMessage(error.message ?? 'Unknown error');
-            }
+            setErrorMessage(error.message ?? 'Unknown error');
           }
         }
       })
-      .finally(() => isRunning && setIsLoading(undefined));
+      .finally(() => {
+        if (isRunning && generation === quoteGeneration.current) setIsLoading(undefined);
+      });
 
     return () => {
       isRunning = false;

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -150,6 +150,11 @@ export default function SellScreen(): JSX.Element {
   const selectedTargetAmount = useWatch({ control, name: 'targetAmount' });
   const selectedAddress = useWatch({ control, name: 'address' });
 
+  const previousAmountRef = useRef<string>();
+  const previousTargetAmountRef = useRef<string>();
+  const spendClearedByUserRef = useRef(false);
+  const targetClearedByUserRef = useRef(false);
+
   const availableBalance = selectedAsset && findBalance(selectedAsset);
 
   useEffect(() => {
@@ -203,11 +208,15 @@ export default function SellScreen(): JSX.Element {
 
   useEffect(() => {
     if (amountIn) {
-      setVal('amount', amountIn);
+      if (!spendClearedByUserRef.current) setVal('amount', amountIn);
     } else if (amountOut) {
-      setVal('targetAmount', amountOut);
-    } else if (selectedAsset && !enteredAmount) {
-      // Asset-specific default amounts
+      if (!targetClearedByUserRef.current) setVal('targetAmount', amountOut);
+    } else if (
+      selectedAsset &&
+      !enteredAmount &&
+      !spendClearedByUserRef.current &&
+      !targetClearedByUserRef.current
+    ) {
       const defaultAmount =
         selectedAsset.name === 'BTC' ? '0.001' : selectedAsset.name === 'ETH' ? '0.1' : '300';
       setVal('amount', defaultAmount);
@@ -243,16 +252,15 @@ export default function SellScreen(): JSX.Element {
     }
   }, [enteredAmount]);
 
-  // A non-empty → empty transition of an amount field is an edit in progress: the cross-side
-  // fallbacks below must not recompute into a field the user just emptied to retype — the
-  // exact-price echo would overwrite their input mid-typing. A field that was never set (deep
-  // links, first render) still resolves over the fallbacks.
-  const previousAmountRef = useRef<string>();
-  const previousTargetAmountRef = useRef<string>();
-
+  // A field the user emptied stays an edit in progress until they type again.
   // SPEND data changed
   useEffect(() => {
-    const amountCleared = !enteredAmount && !!previousAmountRef.current;
+    if (enteredAmount) {
+      spendClearedByUserRef.current = false;
+      if (!previousAmountRef.current) targetClearedByUserRef.current = false;
+    } else if (previousAmountRef.current) {
+      spendClearedByUserRef.current = true;
+    }
     previousAmountRef.current = enteredAmount;
 
     const requiresUpdate =
@@ -262,10 +270,9 @@ export default function SellScreen(): JSX.Element {
     const hasGetData = selectedTargetAmount && selectedCurrency && selectedBankAccount;
 
     if (requiresUpdate) {
-      if (hasSpendData) {
+      if (hasSpendData && !targetClearedByUserRef.current) {
         updateData(Side.GET);
-      } else if (amountCleared) {
-        // the user is retyping the amount — never refill the field from the target side
+      } else if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
         setValidatedData(undefined);
       } else if (hasGetData) {
         updateData(Side.SPEND);
@@ -275,7 +282,12 @@ export default function SellScreen(): JSX.Element {
 
   // GET data changed
   useEffect(() => {
-    const targetAmountCleared = !selectedTargetAmount && !!previousTargetAmountRef.current;
+    if (selectedTargetAmount) {
+      targetClearedByUserRef.current = false;
+      if (!previousTargetAmountRef.current) spendClearedByUserRef.current = false;
+    } else if (previousTargetAmountRef.current) {
+      targetClearedByUserRef.current = true;
+    }
     previousTargetAmountRef.current = selectedTargetAmount;
 
     const requiresUpdate =
@@ -289,11 +301,10 @@ export default function SellScreen(): JSX.Element {
     if (requiresUpdate) {
       if (hasGetData) {
         updateData(Side.SPEND);
-      } else if (targetAmountCleared) {
-        // the user is retyping the target amount — never refill the field from the spend side
-        setValidatedData(undefined);
-      } else if (hasSpendData) {
+      } else if (hasSpendData && !targetClearedByUserRef.current) {
         updateData(Side.GET);
+      } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
+        setValidatedData(undefined);
       }
     }
   }, [selectedTargetAmount, selectedCurrency, selectedBankAccount]);
@@ -336,9 +347,11 @@ export default function SellScreen(): JSX.Element {
       })
       .then((info) => {
         if (isRunning && info) {
-          validatedData.sideToUpdate === Side.SPEND
-            ? setVal('amount', info.amount.toString())
-            : setVal('targetAmount', info.estimatedAmount.toString());
+          if (validatedData.sideToUpdate === Side.SPEND) {
+            if (!spendClearedByUserRef.current) setVal('amount', info.amount.toString());
+          } else if (!targetClearedByUserRef.current) {
+            setVal('targetAmount', info.estimatedAmount.toString());
+          }
           setPaymentInfo(info);
         }
       })

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -555,7 +555,10 @@ export default function SellScreen(): JSX.Element {
   }
 
   function onSubmit(_data: FormData) {
-    return;
+    if (spendClearedByUserRef.current || targetClearedByUserRef.current) return;
+    if (!paymentInfo || kycError || errorMessage || customAmountError?.hideInfos || isProcessing) return;
+    if (selectedAsset?.category === AssetCategory.PRIVATE && !flags?.includes('private')) return;
+    void handleNext(paymentInfo);
   }
 
   function setAddress() {

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -329,7 +329,12 @@ export default function SellScreen(): JSX.Element {
 
     if (requiresUpdate) {
       if (hasGetData && !spendClearedByUserRef.current) {
-        updateData(Side.SPEND);
+        const ibanOnlyChange =
+          Boolean(enteredAmount) &&
+          selectedBankAccount?.iban !== validatedData?.iban &&
+          selectedTargetAmount === paymentInfo?.estimatedAmount?.toString() &&
+          selectedCurrency?.name === paymentInfo?.currency?.name;
+        updateData(ibanOnlyChange ? Side.GET : Side.SPEND);
       } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
         setValidatedData(undefined);
         setPaymentInfo(undefined);

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -34,7 +34,7 @@ import {
   StyledSearchDropdown,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { FieldPath, FieldPathValue, useForm, useWatch } from 'react-hook-form';
 import { BankAccountSelector } from 'src/components/order/bank-account-selector';
 import { AddressSwitch } from 'src/components/payment/address-switch';
@@ -123,6 +123,7 @@ export default function SellScreen(): JSX.Element {
   } = useAppParams();
   const { toDescription, getCurrency, getDefaultCurrency } = useFiat();
   const { currencies, receiveFor } = useSell();
+  const sellableCurrencies = useMemo(() => currencies?.filter((c) => c.sellable), [currencies]);
   const { toString } = useBlockchain();
   const { rootRef } = useLayoutContext();
 
@@ -202,11 +203,11 @@ export default function SellScreen(): JSX.Element {
 
   useEffect(() => {
     const currency =
-      getCurrency(currencies, assetOut) ??
-      getCurrency(currencies, prefCurrency?.name) ??
-      getDefaultCurrency(currencies);
+      getCurrency(sellableCurrencies, assetOut) ??
+      getCurrency(sellableCurrencies, prefCurrency?.name) ??
+      getDefaultCurrency(sellableCurrencies);
     if (prefCurrency && currency) setVal('currency', currency);
-  }, [assetOut, getCurrency, prefCurrency, currencies]);
+  }, [assetOut, getCurrency, prefCurrency, sellableCurrencies]);
 
   useEffect(() => {
     if (amountIn) {
@@ -615,7 +616,7 @@ export default function SellScreen(): JSX.Element {
           translate={translateError}
           hasFormElement={false}
         >
-          {availableAssets && currencies && bankAccounts && (
+          {availableAssets && sellableCurrencies && bankAccounts && (
             <StyledVerticalStack gap={8} full center className="relative">
               <StyledVerticalStack gap={2} full>
                 <h2 className="text-dfxGray-700">{translate('screens/buy', 'You spend')}</h2>
@@ -704,7 +705,7 @@ export default function SellScreen(): JSX.Element {
                       rootRef={rootRef}
                       name="currency"
                       placeholder={translate('general/actions', 'Select') + '...'}
-                      items={currencies}
+                      items={sellableCurrencies}
                       labelFunc={(item) => item.name}
                       descriptionFunc={(item) => toDescription(item)}
                       full

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -133,6 +133,7 @@ export default function SellScreen(): JSX.Element {
   const [kycError, setKycError] = useState<TransactionError>();
   const [isLoading, setIsLoading] = useState<Side>();
   const [paymentInfo, setPaymentInfo] = useState<Sell>();
+  const [isQuoteFinal, setIsQuoteFinal] = useState(false);
   const [balances, setBalances] = useState<AssetBalance[]>();
   const [isProcessing, setIsProcessing] = useState(false);
   const [isTxDone, setTxDone] = useState<boolean>(false);
@@ -375,6 +376,7 @@ export default function SellScreen(): JSX.Element {
     setErrorMessage(undefined);
     setKycError(undefined);
     setPaymentInfo(undefined);
+    setIsQuoteFinal(false);
     setIsLoading(undefined);
 
     if (!validatedData) return;
@@ -412,6 +414,7 @@ export default function SellScreen(): JSX.Element {
           }
         }
         setPaymentInfo(info);
+        setIsQuoteFinal(true);
       })
       .catch((error: ApiError) => {
         if (!isRunning || generation !== quoteGeneration.current) return;
@@ -419,6 +422,7 @@ export default function SellScreen(): JSX.Element {
           navigate('/profile');
         } else {
           setPaymentInfo(undefined);
+          setIsQuoteFinal(false);
           const kycErrorFromMessage = getKycErrorFromMessage(error.message);
           if (kycErrorFromMessage) {
             setKycError(kycErrorFromMessage);
@@ -556,7 +560,8 @@ export default function SellScreen(): JSX.Element {
 
   function onSubmit(_data?: FormData) {
     if (spendClearedByUserRef.current || targetClearedByUserRef.current) return;
-    if (!paymentInfo || kycError || errorMessage || customAmountError?.hideInfos || isProcessing) return;
+    if (!paymentInfo || !isQuoteFinal || kycError || errorMessage || customAmountError?.hideInfos || isProcessing)
+      return;
     if (selectedAsset?.category === AssetCategory.PRIVATE && !flags?.includes('private')) return;
     void handleNext(paymentInfo);
   }
@@ -810,6 +815,7 @@ export default function SellScreen(): JSX.Element {
                                 : 'Click here once you have issued the transaction',
                             )}
                             onClick={() => onSubmit()}
+                            disabled={!isQuoteFinal}
                             caps={false}
                             className="mt-4"
                             isLoading={isProcessing}

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -378,11 +378,22 @@ export default function SellScreen(): JSX.Element {
       })
       .then((info) => {
         if (!isRunning || !info || generation !== quoteGeneration.current) return;
-        isExactPriceWriteRef.current = true;
         if (validatedData.sideToUpdate === Side.SPEND) {
-          setVal('amount', info.amount.toString());
+          const nextAmount = info.amount.toString();
+          if (enteredAmount !== nextAmount) {
+            isExactPriceWriteRef.current = true;
+            setVal('amount', nextAmount);
+          } else {
+            isExactPriceWriteRef.current = false;
+          }
         } else {
-          setVal('targetAmount', info.estimatedAmount.toString());
+          const nextTarget = info.estimatedAmount.toString();
+          if (selectedTargetAmount !== nextTarget) {
+            isExactPriceWriteRef.current = true;
+            setVal('targetAmount', nextTarget);
+          } else {
+            isExactPriceWriteRef.current = false;
+          }
         }
         setPaymentInfo(info);
       })

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -351,13 +351,19 @@ export default function SellScreen(): JSX.Element {
       })
       .then((info) => {
         if (isRunning && info) {
-          isExactPriceWriteRef.current = true;
-          if (validatedData.sideToUpdate === Side.SPEND) {
-            setVal('amount', info.amount.toString());
-          } else {
-            setVal('targetAmount', info.estimatedAmount.toString());
+          const skipWrite =
+            validatedData.sideToUpdate === Side.SPEND
+              ? spendClearedByUserRef.current
+              : targetClearedByUserRef.current;
+          if (!skipWrite) {
+            isExactPriceWriteRef.current = true;
+            if (validatedData.sideToUpdate === Side.SPEND) {
+              setVal('amount', info.amount.toString());
+            } else {
+              setVal('targetAmount', info.estimatedAmount.toString());
+            }
+            setPaymentInfo(info);
           }
-          setPaymentInfo(info);
         }
       })
       .catch((error: ApiError) => {

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -150,6 +150,12 @@ export default function SwapScreen(): JSX.Element {
   const targetClearedByUserRef = useRef(false);
   const isExactPriceWriteRef = useRef(false);
   const quoteGeneration = useRef(0);
+  const enteredAmountLiveRef = useRef(enteredAmount);
+  const selectedTargetAmountLiveRef = useRef(selectedTargetAmount);
+  enteredAmountLiveRef.current = enteredAmount;
+  selectedTargetAmountLiveRef.current = selectedTargetAmount;
+  if (!enteredAmount && previousAmountRef.current) spendClearedByUserRef.current = true;
+  if (!selectedTargetAmount && previousTargetAmountRef.current) targetClearedByUserRef.current = true;
 
   useEffect(() => {
     if (sourceAssets && session?.address) {
@@ -436,10 +442,13 @@ export default function SwapScreen(): JSX.Element {
         return receiveFor({ ...data, exactPrice: true });
       })
       .then((info) => {
-        if (!isRunning || !info || generation !== quoteGeneration.current) return;
+        if (!isRunning || !info) return;
+        if (validatedData.sideToUpdate === Side.SPEND && spendClearedByUserRef.current) return;
+        if (validatedData.sideToUpdate === Side.GET && targetClearedByUserRef.current) return;
+        if (generation !== quoteGeneration.current) return;
         if (validatedData.sideToUpdate === Side.SPEND) {
           const nextAmount = info.amount.toString();
-          if (enteredAmount !== nextAmount) {
+          if (enteredAmountLiveRef.current !== nextAmount) {
             isExactPriceWriteRef.current = true;
             setVal('amount', nextAmount);
           } else {
@@ -447,7 +456,7 @@ export default function SwapScreen(): JSX.Element {
           }
         } else {
           const nextTarget = info.estimatedAmount.toString();
-          if (selectedTargetAmount !== nextTarget) {
+          if (selectedTargetAmountLiveRef.current !== nextTarget) {
             isExactPriceWriteRef.current = true;
             setVal('targetAmount', nextTarget);
           } else {

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -263,6 +263,7 @@ export default function SwapScreen(): JSX.Element {
     } else if (
       selectedSourceAsset &&
       !enteredAmount &&
+      !selectedTargetAmount &&
       !spendClearedByUserRef.current &&
       !targetClearedByUserRef.current
     ) {

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -598,7 +598,7 @@ export default function SwapScreen(): JSX.Element {
     );
   }
 
-  function onSubmit(_data: FormData) {
+  function onSubmit(_data?: FormData) {
     if (spendClearedByUserRef.current || targetClearedByUserRef.current) return;
     if (!paymentInfo || kycError || errorMessage || customAmountError?.hideInfos || isProcessing) return;
     if (
@@ -677,7 +677,13 @@ export default function SwapScreen(): JSX.Element {
       ) : showsSwitchScreen ? (
         <AddressSwitch onClose={(r) => (r ? onAddressSwitch() : setShowsSwitchScreen(false))} />
       ) : (
-        <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
+        <form
+          className="w-full"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmit();
+          }}
+        >
         <Form
           control={control}
           rules={rules}

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -144,6 +144,11 @@ export default function SwapScreen(): JSX.Element {
   const selectedTargetAsset = useWatch({ control, name: 'targetAsset' });
   const selectedAddress = useWatch({ control, name: 'address' });
 
+  const previousAmountRef = useRef<string>();
+  const previousTargetAmountRef = useRef<string>();
+  const spendClearedByUserRef = useRef(false);
+  const targetClearedByUserRef = useRef(false);
+
   useEffect(() => {
     if (sourceAssets && session?.address) {
       const assetMap = sourceAssets.reduce<Record<Blockchain, Asset[]>>(
@@ -244,9 +249,13 @@ export default function SwapScreen(): JSX.Element {
 
   useEffect(() => {
     if (amountIn) {
-      setVal('amount', amountIn);
-    } else if (selectedSourceAsset && !enteredAmount) {
-      // Set default amount based on asset type
+      if (!spendClearedByUserRef.current) setVal('amount', amountIn);
+    } else if (
+      selectedSourceAsset &&
+      !enteredAmount &&
+      !spendClearedByUserRef.current &&
+      !targetClearedByUserRef.current
+    ) {
       const isStablecoin = ['USDT', 'USDC', 'DAI', 'ZCHF', 'dEURO', 'XCHF'].includes(selectedSourceAsset.name);
       setVal('amount', isStablecoin ? '100' : '0.1');
     }
@@ -295,16 +304,15 @@ export default function SwapScreen(): JSX.Element {
     }
   }, [enteredAmount]);
 
-  // A non-empty → empty transition of an amount field is an edit in progress: the cross-side
-  // fallbacks below must not recompute into a field the user just emptied to retype — the
-  // exact-price echo would overwrite their input mid-typing. A field that was never set (deep
-  // links, first render) still resolves over the fallbacks.
-  const previousAmountRef = useRef<string>();
-  const previousTargetAmountRef = useRef<string>();
-
+  // A field the user emptied stays an edit in progress until they type again.
   // SPEND data changed
   useEffect(() => {
-    const amountCleared = !enteredAmount && !!previousAmountRef.current;
+    if (enteredAmount) {
+      spendClearedByUserRef.current = false;
+      if (!previousAmountRef.current) targetClearedByUserRef.current = false;
+    } else if (previousAmountRef.current) {
+      spendClearedByUserRef.current = true;
+    }
     previousAmountRef.current = enteredAmount;
 
     const requiresUpdate =
@@ -315,10 +323,9 @@ export default function SwapScreen(): JSX.Element {
     const hasGetData = selectedTargetAmount && selectedTargetAsset && selectedAddress;
 
     if (requiresUpdate) {
-      if (hasSpendData) {
+      if (hasSpendData && !targetClearedByUserRef.current) {
         updateData(Side.GET);
-      } else if (amountCleared) {
-        // the user is retyping the amount — never refill the field from the target side
+      } else if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
         setValidatedData(undefined);
       } else if (hasGetData) {
         updateData(Side.SPEND);
@@ -328,7 +335,12 @@ export default function SwapScreen(): JSX.Element {
 
   // GET data changed
   useEffect(() => {
-    const targetAmountCleared = !selectedTargetAmount && !!previousTargetAmountRef.current;
+    if (selectedTargetAmount) {
+      targetClearedByUserRef.current = false;
+      if (!previousTargetAmountRef.current) spendClearedByUserRef.current = false;
+    } else if (previousTargetAmountRef.current) {
+      targetClearedByUserRef.current = true;
+    }
     previousTargetAmountRef.current = selectedTargetAmount;
 
     const isSameTargetAmount = selectedTargetAmount === paymentInfo?.estimatedAmount?.toString();
@@ -341,11 +353,10 @@ export default function SwapScreen(): JSX.Element {
     if (requiresUpdate) {
       if (hasGetData) {
         updateData(Side.SPEND);
-      } else if (targetAmountCleared) {
-        // the user is retyping the target amount — never refill the field from the spend side
-        setValidatedData(undefined);
-      } else if (hasSpendData) {
+      } else if (hasSpendData && !targetClearedByUserRef.current) {
         updateData(Side.GET);
+      } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
+        setValidatedData(undefined);
       }
     }
   }, [selectedTargetAmount, selectedTargetAsset]);
@@ -388,9 +399,11 @@ export default function SwapScreen(): JSX.Element {
       })
       .then((info) => {
         if (isRunning && info) {
-          validatedData.sideToUpdate === Side.SPEND
-            ? setVal('amount', info.amount.toString())
-            : setVal('targetAmount', info.estimatedAmount.toString());
+          if (validatedData.sideToUpdate === Side.SPEND) {
+            if (!spendClearedByUserRef.current) setVal('amount', info.amount.toString());
+          } else if (!targetClearedByUserRef.current) {
+            setVal('targetAmount', info.estimatedAmount.toString());
+          }
           setPaymentInfo(info);
         }
       })

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -367,7 +367,9 @@ export default function SwapScreen(): JSX.Element {
 
     const isSameTargetAmount = selectedTargetAmount === paymentInfo?.estimatedAmount?.toString();
     const requiresUpdate =
-      !isSameTargetAmount || selectedTargetAsset?.uniqueName !== paymentInfo?.targetAsset?.uniqueName;
+      !isSameTargetAmount ||
+      selectedTargetAsset?.uniqueName !== paymentInfo?.targetAsset?.uniqueName ||
+      selectedAddress?.address !== validatedData?.receiverAddress;
 
     const hasSpendData = enteredAmount && selectedSourceAsset;
     const hasGetData = selectedTargetAmount && selectedTargetAsset && selectedAddress;
@@ -393,7 +395,7 @@ export default function SwapScreen(): JSX.Element {
         updateData(Side.GET);
       }
     }
-  }, [selectedTargetAmount, selectedTargetAsset]);
+  }, [selectedTargetAmount, selectedTargetAsset, selectedAddress]);
 
   function updateData(sideToUpdate: Side) {
     const data = validateData({
@@ -430,11 +432,22 @@ export default function SwapScreen(): JSX.Element {
       })
       .then((info) => {
         if (!isRunning || !info || generation !== quoteGeneration.current) return;
-        isExactPriceWriteRef.current = true;
         if (validatedData.sideToUpdate === Side.SPEND) {
-          setVal('amount', info.amount.toString());
+          const nextAmount = info.amount.toString();
+          if (enteredAmount !== nextAmount) {
+            isExactPriceWriteRef.current = true;
+            setVal('amount', nextAmount);
+          } else {
+            isExactPriceWriteRef.current = false;
+          }
         } else {
-          setVal('targetAmount', info.estimatedAmount.toString());
+          const nextTarget = info.estimatedAmount.toString();
+          if (selectedTargetAmount !== nextTarget) {
+            isExactPriceWriteRef.current = true;
+            setVal('targetAmount', nextTarget);
+          } else {
+            isExactPriceWriteRef.current = false;
+          }
         }
         setPaymentInfo(info);
       })

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -625,6 +625,7 @@ export default function SwapScreen(): JSX.Element {
 
   async function handleNext(paymentInfo: Swap): Promise<void> {
     setIsProcessing(true);
+    setErrorMessage(undefined);
 
     if (canSendTransaction() && !activeWallet) return close(paymentInfo, false);
 
@@ -634,6 +635,14 @@ export default function SwapScreen(): JSX.Element {
       }
 
       setTxDone(true);
+    } catch (error: any) {
+      if (error.code === 4001) return;
+      setErrorMessage(
+        translate(
+          'screens/swap',
+          'Transaction failed. Click Retry to see the deposit address for manual transfer.',
+        ),
+      );
     } finally {
       setIsProcessing(false);
     }

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -383,7 +383,12 @@ export default function SwapScreen(): JSX.Element {
 
     if (requiresUpdate) {
       if (hasGetData && !spendClearedByUserRef.current) {
-        updateData(Side.SPEND);
+        const addressOnlyChange =
+          Boolean(enteredAmount) &&
+          selectedAddress?.address !== validatedData?.receiverAddress &&
+          selectedTargetAmount === paymentInfo?.estimatedAmount?.toString() &&
+          selectedTargetAsset?.uniqueName === paymentInfo?.targetAsset?.uniqueName;
+        updateData(addressOnlyChange ? Side.GET : Side.SPEND);
       } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
         setValidatedData(undefined);
         setPaymentInfo(undefined);

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -128,6 +128,7 @@ export default function SwapScreen(): JSX.Element {
   const [kycError, setKycError] = useState<TransactionError>();
   const [isLoading, setIsLoading] = useState<Side>();
   const [paymentInfo, setPaymentInfo] = useState<Swap>();
+  const [isQuoteFinal, setIsQuoteFinal] = useState(false);
   const [balances, setBalances] = useState<AssetBalance[]>();
   const [isProcessing, setIsProcessing] = useState(false);
   const [isTxDone, setTxDone] = useState<boolean>(false);
@@ -427,6 +428,7 @@ export default function SwapScreen(): JSX.Element {
     setErrorMessage(undefined);
     setKycError(undefined);
     setPaymentInfo(undefined);
+    setIsQuoteFinal(false);
     setIsLoading(undefined);
 
     if (!validatedData) return;
@@ -464,6 +466,7 @@ export default function SwapScreen(): JSX.Element {
           }
         }
         setPaymentInfo(info);
+        setIsQuoteFinal(true);
       })
       .catch((error: ApiError) => {
         if (!isRunning || generation !== quoteGeneration.current) return;
@@ -471,6 +474,7 @@ export default function SwapScreen(): JSX.Element {
           navigate('/profile');
         } else {
           setPaymentInfo(undefined);
+          setIsQuoteFinal(false);
           const kycErrorFromMessage = getKycErrorFromMessage(error.message);
           if (kycErrorFromMessage) {
             setKycError(kycErrorFromMessage);
@@ -600,7 +604,8 @@ export default function SwapScreen(): JSX.Element {
 
   function onSubmit(_data?: FormData) {
     if (spendClearedByUserRef.current || targetClearedByUserRef.current) return;
-    if (!paymentInfo || kycError || errorMessage || customAmountError?.hideInfos || isProcessing) return;
+    if (!paymentInfo || !isQuoteFinal || kycError || errorMessage || customAmountError?.hideInfos || isProcessing)
+      return;
     if (
       (selectedSourceAsset?.category === AssetCategory.PRIVATE ||
         selectedTargetAsset?.category === AssetCategory.PRIVATE) &&
@@ -877,6 +882,7 @@ export default function SwapScreen(): JSX.Element {
                                 : 'Click here once you have issued the transaction',
                             )}
                             onClick={() => onSubmit()}
+                            disabled={!isQuoteFinal}
                             caps={false}
                             className="mt-4"
                             isLoading={isProcessing}

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -149,6 +149,7 @@ export default function SwapScreen(): JSX.Element {
   const spendClearedByUserRef = useRef(false);
   const targetClearedByUserRef = useRef(false);
   const isExactPriceWriteRef = useRef(false);
+  const quoteGeneration = useRef(0);
 
   useEffect(() => {
     if (sourceAssets && session?.address) {
@@ -327,11 +328,16 @@ export default function SwapScreen(): JSX.Element {
     const hasSpendData = enteredAmount && selectedSourceAsset;
     const hasGetData = selectedTargetAmount && selectedTargetAsset && selectedAddress;
 
+    if (requiresUpdate && !exactPriceWrite) {
+      quoteGeneration.current += 1;
+    }
+
     if (requiresUpdate) {
       if (hasSpendData && !targetClearedByUserRef.current) {
         updateData(Side.GET);
       } else if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
         setValidatedData(undefined);
+        setPaymentInfo(undefined);
       } else if (hasGetData) {
         updateData(Side.SPEND);
       }
@@ -359,11 +365,16 @@ export default function SwapScreen(): JSX.Element {
     const hasSpendData = enteredAmount && selectedSourceAsset;
     const hasGetData = selectedTargetAmount && selectedTargetAsset && selectedAddress;
 
+    if (requiresUpdate && !exactPriceWrite) {
+      quoteGeneration.current += 1;
+    }
+
     if (requiresUpdate) {
       if (hasGetData && !spendClearedByUserRef.current) {
         updateData(Side.SPEND);
       } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
         setValidatedData(undefined);
+        setPaymentInfo(undefined);
       } else if (hasSpendData) {
         updateData(Side.GET);
       }
@@ -391,49 +402,44 @@ export default function SwapScreen(): JSX.Element {
 
     if (!validatedData) return;
 
+    const generation = quoteGeneration.current;
     const data: SwapPaymentInfo = { ...validatedData, externalTransactionId };
 
     setIsLoading(validatedData.sideToUpdate);
     receiveFor(data)
       .then((swap) => {
-        if (!isRunning || !swap) return;
+        if (!isRunning || !swap || generation !== quoteGeneration.current) return;
         validateSwap(swap);
         setPaymentInfo(swap);
         return receiveFor({ ...data, exactPrice: true });
       })
       .then((info) => {
-        if (isRunning && info) {
-          const skipWrite =
-            validatedData.sideToUpdate === Side.SPEND
-              ? spendClearedByUserRef.current
-              : targetClearedByUserRef.current;
-          if (!skipWrite) {
-            isExactPriceWriteRef.current = true;
-            if (validatedData.sideToUpdate === Side.SPEND) {
-              setVal('amount', info.amount.toString());
-            } else {
-              setVal('targetAmount', info.estimatedAmount.toString());
-            }
-            setPaymentInfo(info);
-          }
+        if (!isRunning || !info || generation !== quoteGeneration.current) return;
+        isExactPriceWriteRef.current = true;
+        if (validatedData.sideToUpdate === Side.SPEND) {
+          setVal('amount', info.amount.toString());
+        } else {
+          setVal('targetAmount', info.estimatedAmount.toString());
         }
+        setPaymentInfo(info);
       })
       .catch((error: ApiError) => {
-        if (isRunning) {
-          if (error.statusCode === 400 && error.message === 'Ident data incomplete') {
-            navigate('/profile');
+        if (!isRunning || generation !== quoteGeneration.current) return;
+        if (error.statusCode === 400 && error.message === 'Ident data incomplete') {
+          navigate('/profile');
+        } else {
+          setPaymentInfo(undefined);
+          const kycErrorFromMessage = getKycErrorFromMessage(error.message);
+          if (kycErrorFromMessage) {
+            setKycError(kycErrorFromMessage);
           } else {
-            setPaymentInfo(undefined);
-            const kycErrorFromMessage = getKycErrorFromMessage(error.message);
-            if (kycErrorFromMessage) {
-              setKycError(kycErrorFromMessage);
-            } else {
-              setErrorMessage(error.message ?? 'Unknown error');
-            }
+            setErrorMessage(error.message ?? 'Unknown error');
           }
         }
       })
-      .finally(() => isRunning && setIsLoading(undefined));
+      .finally(() => {
+        if (isRunning && generation === quoteGeneration.current) setIsLoading(undefined);
+      });
 
     return () => {
       isRunning = false;

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -148,6 +148,7 @@ export default function SwapScreen(): JSX.Element {
   const previousTargetAmountRef = useRef<string>();
   const spendClearedByUserRef = useRef(false);
   const targetClearedByUserRef = useRef(false);
+  const isExactPriceWriteRef = useRef(false);
 
   useEffect(() => {
     if (sourceAssets && session?.address) {
@@ -307,12 +308,16 @@ export default function SwapScreen(): JSX.Element {
   // A field the user emptied stays an edit in progress until they type again.
   // SPEND data changed
   useEffect(() => {
+    const exactPriceWrite = isExactPriceWriteRef.current;
     if (enteredAmount) {
       spendClearedByUserRef.current = false;
-      if (!previousAmountRef.current) targetClearedByUserRef.current = false;
+      if (enteredAmount !== previousAmountRef.current && !exactPriceWrite) {
+        targetClearedByUserRef.current = false;
+      }
     } else if (previousAmountRef.current) {
       spendClearedByUserRef.current = true;
     }
+    if (enteredAmount !== previousAmountRef.current) isExactPriceWriteRef.current = false;
     previousAmountRef.current = enteredAmount;
 
     const requiresUpdate =
@@ -335,12 +340,16 @@ export default function SwapScreen(): JSX.Element {
 
   // GET data changed
   useEffect(() => {
+    const exactPriceWrite = isExactPriceWriteRef.current;
     if (selectedTargetAmount) {
       targetClearedByUserRef.current = false;
-      if (!previousTargetAmountRef.current) spendClearedByUserRef.current = false;
+      if (selectedTargetAmount !== previousTargetAmountRef.current && !exactPriceWrite) {
+        spendClearedByUserRef.current = false;
+      }
     } else if (previousTargetAmountRef.current) {
       targetClearedByUserRef.current = true;
     }
+    if (selectedTargetAmount !== previousTargetAmountRef.current) isExactPriceWriteRef.current = false;
     previousTargetAmountRef.current = selectedTargetAmount;
 
     const isSameTargetAmount = selectedTargetAmount === paymentInfo?.estimatedAmount?.toString();
@@ -351,12 +360,12 @@ export default function SwapScreen(): JSX.Element {
     const hasGetData = selectedTargetAmount && selectedTargetAsset && selectedAddress;
 
     if (requiresUpdate) {
-      if (hasGetData) {
+      if (hasGetData && !spendClearedByUserRef.current) {
         updateData(Side.SPEND);
-      } else if (hasSpendData && !targetClearedByUserRef.current) {
-        updateData(Side.GET);
       } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
         setValidatedData(undefined);
+      } else if (hasSpendData) {
+        updateData(Side.GET);
       }
     }
   }, [selectedTargetAmount, selectedTargetAsset]);
@@ -400,8 +409,12 @@ export default function SwapScreen(): JSX.Element {
       .then((info) => {
         if (isRunning && info) {
           if (validatedData.sideToUpdate === Side.SPEND) {
-            if (!spendClearedByUserRef.current) setVal('amount', info.amount.toString());
+            if (!spendClearedByUserRef.current) {
+              isExactPriceWriteRef.current = true;
+              setVal('amount', info.amount.toString());
+            }
           } else if (!targetClearedByUserRef.current) {
+            isExactPriceWriteRef.current = true;
             setVal('targetAmount', info.estimatedAmount.toString());
           }
           setPaymentInfo(info);

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -687,6 +687,8 @@ export default function SwapScreen(): JSX.Element {
                           customAmountError.interpolation,
                         )
                       }
+                      loading={isLoading === Side.SPEND}
+                      disabled={isLoading === Side.SPEND}
                       full
                     />
                   </div>

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -636,9 +636,12 @@ export default function SwapScreen(): JSX.Element {
     setIsProcessing(true);
     setErrorMessage(undefined);
 
-    if (canSendTransaction() && !activeWallet) return close(paymentInfo, false);
-
     try {
+      if (canSendTransaction() && !activeWallet) {
+        close(paymentInfo, false);
+        return;
+      }
+
       if (canSendTransaction()) {
         await sendTransaction(paymentInfo).then(setSwapTxId);
       }

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -426,7 +426,7 @@ export default function SwapScreen(): JSX.Element {
       address: selectedAddress,
     });
 
-    data && setValidatedData({ ...data, sideToUpdate });
+    setValidatedData(data ? { ...data, sideToUpdate } : undefined);
   }
 
   useEffect(() => {

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -339,8 +339,11 @@ export default function SwapScreen(): JSX.Element {
     if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
       quoteGeneration.current += 1;
       isExactPriceWriteRef.current = false;
+      setIsQuoteFinal(false);
     } else if (requiresUpdate && !exactPriceWrite) {
       quoteGeneration.current += 1;
+      setIsQuoteFinal(false);
+      setPaymentInfo(undefined);
     }
 
     if (requiresUpdate) {
@@ -385,8 +388,11 @@ export default function SwapScreen(): JSX.Element {
     if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
       quoteGeneration.current += 1;
       isExactPriceWriteRef.current = false;
+      setIsQuoteFinal(false);
     } else if (requiresUpdate && !exactPriceWrite) {
       quoteGeneration.current += 1;
+      setIsQuoteFinal(false);
+      setPaymentInfo(undefined);
     }
 
     if (requiresUpdate) {

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -134,6 +134,7 @@ export default function SwapScreen(): JSX.Element {
   const [swapTxId, setSwapTxId] = useState<string>();
   const [showsSwitchScreen, setShowsSwitchScreen] = useState(false);
   const [validatedData, setValidatedData] = useState<ValidatedData>();
+  const [retryToken, setRetryToken] = useState(0);
 
   // form
   const { control, handleSubmit, setValue, resetField } = useForm<FormData>({ mode: 'onTouched' });
@@ -485,7 +486,7 @@ export default function SwapScreen(): JSX.Element {
     return () => {
       isRunning = false;
     };
-  }, [useDebounce(validatedData, 500)]);
+  }, [useDebounce(validatedData, 500), retryToken]);
 
   function validateSwap(swap: Swap): void {
     setCustomAmountError(undefined);
@@ -814,7 +815,7 @@ export default function SwapScreen(): JSX.Element {
                       <StyledButton
                         width={StyledButtonWidth.MIN}
                         label={translate('general/actions', 'Retry')}
-                        onClick={() => setVal('amount', enteredAmount)} // re-trigger
+                        onClick={() => setRetryToken((token) => token + 1)}
                         className="mt-4"
                         color={StyledButtonColor.STURDY_WHITE}
                       />

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -403,13 +403,19 @@ export default function SwapScreen(): JSX.Element {
       })
       .then((info) => {
         if (isRunning && info) {
-          isExactPriceWriteRef.current = true;
-          if (validatedData.sideToUpdate === Side.SPEND) {
-            setVal('amount', info.amount.toString());
-          } else {
-            setVal('targetAmount', info.estimatedAmount.toString());
+          const skipWrite =
+            validatedData.sideToUpdate === Side.SPEND
+              ? spendClearedByUserRef.current
+              : targetClearedByUserRef.current;
+          if (!skipWrite) {
+            isExactPriceWriteRef.current = true;
+            if (validatedData.sideToUpdate === Side.SPEND) {
+              setVal('amount', info.amount.toString());
+            } else {
+              setVal('targetAmount', info.estimatedAmount.toString());
+            }
+            setPaymentInfo(info);
           }
-          setPaymentInfo(info);
         }
       })
       .catch((error: ApiError) => {

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -677,6 +677,7 @@ export default function SwapScreen(): JSX.Element {
       ) : showsSwitchScreen ? (
         <AddressSwitch onClose={(r) => (r ? onAddressSwitch() : setShowsSwitchScreen(false))} />
       ) : (
+        <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
         <Form
           control={control}
           rules={rules}
@@ -879,6 +880,7 @@ export default function SwapScreen(): JSX.Element {
             </StyledVerticalStack>
           )}
         </Form>
+        </form>
       )}
     </>
   );

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -599,7 +599,16 @@ export default function SwapScreen(): JSX.Element {
   }
 
   function onSubmit(_data: FormData) {
-    return;
+    if (spendClearedByUserRef.current || targetClearedByUserRef.current) return;
+    if (!paymentInfo || kycError || errorMessage || customAmountError?.hideInfos || isProcessing) return;
+    if (
+      (selectedSourceAsset?.category === AssetCategory.PRIVATE ||
+        selectedTargetAsset?.category === AssetCategory.PRIVATE) &&
+      !flags?.includes('private')
+    ) {
+      return;
+    }
+    void handleNext(paymentInfo);
   }
 
   function setAddress() {

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -200,7 +200,7 @@ export default function SwapScreen(): JSX.Element {
     .filter((b) => filteredAssets?.some((a) => a.blockchain === b));
 
   const addressItems: Address[] =
-    userAddressItems.length > 0 && targetBlockchains?.length
+    userAddressItems.length > 0 && targetBlockchains.length
       ? [
           ...targetBlockchains.flatMap((b) => {
             const addresses = userAddressItems.filter((a) => a.blockchains.includes(b));
@@ -219,12 +219,12 @@ export default function SwapScreen(): JSX.Element {
       : [];
 
   useEffect(() => {
-    const blockchainSourceAssets = getAssets(sourceBlockchains ?? [], { sellable: true, comingSoon: false });
+    const blockchainSourceAssets = getAssets(sourceBlockchains, { sellable: true, comingSoon: false });
     const activeSourceAssets = filterAssets(blockchainSourceAssets, assetFilter);
     setSourceAssets(activeSourceAssets);
 
-    const activeTargetBlockchains = blockchain ? [blockchain as Blockchain] : (targetBlockchains ?? []);
-    const blockchainTargetAssets = getAssets(activeTargetBlockchains ?? [], { buyable: true, comingSoon: false });
+    const activeTargetBlockchains = blockchain ? [blockchain as Blockchain] : targetBlockchains;
+    const blockchainTargetAssets = getAssets(activeTargetBlockchains, { buyable: true, comingSoon: false });
     const activeTargetAssets = filterAssets(blockchainTargetAssets, assetFilter);
     setTargetAssets(activeTargetAssets);
 
@@ -396,25 +396,17 @@ export default function SwapScreen(): JSX.Element {
     setIsLoading(validatedData.sideToUpdate);
     receiveFor(data)
       .then((swap) => {
-        if (isRunning) {
-          validateSwap(swap);
-          setPaymentInfo(swap);
-
-          // load exact price
-          if (swap) {
-            return receiveFor({ ...data, exactPrice: true });
-          }
-        }
+        if (!isRunning || !swap) return;
+        validateSwap(swap);
+        setPaymentInfo(swap);
+        return receiveFor({ ...data, exactPrice: true });
       })
       .then((info) => {
         if (isRunning && info) {
+          isExactPriceWriteRef.current = true;
           if (validatedData.sideToUpdate === Side.SPEND) {
-            if (!spendClearedByUserRef.current) {
-              isExactPriceWriteRef.current = true;
-              setVal('amount', info.amount.toString());
-            }
-          } else if (!targetClearedByUserRef.current) {
-            isExactPriceWriteRef.current = true;
+            setVal('amount', info.amount.toString());
+          } else {
             setVal('targetAmount', info.estimatedAmount.toString());
           }
           setPaymentInfo(info);
@@ -511,7 +503,7 @@ export default function SwapScreen(): JSX.Element {
     targetAsset,
     targetAmount: targetAmountStr,
     address,
-  }: Partial<FormData> = {}): SwapPaymentInfo | undefined {
+  }: Partial<FormData>): SwapPaymentInfo | undefined {
     const amount = Number(amountStr);
     const targetAmount = Number(targetAmountStr);
     if (sourceAsset != null && targetAsset != null && address != null) {
@@ -541,22 +533,19 @@ export default function SwapScreen(): JSX.Element {
   }
 
   function getPaymentInfoString(paymentInfo: Swap): string {
-    return (
-      paymentInfo &&
-      translate(
-        'screens/swap',
-        'Send the selected amount to the address below. This address can be used multiple times, it is always the same for swaps from {{sourceChain}} to {{asset}} on {{targetChain}}.',
-        {
-          sourceChain: toString(paymentInfo.sourceAsset.blockchain),
-          targetChain: toString(paymentInfo.targetAsset.blockchain),
-          asset: paymentInfo.targetAsset.name,
-        },
-      )
+    return translate(
+      'screens/swap',
+      'Send the selected amount to the address below. This address can be used multiple times, it is always the same for swaps from {{sourceChain}} to {{asset}} on {{targetChain}}.',
+      {
+        sourceChain: toString(paymentInfo.sourceAsset.blockchain),
+        targetChain: toString(paymentInfo.targetAsset.blockchain),
+        asset: paymentInfo.targetAsset.name,
+      },
     );
   }
 
   function onSubmit(_data: FormData) {
-    // TODO: (Krysh fix broken form validation and onSubmit
+    return;
   }
 
   function setAddress() {

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -443,8 +443,7 @@ export default function SwapScreen(): JSX.Element {
       })
       .then((info) => {
         if (!isRunning || !info) return;
-        if (validatedData.sideToUpdate === Side.SPEND && spendClearedByUserRef.current) return;
-        if (validatedData.sideToUpdate === Side.GET && targetClearedByUserRef.current) return;
+        if (spendClearedByUserRef.current || targetClearedByUserRef.current) return;
         if (generation !== quoteGeneration.current) return;
         if (validatedData.sideToUpdate === Side.SPEND) {
           const nextAmount = info.amount.toString();
@@ -873,7 +872,7 @@ export default function SwapScreen(): JSX.Element {
                                 ? 'Complete transaction in your wallet'
                                 : 'Click here once you have issued the transaction',
                             )}
-                            onClick={() => handleNext(paymentInfo)}
+                            onClick={() => onSubmit()}
                             caps={false}
                             className="mt-4"
                             isLoading={isProcessing}

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -328,7 +328,10 @@ export default function SwapScreen(): JSX.Element {
     const hasSpendData = enteredAmount && selectedSourceAsset;
     const hasGetData = selectedTargetAmount && selectedTargetAsset && selectedAddress;
 
-    if (requiresUpdate && !exactPriceWrite) {
+    if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
+      quoteGeneration.current += 1;
+      isExactPriceWriteRef.current = false;
+    } else if (requiresUpdate && !exactPriceWrite) {
       quoteGeneration.current += 1;
     }
 
@@ -369,7 +372,10 @@ export default function SwapScreen(): JSX.Element {
     const hasSpendData = enteredAmount && selectedSourceAsset;
     const hasGetData = selectedTargetAmount && selectedTargetAsset && selectedAddress;
 
-    if (requiresUpdate && !exactPriceWrite) {
+    if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
+      quoteGeneration.current += 1;
+      isExactPriceWriteRef.current = false;
+    } else if (requiresUpdate && !exactPriceWrite) {
       quoteGeneration.current += 1;
     }
 

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -33,7 +33,7 @@ import {
   StyledSearchDropdown,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FieldPath, FieldPathValue, useForm, useWatch } from 'react-hook-form';
 import { PaymentInformationContent } from 'src/components/payment/payment-info-sell';
 import { PrivateAssetHint } from 'src/components/private-asset-hint';
@@ -295,8 +295,18 @@ export default function SwapScreen(): JSX.Element {
     }
   }, [enteredAmount]);
 
+  // A non-empty → empty transition of an amount field is an edit in progress: the cross-side
+  // fallbacks below must not recompute into a field the user just emptied to retype — the
+  // exact-price echo would overwrite their input mid-typing. A field that was never set (deep
+  // links, first render) still resolves over the fallbacks.
+  const previousAmountRef = useRef<string>();
+  const previousTargetAmountRef = useRef<string>();
+
   // SPEND data changed
   useEffect(() => {
+    const amountCleared = !enteredAmount && !!previousAmountRef.current;
+    previousAmountRef.current = enteredAmount;
+
     const requiresUpdate =
       enteredAmount !== paymentInfo?.amount?.toString() ||
       selectedSourceAsset?.uniqueName !== paymentInfo?.sourceAsset.uniqueName;
@@ -307,6 +317,9 @@ export default function SwapScreen(): JSX.Element {
     if (requiresUpdate) {
       if (hasSpendData) {
         updateData(Side.GET);
+      } else if (amountCleared) {
+        // the user is retyping the amount — never refill the field from the target side
+        setValidatedData(undefined);
       } else if (hasGetData) {
         updateData(Side.SPEND);
       }
@@ -315,6 +328,9 @@ export default function SwapScreen(): JSX.Element {
 
   // GET data changed
   useEffect(() => {
+    const targetAmountCleared = !selectedTargetAmount && !!previousTargetAmountRef.current;
+    previousTargetAmountRef.current = selectedTargetAmount;
+
     const isSameTargetAmount = selectedTargetAmount === paymentInfo?.estimatedAmount?.toString();
     const requiresUpdate =
       !isSameTargetAmount || selectedTargetAsset?.uniqueName !== paymentInfo?.targetAsset?.uniqueName;
@@ -325,6 +341,9 @@ export default function SwapScreen(): JSX.Element {
     if (requiresUpdate) {
       if (hasGetData) {
         updateData(Side.SPEND);
+      } else if (targetAmountCleared) {
+        // the user is retyping the target amount — never refill the field from the spend side
+        setValidatedData(undefined);
       } else if (hasSpendData) {
         updateData(Side.GET);
       }

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -535,7 +535,7 @@ export default function SwapScreen(): JSX.Element {
 
   function setAddress() {
     if (session?.address && addressItems.length > 0) {
-      // Priorität: 1. blockchain URL-Parameter, 2. assetOut Blockchain, 3. erste Adresse
+      // Prefer URL blockchain, then assetOut chain, then the first address.
       let preferredChain = blockchain;
       if (!preferredChain && assetOut) {
         // Extract blockchain from assetOut (format: Blockchain/AssetName)

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -338,6 +338,10 @@ export default function SwapScreen(): JSX.Element {
       } else if (spendClearedByUserRef.current || targetClearedByUserRef.current) {
         setValidatedData(undefined);
         setPaymentInfo(undefined);
+        setKycError(undefined);
+        setErrorMessage(undefined);
+        setCustomAmountError(undefined);
+        setIsLoading(undefined);
       } else if (hasGetData) {
         updateData(Side.SPEND);
       }
@@ -375,6 +379,10 @@ export default function SwapScreen(): JSX.Element {
       } else if (targetClearedByUserRef.current || spendClearedByUserRef.current) {
         setValidatedData(undefined);
         setPaymentInfo(undefined);
+        setKycError(undefined);
+        setErrorMessage(undefined);
+        setCustomAmountError(undefined);
+        setIsLoading(undefined);
       } else if (hasSpendData) {
         updateData(Side.GET);
       }
@@ -397,6 +405,7 @@ export default function SwapScreen(): JSX.Element {
     let isRunning = true;
 
     setErrorMessage(undefined);
+    setKycError(undefined);
     setPaymentInfo(undefined);
     setIsLoading(undefined);
 


### PR DESCRIPTION
EN:
Emptying an amount field on /buy, /sell or /swap no longer lets the opposite side, a default, or a stale quote refill it.
Native form submit and the payment button share the same next-step guards.
/sell lists only sellable fiats and selects an existing bank-account query param instead of creating accounts in a loop.
Without that param a manual bank-account choice is kept; never-set fields still use the existing fallbacks.

DE:
Das Leeren eines Betragsfelds auf /buy, /sell oder /swap füllt es nicht mehr aus der Gegenseite, einem Default oder einer veralteten Quote nach.
Natives Form-Submit und der Zahlungs-Button teilen sich dieselben Next-Schritt-Guards.
/sell zeigt nur sellable Fiats und wählt ein bestehendes Konto aus dem bank-account-Parameter, statt Konten in einer Schleife anzulegen.
Ohne diesen Parameter bleibt eine manuelle Kontoauswahl stehen; nie gesetzte Felder nutzen weiter die Fallbacks.

<details>
<summary>Details</summary>

Cleared spend/target fields stay empty until the user types again, including when exact-price resolves in the same turn as the clear. Exact-price aborts if either side is cleared. Buy quote loading aborts when live validatedData no longer matches the debounced snapshot. Sell and swap skip the asset default while a target amount is already set.

The shared Form component does not put onSubmit on its own form tag. Each screen wraps a native form that calls onSubmit(); the payment CTA uses the same handler. onSubmit does nothing when the amount was cleared, the quote is missing or not final, KYC or a quote error is showing, the asset is private without the flag, personal-IBAN acknowledgement is pending, or a confirm/send is already in flight. Buy confirm runs for a final quote; sell/swap call handleNext.

Full-stack e2e pins native form submit on /buy, /sell and /swap: requestSubmit confirms after the manual payment CTA is enabled and does nothing after a cleared spend field.

Sell and swap Retry increment a retry token so a quote reload is not swallowed by debounce deep-equality. Failed validation now clears the previous quote snapshot, so Retry cannot resend an old amount after the field became invalid. handleNext always clears processing in finally, including when updating the bank account fails.

Sell currency dropdown items are `currencies.filter(c => c.sellable)`. `BankAccountSelector` selects a matching existing IBAN from `bank-account` and creates at most once when none exists. Create results are ignored after that param changes or the selector unmounts. Without the param it auto-selects the default or only account only when nothing is selected yet.

Pre-existing, not changed: `/buyCrypto/update` Admin save still hits a known API 500 (`test.fail` kept until that API fix). Dead CARD buy UI is removed because bank is the only payment method.

Jest coverage on the touched instrumented files, measured as statements / branches / functions / lines:

- `src/screens/buy.screen.tsx`: 100 / 100 / 100 / 100
- `src/screens/sell.screen.tsx`: 100 / 100 / 100 / 100
- `src/screens/swap.screen.tsx`: 100 / 100 / 100 / 100
- `src/components/order/bank-account-selector.tsx`: 100 / 100 / 100 / 100

</details>
