### PR TITLE
01a04227 - Expect buyCrypto update save to pass

### DIFF
--- a/e2e-stack/specs/buy.spec.ts
+++ b/e2e-stack/specs/buy.spec.ts
@@ -961,13 +961,7 @@ test.describe('Buy flow', () => {
     await expect(save).toBeDisabled();
   });
 
-  // Known API bug: BuyCryptoService.changeRoute throws when userData on the route is null under
-  // this request shape. test.fail keeps the case running; remove once the API is fixed.
   test('/buyCrypto/update: Admin save updates buyId and shows Saved', async ({ page }) => {
-    test.fail(
-      true,
-      'BuyCryptoService.changeRoute throws TypeError reading id of null userData on the route (API 500).',
-    );
     test.setTimeout(90000);
     const { jwt: adminJwt } = await loginAs('Admin');
 


### PR DESCRIPTION
EN:
The buyCrypto update save e2e was marked as expected to fail because the API 500ed. That bug is gone, so the annotation now makes the backend release E2E red.

DE:
Der buyCrypto-Update-Save-E2E war als expected-to-fail markiert, weil die API 500 geliefert hat. Der Bug ist weg; die Markierung macht den Backend-Release-E2E jetzt rot.

<details>
<summary>Details</summary>

Backend release [DFXswiss/backend#5249](https://github.com/DFXswiss/backend/pull/5249) Full-stack E2E:

`specs/buy.spec.ts` `/buyCrypto/update: Admin save updates buyId and shows Saved` — `Expected to fail, but passed.`

`test.fail(true, …)` removed. The case stays, now as a real assertion.

</details>