### PR TITLE
fix(compliance): let a Repeat call outcome release the transaction

### DIFF
--- a/src/__tests__/call-queue-outcome-form.test.tsx
+++ b/src/__tests__/call-queue-outcome-form.test.tsx
@@ -277,6 +277,35 @@ describe('CallQueueOutcomeForm AmlCheck action', () => {
   it('defaults an open-ended outcome to no change', async () => {
     renderForm(TX_CONTEXT);
 
+    fillAndSubmit(CallOutcome.SUSPICIOUS);
+
+    await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
+    expect(submittedAmlAction()).toBeUndefined();
+  });
+
+  // Repeat decides the transaction on its own: the hook releases this one transaction and the account
+  // stays in the queue for its next one. Asking for an AML action on top would only offer the plain
+  // reset, which re-runs the very check the still-missing check date is failing.
+  it('asks for no AML action on Repeat', () => {
+    renderForm(TX_CONTEXT);
+
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: CallOutcome.REPEAT } });
+
+    expect(screen.getAllByRole('combobox')).toHaveLength(1);
+  });
+
+  it('sends the automatic reset on Repeat for a recheck-blocked queue', async () => {
+    renderForm(TX_CONTEXT);
+
+    fillAndSubmit(CallOutcome.REPEAT);
+
+    await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
+    expect(submittedAmlAction()).toBe('Reset');
+  });
+
+  it('sends no AML action on Repeat where the cron re-evaluates anyway', async () => {
+    renderForm(PLAIN_PHONE_TX_CONTEXT);
+
     fillAndSubmit(CallOutcome.REPEAT);
 
     await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));

--- a/src/__tests__/compliance-call-outcome.hook.test.ts
+++ b/src/__tests__/compliance-call-outcome.hook.test.ts
@@ -88,6 +88,89 @@ describe('saveCallOutcome write order', () => {
   });
 });
 
+// Repeat: let THIS payment through, call the customer again on the next one. The release is therefore
+// written on the transaction while the account deliberately keeps its empty check date — which is what
+// puts the next payment back into the queue.
+describe('saveCallOutcome on a Repeat outcome', () => {
+  beforeEach(() => {
+    mockCalls.length = 0;
+    mockCall.mockImplementation(async (cfg: any) => {
+      mockCalls.push({ method: cfg.method, url: cfg.url, data: cfg.data });
+      return {};
+    });
+  });
+
+  // The release is only accepted while the transaction still carries its queue reason, so it has to be
+  // written before the reset that clears amlCheck/amlReason.
+  it('releases the transaction before resetting it, and writes no check date', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    const res = await result.current.saveCallOutcome(TX_CONTEXT, CallOutcome.REPEAT, {
+      signature: 'JR',
+      comment: 'call again next time',
+      amlAction: 'Reset',
+    });
+
+    expect(res.success).toBe(true);
+    expect(mockCalls.map((c) => `${c.method} ${c.url}`)).toEqual([
+      'PUT userData/7',
+      'PUT buyCrypto/42/phoneCallCleared',
+      'PUT buyCrypto/42/amlCheck/reviewReset',
+      'POST kyc/admin/log',
+    ]);
+    expect(mockCalls[0].data.phoneCallStatus).toBe('Repeat');
+    expect(mockCalls[0].data.phoneCallIpCountryCheckDate).toBeUndefined();
+  });
+
+  it('releases a sell transaction through its own endpoint', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    await result.current.saveCallOutcome(
+      { ...TX_CONTEXT, queue: 'ManualCheckPhone', sourceType: 'BuyFiat' },
+      CallOutcome.REPEAT,
+      { signature: 'JR', comment: 'call again next time' },
+    );
+
+    expect(mockCalls.map((c) => `${c.method} ${c.url}`)).toEqual([
+      'PUT userData/7',
+      'PUT buyFiat/42/phoneCallCleared',
+      'POST kyc/admin/log',
+    ]);
+  });
+
+  // The user queue has no transaction to release, and Repeat there deliberately writes nothing at all.
+  it('writes nothing but the log for a queue entry without a transaction', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    await result.current.saveCallOutcome({ queue: 'UnavailableSuspicious', userDataId: 7 } as any, CallOutcome.REPEAT, {
+      signature: 'JR',
+      comment: 'call again next time',
+    });
+
+    expect(mockCalls.map((c) => `${c.method} ${c.url}`)).toEqual(['POST kyc/admin/log']);
+  });
+
+  // A failed release must surface as a failed save: reporting success would tell the clerk the payment
+  // is on its way while it silently stays in the queue.
+  it('reports the transaction step as failed when the release is rejected', async () => {
+    mockCall.mockImplementation(async (cfg: any) => {
+      if (cfg.url.endsWith('/phoneCallCleared')) throw new Error('not waiting for a compliance phone call');
+      mockCalls.push({ method: cfg.method, url: cfg.url, data: cfg.data });
+      return {};
+    });
+    const { result } = renderHook(() => useCompliance());
+
+    const res = await result.current.saveCallOutcome({ ...TX_CONTEXT, queue: 'ManualCheckPhone' }, CallOutcome.REPEAT, {
+      signature: 'JR',
+      comment: 'call again next time',
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.failedStep).toBe('transaction');
+    expect(mockCalls.some((c) => c.url === 'kyc/admin/log')).toBe(false);
+  });
+});
+
 // Which queues need the outcome form to clear the transaction itself: exactly those whose AML reason
 // sits in the API's BlockAmlReasons, because the recheck cron never picks them up again. Everything
 // else must stay untouched so the API keeps deciding.

--- a/src/components/compliance/call-queue/call-queue-outcome-form.tsx
+++ b/src/components/compliance/call-queue/call-queue-outcome-form.tsx
@@ -15,10 +15,16 @@ import { useStaffVerifiedName } from 'src/hooks/staff-verified-name.hook';
 import { canManuallySetAmlPass } from 'src/util/aml-pass.util';
 import { STAFF_NAME_MISSING, staffNameLoadError } from '../staff-identity';
 
-// Completed and Failed leave nothing to decide: the phone-call status written in the same save
-// already determines the transaction — the API passes it on the check date a completed call writes,
-// and fails it on a failed one (`UserDataFailedCall`).
-const OutcomesImplyingAmlAction: (CallOutcome | '')[] = [CallOutcome.COMPLETED, CallOutcome.FAILED];
+// These outcomes leave nothing to decide: the save itself already determines the transaction — the API
+// passes it on the check date a completed call writes, fails it on a failed one (`UserDataFailedCall`),
+// and on Repeat releases this one transaction while the account stays in the queue. Offering an AML
+// action on top would only invite the combination that cannot work: a plain reset re-runs the very
+// check the missing check date is still failing.
+const OutcomesImplyingAmlAction: (CallOutcome | '')[] = [
+  CallOutcome.COMPLETED,
+  CallOutcome.FAILED,
+  CallOutcome.REPEAT,
+];
 
 interface Props {
   context: CallOutcomeContext;
@@ -58,10 +64,11 @@ export function CallQueueOutcomeForm({
   const canSubmit =
     !!signature && !!outcome && !!comment.trim() && !isSaving && !isLoadingSignature && !impliedResetUnavailable;
 
-  // What the save sends for a Completed/Failed outcome. Only the queues whose AML reason the API
-  // excludes from the recheck cron need an explicit action: their transaction would otherwise stay
+  // What the save sends for an outcome that implies its action. Only the queues whose AML reason the
+  // API excludes from the recheck cron need an explicit action: their transaction would otherwise stay
   // Pending forever. Reset (never Pass/Fail) clears amlCheck + amlReason so the cron re-runs the FULL
-  // AML check on the state the call just produced — the API decides the outcome, not the tool.
+  // AML check on the state the call just produced — the API decides the outcome, not the tool. On
+  // Repeat the release is written before this reset, so the re-run no longer sees the call-queue error.
   function impliedAmlAction(): AmlAction | undefined {
     if (!needsExplicitAmlReset(context.queue) || buyCryptoResetUnavailable) return undefined;
     return 'Reset';
@@ -69,8 +76,8 @@ export function CallQueueOutcomeForm({
 
   function handleOutcomeChange(value: CallOutcome | '') {
     setOutcome(value);
-    // Drop a selection made before the outcome was known; it is not submitted for Completed/Failed
-    // and must not reappear when the clerk switches back to another outcome.
+    // Drop a selection made before the outcome was known; it is not submitted for the outcomes that
+    // imply their action and must not reappear when the clerk switches back to another outcome.
     setAmlAction('');
   }
 

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -1059,6 +1059,20 @@ export function useCompliance() {
 
     // 2) Transaction update (if applicable)
     try {
+      // Repeat releases THIS transaction while the account stays in the queue: no check date was written
+      // above, so the AML re-run would otherwise hold it for the very same reason again. The API clears
+      // only the call-queue errors for this transaction and still decides the verdict itself. Runs before
+      // any reset, because it is only accepted while the transaction still carries its queue reason.
+      if (tx && outcome === CallOutcome.REPEAT) {
+        if (tx.sourceType === 'BuyCrypto') await clearBuyCryptoPhoneCall(tx.id);
+        else await clearBuyFiatPhoneCall(tx.id);
+        results.push({
+          table: tx.sourceType === 'BuyCrypto' ? 'buyCrypto' : 'buyFiat',
+          column: 'phoneCallClearedDate',
+          value: 'released for this transaction',
+        });
+        completedSteps.push('transaction');
+      }
       if (tx && options.amlAction) {
         const signature = options.signature.trim();
         const txTable = tx.sourceType === 'BuyCrypto' ? 'buyCrypto' : 'buyFiat';
@@ -1092,7 +1106,7 @@ export function useCompliance() {
           } else await resetBuyFiatAml(tx.id);
           results.push({ table: txTable, column: 'amlCheck', value: 'Reset' });
         }
-        completedSteps.push('transaction');
+        if (!completedSteps.includes('transaction')) completedSteps.push('transaction');
       }
     } catch (e) {
       return fail('transaction', e);
@@ -1433,6 +1447,22 @@ export function useCompliance() {
     return call<void>({
       url: `buyFiat/${id}/amlCheck`,
       method: 'DELETE',
+    });
+  }
+
+  // Releases a single transaction from its call queue without writing a check date on the account, so
+  // the account is called again on its next transaction. Sets no verdict — the API's AML run decides.
+  async function clearBuyCryptoPhoneCall(id: number): Promise<void> {
+    return call<void>({
+      url: `buyCrypto/${id}/phoneCallCleared`,
+      method: 'PUT',
+    });
+  }
+
+  async function clearBuyFiatPhoneCall(id: number): Promise<void> {
+    return call<void>({
+      url: `buyFiat/${id}/phoneCallCleared`,
+      method: 'PUT',
     });
   }
 


### PR DESCRIPTION
EN:
Repeat now releases this one transaction through the new API endpoint, writes no check date on the account, and no longer offers an AML action. Pass stays Admin-only; the pipeline still decides the verdict. Merge after the companion API change is on the development environment, or the new endpoint 404s.

DE:
Repeat gibt jetzt diese eine Zahlung über den neuen API-Endpoint frei, schreibt kein Check-Datum auf dem Konto und bietet keine AML-Aktion mehr an. Pass bleibt Admin-only; die Pipeline entscheidet weiterhin das Verdikt. Erst mergen, wenn die zugehörige API-Änderung auf der Entwicklungsumgebung liegt, sonst 404t der neue Endpoint.

<details>
<summary>Details</summary>

## Problem

Repeat means: let this payment through, call the customer again next time. The tool wrote the phone-call status and left the transaction to the clerk — and none of the offered AML actions could finish the job:

- Pass is Admin-only (the API rejects it for Compliance), and the option is already hidden for non-Admins.
- Reset re-runs the very check the deliberately missing check date is failing, so the payment loops straight back into the queue it came from.
- Fail is wrong.

## Solution

Repeat now decides the transaction itself, exactly like Completed and Failed do:

- The save releases this one transaction through `PUT :id/phoneCallCleared`, which clears the call-queue holds for that transaction only.
- The AmlCheck selector disappears for Repeat. Offering it would only invite the combination that cannot work.
- The release is written before the implied reset — the API accepts it only while the transaction still carries its queue reason, which the reset clears.

The account is untouched apart from its status: no check date is written, so its next transaction is held again and the customer reappears in the call list. The verdict stays with the API — a released transaction passes only when no other AML error remains.

The implied reset is unchanged in its own right: still only for the queues the API excludes from its recheck cron (`ManualCheckIpCountryPhone`), still Reset rather than Pass/Fail.

## Failure behaviour

A rejected release fails the save with `failedStep: 'transaction'` and no KYC log is written. Reporting success there would tell the clerk the payment is on its way while it silently stays in the queue.

## Tests

- Write order pinned: `userData` → `phoneCallCleared` → `reviewReset` → log, and no check date in the userData payload.
- Sell transactions go through `buyFiat/:id/phoneCallCleared`.
- A queue entry without a transaction still writes nothing but the log on Repeat.
- A rejected release surfaces as a failed transaction step with no log entry.
- Form: no AmlCheck selector on Repeat; automatic Reset on the recheck-blocked queue and none where the cron re-evaluates anyway.

</details>