### PR TITLE
01a05c15 - test(e2e-stack): list Limit Requests as Compliance

### DIFF
--- a/e2e-stack/specs/support-dashboard.spec.ts
+++ b/e2e-stack/specs/support-dashboard.spec.ts
@@ -131,7 +131,9 @@ test.describe('Support dashboard (staff)', () => {
         ]);
     const issue = required(issueRow, 'createLimitRequest must leave a support_issue row');
 
-    const { jwt } = await loginAs('Support');
+    // Customer LimitRequests are filed under Department.Compliance. Support's issue list is
+    // restricted to Department.Support, so this listing uses Compliance (who can open the dashboard).
+    const { jwt } = await loginAs('Compliance');
     await openScreen(page, '/support/dashboard/all', jwt);
 
     await page.getByRole('button', { name: /^Limit Requests \(/ }).click();


### PR DESCRIPTION
EN:
The Limit Requests tab e2e listed a customer LimitRequest while logged in as Support, so Full-stack E2E failed. Support can only see Department.Support; those tickets are Department.Compliance. The listing test now logs in as Compliance, who can open the dashboard and see those issues.

DE:
Der Limit-Requests-Tab-E2E listete einen Kunden-LimitRequest als Support, deshalb ist Full-stack E2E rot. Support sieht nur Department.Support; diese Tickets liegen in Department.Compliance. Der Listing-Test loggt sich jetzt als Compliance ein, die das Dashboard öffnen und die Tickets sehen kann.

<details>
<summary>Details</summary>

The staff support-dashboard suite seeds a customer LimitRequest via `createLimitRequest` and then opened `/support/dashboard/all` as Support. The Limit Requests tab loads `Created`/`Pending` issues of type `LimitRequest` without the Open tab's type/department UI filters, but the API still applies JWT department visibility. Customer LimitRequests are filed under Department.Compliance; Support is restricted to Department.Support, so the seeded row never appeared (`getByText(issue.name)` timed out).

Compliance is already in `SUPPORT_DASHBOARD_ROLES` and can see Compliance-department issues. This change is the listing test only (`e2e-stack/specs/support-dashboard.spec.ts`); other tests in the file stay on Support. Application code is unchanged, so Support users still do not see customer LimitRequests in that tab.

Verification is Full-stack E2E with `ci:full` (local tests are not run on the authoring machine).

</details>