### PR TITLE
01a03d26 - Point clone docs and repo identity at DFXswiss/app

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Code Owners for DFXswiss/services
+# Code Owners for DFXswiss/app
 # These users must approve all pull requests to protected branches
 
 # Default owners for everything in the repo

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Reusable web widget to buy, sell and swap crypto assets
 ### Quick Start
 
 ```bash
-# 1. Start the API first (in the backend repository)
-cd ../backend
+# 1. Start the API first (in the backend repository; local folder is still named api)
+cd ../api
 docker-compose up -d
 npm run start:local
 

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ Reusable web widget to buy, sell and swap crypto assets
 ### Quick Start
 
 ```bash
-# 1. Start the API first (in the api repository)
-cd ../api
+# 1. Start the API first (in the backend repository)
+cd ../backend
 docker-compose up -d
 npm run start:local
 
-# 2. Then start the services (in this repository)
-cd ../services
+# 2. Then start the app (in this repository)
+cd ../app
 npm install
 npm run start
 ```
 
-The services will be available at http://localhost:3001
+The app will be available at http://localhost:3001
 
 ### Configuration
 

--- a/e2e-stack/README.md
+++ b/e2e-stack/README.md
@@ -131,7 +131,7 @@ side by side and serve different purposes.
 
 ## Relationship with the API repository
 
-The API repository has its own workflow that checks out this repository (`DFXswiss/services`)
+The API repository has its own workflow that checks out this repository (`DFXswiss/app`)
 to obtain `e2e-stack/`. Conversely, this harness builds the API image from a checked-out API
 repo (`E2E_API_REPO`, default `../api`) or uses a pre-built image (`E2E_API_IMAGE`). The two
 repos therefore depend on each other for full-stack CI: the harness lives here; the API image

--- a/e2e-stack/scripts/up.sh
+++ b/e2e-stack/scripts/up.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 if [[ -z "${E2E_API_IMAGE:-}" ]]; then
-  # Default: API repo checked out as sibling directory "api" next to "services".
-  # Relative paths resolve from the services repository root so caller cwd does not matter.
+  # Default: backend repo checked out as sibling directory "api" next to "app".
+  # Relative paths resolve from the app repository root so caller cwd does not matter.
   api_repo_raw="${E2E_API_REPO:-../api}"
   if [[ "$api_repo_raw" = /* ]]; then
     api_repo="$api_repo_raw"
@@ -19,7 +19,7 @@ if [[ -z "${E2E_API_IMAGE:-}" ]]; then
 
   if [[ ! -d "$api_repo" ]]; then
     log_error "API image not set and API repository not found."
-    log_error "Either check out the API repo as a sibling directory named 'api' next to 'services',"
+    log_error "Either check out the backend repo as a sibling directory named 'api' next to 'app',"
     log_error "or set E2E_API_IMAGE to a pre-built image tag (e.g. export E2E_API_IMAGE=dfx-api:e2e)."
     log_error "Looked for: ${api_repo} (override with E2E_API_REPO)."
     exit 1

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Handbook assembly for DFXswiss/services.
+ * Handbook assembly for DFXswiss/app.
  *
  * Auto-discovers screenshot baselines, design tokens, logos and markdown
  * docs; generates a single deterministic index.html + manifest.json.


### PR DESCRIPTION
EN:
Point clone docs and repo identity at DFXswiss/app.
The local API sibling folder stays named api so the e2e harness default still matches.
npm package names and GHCR e2e image tags stay unchanged.

DE:
Zieht Clone-Doku und Repo-Identität auf DFXswiss/app.
Der lokale API-Ordner heisst weiter api, damit der e2e-Default passt.
npm-Paketnamen und GHCR-e2e-Image-Tags bleiben unverändert.

<details>
<summary>Details</summary>

Merge after the GitHub rename `DFXswiss/services` → `DFXswiss/app`. Do not recreate `DFXswiss/services`.

Unchanged: `@dfx.swiss/services-react`, `ghcr.io/dfxswiss/services-e2e-frontend`, `ghcr.io/dfxswiss/services-e2e-widget`.

</details>