### PR TITLE
0a974e89 - Set FAUCET_LOW_BALANCE_THRESHOLD in the e2e-stack API env

### DIFF
--- a/e2e-stack/env/api.env
+++ b/e2e-stack/env/api.env
@@ -18,7 +18,12 @@
 # --- Core boot ---
 ENVIRONMENT=loc
 CRON_ROLE=all
+# Both low-balance thresholds are read and validated in the API's Configuration
+# constructor, which throws when either is unset — the whole boot fails, not just
+# the feature that uses them. Neither wallet is funded in this stack; the values
+# only have to be present and positive.
 REALUNIT_W2W_GAS_LOW_BALANCE_THRESHOLD=0.05
+FAUCET_LOW_BALANCE_THRESHOLD=0.05
 JWT_SECRET=e2e-stack-jwt-secret-not-a-real-secret
 JWT_EXPIRES_IN=2d
 PORT=3000


### PR DESCRIPTION
EN:
The API container in `e2e-stack` no longer boots: its `Configuration` constructor validates `FAUCET_LOW_BALANCE_THRESHOLD` and throws when it is unset, so the process exits before Nest starts and `up.sh` times out after 540s waiting for `api` to be healthy. `env/api.env` never set that variable, so every full E2E run since that guard landed fails before a single Playwright test executes. This adds the variable next to the identical `REALUNIT_W2W_GAS_LOW_BALANCE_THRESHOLD` entry.

DE:
Der API-Container in `e2e-stack` bootet nicht mehr: Sein `Configuration`-Konstruktor validiert `FAUCET_LOW_BALANCE_THRESHOLD` und wirft, wenn die Variable fehlt, wodurch der Prozess vor dem Nest-Start abbricht und `up.sh` nach 540s auf einen gesunden `api` wartet. `env/api.env` hat diese Variable nie gesetzt, also scheitert seither jeder vollständige E2E-Lauf, bevor überhaupt ein Playwright-Test läuft. Dieser PR ergänzt die Variable direkt neben dem gleichartigen Eintrag `REALUNIT_W2W_GAS_LOW_BALANCE_THRESHOLD`.

<details>
<summary>Details</summary>

**Observed failure**

`up.sh` waits for the `api` service and then dumps the container log:

```
[e2e-stack] Waiting for service 'api' to become healthy (timeout 540s)...
[e2e-stack] ERROR: Timed out after 540s waiting for 'api' (last status: starting).
[e2e-stack] ERROR: API failed to become healthy. Recent API logs:
api-1  |             throw new Error('Missing FAUCET_LOW_BALANCE_THRESHOLD');
api-1  |     at new Configuration (/home/node/dist/src/config/config.js:62:1)
api-1  |     at GetConfig (/home/node/dist/src/config/config.js:60:12)
```

The throw happens while a module-level static initializer builds the config, i.e. during
`require`, so it is fatal for the process — the faucet feature itself is never reached.

**Timeline**

The last green full E2E run was at 2026-08-26T09:57Z. The guard was merged into the API at
10:45Z. Every full run after that point fails with the log above; none of them reach the
Playwright step.

**Why this value**

It is a tuning threshold in ETH, not a credential, and the guard only requires a finite value
greater than zero. No faucet wallet is funded in this hermetic stack, so the threshold is never
compared against a real balance. `0.05` mirrors `REALUNIT_W2W_GAS_LOW_BALANCE_THRESHOLD`, which
sits in the same block for the identical kind of guard, and matches the API's own
`.env.example`.

**Scope**

One variable plus a comment covering both threshold entries. No compose or script change.

</details>
