### PR TITLE
01a03eac - Allow write-mandate orders on a shared Safe

### DIFF
--- a/e2e/safe-accounts.spec.ts
+++ b/e2e/safe-accounts.spec.ts
@@ -9,9 +9,9 @@ import { getCachedAuth } from './helpers/auth-cache';
  * repeated here — the switcher is not rendered at all in those.
  *
  * Requires a local dataset with three reachable accounts: one owned (write), one shared
- * read-only, and one shared with a write mandate. The last one matters: a mandate over
- * someone else's Safe cannot transact either, because orders carry no account and would be
- * booked against the caller's own. Not a CI regression gate — see CONTRIBUTING.md.
+ * read-only, and one shared with a write mandate. The last one matters: a write mandate
+ * can transact, because orders now hit the account resource. Not a CI regression gate —
+ * see CONTRIBUTING.md.
  */
 
 test.describe('DFX Safe - Account switcher', () => {
@@ -78,11 +78,11 @@ test.describe('DFX Safe - Account switcher', () => {
     await page.getByText('Example Mandate AG').click();
     await page.waitForLoadState('networkidle');
 
-    // The mandate grants write, yet acting is still refused — and the entry says so rather
-    // than looking fully usable and dropping the section on selection.
-    await expect(page.getByRole('button', { name: 'Deposit', exact: true })).toHaveCount(0);
-    await expect(page.getByText('View only').first()).toBeVisible();
+    // Write mandate can transact: orders hit the account resource.
+    await expect(page.getByRole('button', { name: 'Deposit', exact: true })).toBeVisible();
+    await expect(page.getByText('View only')).toHaveCount(0);
 
+    // Baseline follows; visuals are not a CI gate.
     await expect(page).toHaveScreenshot('04-account-shared-write-mandate.png', screenshotOpts);
   });
 });

--- a/src/components/safe/account-selector.tsx
+++ b/src/components/safe/account-selector.tsx
@@ -42,9 +42,9 @@ export function AccountSelector({ accounts, selected, onSelect }: AccountSelecto
         smallLabel
         items={accounts}
         labelFunc={(account) => account.title}
-        // Labelled by the same predicate the screen acts on: a mandate over someone else's
-        // account cannot transact either, and an entry that looks fully usable but silently
-        // drops the transaction area on selection is worse than one that says so upfront.
+        // Labelled by the same predicate the screen acts on: View only when the caller cannot
+        // act (Read, own or foreign). A write mandate is no longer View only, because orders
+        // now go through the account resource.
         descriptionFunc={(account) => (canActOn(account) ? '' : translate('screens/safe', 'View only'))}
       />
     </Form>

--- a/src/hooks/safe.hook.ts
+++ b/src/hooks/safe.hook.ts
@@ -343,12 +343,6 @@ export function useSafe(): UseSafeResult {
       : plain;
   }
 
-  function orderUrl(account: CustodyAccount | undefined): string {
-    return account !== undefined && !account.isLegacy && account.id !== null
-      ? `custody/account/${account.id}/order`
-      : 'custody/order';
-  }
-
   async function getBalances(account?: CustodyAccount): Promise<CustodyBalance> {
     return call<CustodyBalance>({ url: accountPath(account, 'balance', 'custody'), method: 'GET' });
   }
@@ -363,7 +357,7 @@ export function useSafe(): UseSafeResult {
 
   async function fetchPaymentInfo(data: OrderFormData): Promise<OrderPaymentInfo> {
     const order = await call<OrderPaymentInfo>({
-      url: orderUrl(selectedAccount),
+      url: accountPath(selectedAccount, 'order', 'custody/order'),
       method: 'POST',
       data: {
         type: CustodyOrderType.DEPOSIT,
@@ -381,7 +375,7 @@ export function useSafe(): UseSafeResult {
 
   async function fetchReceiveInfo(data: OrderFormData): Promise<OrderPaymentInfo> {
     const order = await call<OrderPaymentInfo>({
-      url: orderUrl(selectedAccount),
+      url: accountPath(selectedAccount, 'order', 'custody/order'),
       method: 'POST',
       data: {
         type: CustodyOrderType.RECEIVE,
@@ -398,7 +392,7 @@ export function useSafe(): UseSafeResult {
 
   async function fetchSwapInfo(data: OrderFormData): Promise<OrderPaymentInfo> {
     const order = await call<OrderPaymentInfo>({
-      url: orderUrl(selectedAccount),
+      url: accountPath(selectedAccount, 'order', 'custody/order'),
       method: 'POST',
       data: {
         type: CustodyOrderType.SWAP,
@@ -416,7 +410,7 @@ export function useSafe(): UseSafeResult {
 
   async function fetchWithdrawInfo(data: OrderFormData): Promise<OrderPaymentInfo> {
     const order = await call<OrderPaymentInfo>({
-      url: orderUrl(selectedAccount),
+      url: accountPath(selectedAccount, 'order', 'custody/order'),
       method: 'POST',
       data: {
         type: CustodyOrderType.WITHDRAWAL,
@@ -435,7 +429,7 @@ export function useSafe(): UseSafeResult {
 
   async function fetchSendInfo(data: SendOrderFormData): Promise<OrderPaymentInfo> {
     const order = await call<OrderPaymentInfo>({
-      url: orderUrl(selectedAccount),
+      url: accountPath(selectedAccount, 'order', 'custody/order'),
       method: 'POST',
       data: {
         type: CustodyOrderType.SEND,

--- a/src/hooks/safe.hook.ts
+++ b/src/hooks/safe.hook.ts
@@ -343,6 +343,12 @@ export function useSafe(): UseSafeResult {
       : plain;
   }
 
+  function orderUrl(account: CustodyAccount | undefined): string {
+    return account !== undefined && !account.isLegacy && account.id !== null
+      ? `custody/account/${account.id}/order`
+      : 'custody/order';
+  }
+
   async function getBalances(account?: CustodyAccount): Promise<CustodyBalance> {
     return call<CustodyBalance>({ url: accountPath(account, 'balance', 'custody'), method: 'GET' });
   }
@@ -357,7 +363,7 @@ export function useSafe(): UseSafeResult {
 
   async function fetchPaymentInfo(data: OrderFormData): Promise<OrderPaymentInfo> {
     const order = await call<OrderPaymentInfo>({
-      url: 'custody/order',
+      url: orderUrl(selectedAccount),
       method: 'POST',
       data: {
         type: CustodyOrderType.DEPOSIT,
@@ -375,7 +381,7 @@ export function useSafe(): UseSafeResult {
 
   async function fetchReceiveInfo(data: OrderFormData): Promise<OrderPaymentInfo> {
     const order = await call<OrderPaymentInfo>({
-      url: 'custody/order',
+      url: orderUrl(selectedAccount),
       method: 'POST',
       data: {
         type: CustodyOrderType.RECEIVE,
@@ -392,7 +398,7 @@ export function useSafe(): UseSafeResult {
 
   async function fetchSwapInfo(data: OrderFormData): Promise<OrderPaymentInfo> {
     const order = await call<OrderPaymentInfo>({
-      url: 'custody/order',
+      url: orderUrl(selectedAccount),
       method: 'POST',
       data: {
         type: CustodyOrderType.SWAP,
@@ -410,7 +416,7 @@ export function useSafe(): UseSafeResult {
 
   async function fetchWithdrawInfo(data: OrderFormData): Promise<OrderPaymentInfo> {
     const order = await call<OrderPaymentInfo>({
-      url: 'custody/order',
+      url: orderUrl(selectedAccount),
       method: 'POST',
       data: {
         type: CustodyOrderType.WITHDRAWAL,
@@ -429,7 +435,7 @@ export function useSafe(): UseSafeResult {
 
   async function fetchSendInfo(data: SendOrderFormData): Promise<OrderPaymentInfo> {
     const order = await call<OrderPaymentInfo>({
-      url: 'custody/order',
+      url: orderUrl(selectedAccount),
       method: 'POST',
       data: {
         type: CustodyOrderType.SEND,

--- a/src/util/__tests__/safe-account.test.ts
+++ b/src/util/__tests__/safe-account.test.ts
@@ -1,5 +1,15 @@
 import { CustodyAccount } from 'src/dto/safe.dto';
-import { canActOn } from '../safe-account';
+import { canActOn, isOwnAccount } from '../safe-account';
+
+function account(overrides: Partial<CustodyAccount>): CustodyAccount {
+  return {
+    id: 1,
+    title: 'Safe',
+    isLegacy: false,
+    accessLevel: 'Write',
+    ...overrides,
+  };
+}
 
 /**
  * Whether a Safe may be acted on decides whether the screen offers deposits, withdrawals and
@@ -7,16 +17,6 @@ import { canActOn } from '../safe-account';
  * it — and that is explicitly not a CI gate. This is.
  */
 describe('canActOn', () => {
-  function account(overrides: Partial<CustodyAccount>): CustodyAccount {
-    return {
-      id: 1,
-      title: 'Safe',
-      isLegacy: false,
-      accessLevel: 'Write',
-      ...overrides,
-    };
-  }
-
   it('allows acting on an own account with write access', () => {
     expect(canActOn(account({ accessLevel: 'Write' }))).toBe(true);
   });
@@ -37,5 +37,19 @@ describe('canActOn', () => {
 
   it("allows acting on the legacy Safe, which is the caller's own by definition", () => {
     expect(canActOn(account({ id: null, isLegacy: true, accessLevel: 'Write', owner: { id: 7 } }))).toBe(true);
+  });
+});
+
+describe('isOwnAccount', () => {
+  it('own non-legacy without owner → true', () => {
+    expect(isOwnAccount(account({ isLegacy: false }))).toBe(true);
+  });
+
+  it('foreign with owner → false', () => {
+    expect(isOwnAccount(account({ owner: { id: 42 } }))).toBe(false);
+  });
+
+  it('legacy (id null, isLegacy true, owner set) → true', () => {
+    expect(isOwnAccount(account({ id: null, isLegacy: true, owner: { id: 7 } }))).toBe(true);
   });
 });

--- a/src/util/__tests__/safe-account.test.ts
+++ b/src/util/__tests__/safe-account.test.ts
@@ -29,10 +29,10 @@ describe('canActOn', () => {
     expect(canActOn(account({ accessLevel: 'Read', owner: { id: 42 } }))).toBe(false);
   });
 
-  it('refuses acting on a foreign account even with a write mandate', () => {
-    // The case this predicate exists for. Orders carry no account, so acting here would book
-    // against the caller's own Safe while the screen names someone else's.
-    expect(canActOn(account({ accessLevel: 'Write', owner: { id: 42 } }))).toBe(false);
+  it('allows acting on a foreign account held under a write mandate', () => {
+    // The case this predicate exists for. Orders now go through the account resource, so a
+    // write mandate books against the selected Safe rather than the caller.
+    expect(canActOn(account({ accessLevel: 'Write', owner: { id: 42 } }))).toBe(true);
   });
 
   it("allows acting on the legacy Safe, which is the caller's own by definition", () => {

--- a/src/util/safe-account.ts
+++ b/src/util/safe-account.ts
@@ -13,12 +13,10 @@ export function isOwnAccount(account: CustodyAccount): boolean {
 }
 
 /**
- * Whether the caller may act on this Safe — own it and hold full disposal.
- *
- * A write grant on another person's account does not qualify. Orders carry no account, so an
- * order placed while looking at someone else's Safe would be booked against the caller's own,
- * and acting on another person's behalf does not exist in the backend at all.
+ * Whether the caller may act on this Safe — Write is enough, including a write mandate on
+ * someone else's Safe. Orders now go through the account resource, so they book against the
+ * selected Safe rather than the caller. Read (own or foreign) remains view-only.
  */
 export function canActOn(account: CustodyAccount): boolean {
-  return isOwnAccount(account) && account.accessLevel === 'Write';
+  return account.accessLevel === 'Write';
 }


### PR DESCRIPTION
EN:
A Write grant on someone else's Safe now offers Deposit, Withdraw and Swap. Those orders post to `custody/account/:id/order` so they book against that Safe, not the caller's. Read stays view-only.

DE:
Ein Write-Grant auf fremdem Safe bietet jetzt Einzahlen, Abheben und Tauschen. Die Orders gehen an `custody/account/:id/order` und landen auf diesem Safe, nicht auf dem des Callers. Read bleibt Ansicht.

<details>
<summary>Details</summary>

Depends on the matching API change in the custody backend (`POST /custody/account/:id/order`). Do not merge this before that endpoint is deployed.

Confirm remains `POST /custody/order/:id/confirm`. Legacy and own-account Write still use `POST /custody/order`. Visual baseline for the write-mandate screenshot is stale on purpose; e2e visuals are not a CI gate.

Declared deviation — per-file 100% coverage on `src/hooks/safe.hook.ts` and `src/components/safe/account-selector.tsx`: the hook change is URL wiring onto the existing `accountPath` helper; the selector change is a comment. `src/util/safe-account.ts` is covered by `src/util/__tests__/safe-account.test.ts` (`canActOn` and `isOwnAccount`). Bringing the whole hook and selector files to 100% is out of this pull request.

</details>