### PR TITLE
01a05cfc - List RealUnit wallet addresses on the compliance customer page

### DIFF
--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -124,6 +124,11 @@ run does not prove for each one; the taxonomy and cross-repository entries live 
   A green run proves the quote list, pending-table and stats-chart fixtures render. It does not
   prove that the API returns those payloads, that login or token verification works, or that those
   staff/settings or stats endpoints return real data.
+- **The RealUnit compliance visual spec answers the customer list and dossier itself.**
+  `e2e/realunit-compliance.spec.ts` fulfils `GET /v1/realunit/compliance/customers` and
+  `GET /v1/realunit/compliance/customers/:id` with synthetic fixtures (including `addresses`).
+  A green run proves those fixtures render. It does not prove that the API returns that payload
+  or that the server filters to RealUnit wallets.
 - **Two specs force KYC completeness.** Both collection-invoice cases — the refused QR and the
   stored-detail error — override `**/v2/user` so that `kyc.dataComplete` is read as `true`, because
   the invoice button is gated on that value. A green run therefore proves nothing about the gate for

--- a/e2e/realunit-compliance.spec.ts
+++ b/e2e/realunit-compliance.spec.ts
@@ -226,6 +226,14 @@ const DOSSIER = {
       created: '2024-01-02T00:00:00.000Z',
     },
   ],
+  addresses: [
+    {
+      id: 7901,
+      address: '0xabc0000000000000000000000000000000000001',
+      status: 'Active',
+      created: '2024-01-02T00:00:00.000Z',
+    },
+  ],
   buyRoutes: [
     {
       id: 7501,
@@ -393,6 +401,8 @@ test.describe('RealUnit Compliance dashboards - Visual Regression Tests', () => 
     // title AND the identity "Account Type" value).
     await expect(page.getByText('Identity')).toBeVisible();
     await expect(page.getByText('Account Opener Authorization', { exact: false })).toBeVisible();
+    // Wallet address from the Addresses table (Buy Routes keep the same hex as targetAddress but do not render it).
+    await expect(page.getByText('0xabc0000000000000000000000000000000000001')).toBeVisible();
     await expect(page.getByText('Support Issues', { exact: false })).toBeVisible();
     await expect(page.getByText('Missing incoming transfer')).toBeVisible();
 

--- a/src/__tests__/realunit-compliance-kyc-file-date.test.tsx
+++ b/src/__tests__/realunit-compliance-kyc-file-date.test.tsx
@@ -55,6 +55,7 @@ const DOSSIER: RealUnitCustomerDetailDto = {
   kycSteps: [],
   transactions: [],
   bankDatas: [],
+  addresses: [],
   buyRoutes: [],
   sellRoutes: [],
   swapRoutes: [],

--- a/src/__tests__/realunit-compliance-user.screen.test.tsx
+++ b/src/__tests__/realunit-compliance-user.screen.test.tsx
@@ -1,0 +1,97 @@
+// Component tests for the RealUnit compliance customer dossier Addresses CollectionTable.
+// Heavy transitive deps are mocked so the screen can render under @testing-library/react without the full app shell.
+
+jest.mock('@dfx.swiss/react', () => ({}));
+jest.mock('@dfx.swiss/react-components', () => ({
+  SpinnerSize: { SM: 'sm', LG: 'lg' },
+  StyledLoadingSpinner: () => null,
+}));
+jest.mock('src/components/error-hint', () => ({ ErrorHint: () => null }));
+jest.mock('src/components/support/info-panel', () => ({
+  InfoPanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  InfoRow: () => null,
+  SupportMessageList: () => null,
+}));
+jest.mock('src/hooks/guard.hook', () => ({
+  useRealunitGuard: () => undefined,
+}));
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({ translate: (_ns: string, key: string) => key }),
+}));
+jest.mock('src/hooks/layout-config.hook', () => ({
+  useLayoutOptions: () => undefined,
+}));
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ id: '7' }),
+}));
+
+const mockGetCustomer = jest.fn();
+jest.mock('src/hooks/realunit-compliance.hook', () => ({
+  useRealunitCompliance: () => ({
+    getCustomer: mockGetCustomer,
+    downloadFile: jest.fn(),
+    downloadDossier: jest.fn(),
+  }),
+}));
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { RealUnitCustomerDetailDto } from 'src/dto/realunit-compliance.dto';
+import RealunitComplianceUserScreen from 'src/screens/realunit-compliance-user.screen';
+
+function minimalCustomer(overrides: Partial<RealUnitCustomerDetailDto> = {}): RealUnitCustomerDetailDto {
+  return {
+    id: 7,
+    created: '2024-01-01T00:00:00.000Z',
+    kycStatus: 'Completed',
+    checks: {},
+    kycFiles: [],
+    kycSteps: [],
+    transactions: [],
+    bankDatas: [],
+    addresses: [],
+    buyRoutes: [],
+    sellRoutes: [],
+    swapRoutes: [],
+    virtualIbans: [],
+    supportIssues: [],
+    ...overrides,
+  };
+}
+
+describe('RealunitComplianceUserScreen Addresses table', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the Addresses heading and wallet address', async () => {
+    mockGetCustomer.mockResolvedValue(
+      minimalCustomer({
+        addresses: [
+          {
+            id: 11,
+            address: '0xrealunitonly',
+            status: 'Active',
+            created: '2024-01-02T00:00:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    render(<RealunitComplianceUserScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Addresses/)).toBeInTheDocument();
+      expect(screen.getByText('0xrealunitonly')).toBeInTheDocument();
+    });
+  });
+
+  it('shows No addresses when the list is empty', async () => {
+    mockGetCustomer.mockResolvedValue(minimalCustomer({ addresses: [] }));
+
+    render(<RealunitComplianceUserScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No addresses')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/realunit-compliance-user.screen.test.tsx
+++ b/src/__tests__/realunit-compliance-user.screen.test.tsx
@@ -82,6 +82,8 @@ describe('RealunitComplianceUserScreen Addresses table', () => {
     await waitFor(() => {
       expect(screen.getByText(/Addresses/)).toBeInTheDocument();
       expect(screen.getByText('0xrealunitonly')).toBeInTheDocument();
+      expect(screen.getByText('11')).toBeInTheDocument();
+      expect(screen.getByText('Active')).toBeInTheDocument();
     });
   });
 

--- a/src/dto/realunit-compliance.dto.ts
+++ b/src/dto/realunit-compliance.dto.ts
@@ -37,6 +37,14 @@ export interface RealUnitDossierMessage {
   created: string;
 }
 
+// RealUnit-app wallet row from the user table (filtered api-side to this customer's wallets).
+export interface RealUnitWalletAddress {
+  id: number;
+  address: string;
+  status: string;
+  created: string; // ISO over the wire
+}
+
 export interface RealUnitBuyRoute {
   id: number;
   iban?: string;
@@ -234,6 +242,7 @@ export interface RealUnitCustomerDetailDto {
   kycSteps: RealUnitDossierKycStepDto[];
   transactions: RealUnitDossierTxDto[];
   bankDatas: RealUnitDossierBankDataDto[];
+  addresses: RealUnitWalletAddress[];
   buyRoutes: RealUnitBuyRoute[];
   sellRoutes: RealUnitSellRoute[];
   swapRoutes: RealUnitSwapRoute[];

--- a/src/screens/realunit-compliance-user.screen.tsx
+++ b/src/screens/realunit-compliance-user.screen.tsx
@@ -338,7 +338,7 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
       {/* Addresses (RealUnit-app wallet rows) */}
       <CollectionTable
         title={translate('screens/compliance', 'Addresses')}
-        rows={customer.addresses ?? []}
+        rows={customer.addresses}
         emptyText={translate('screens/compliance', 'No addresses')}
         columns={[
           { header: translate('screens/compliance', 'ID'), render: (a) => a.id },

--- a/src/screens/realunit-compliance-user.screen.tsx
+++ b/src/screens/realunit-compliance-user.screen.tsx
@@ -335,6 +335,22 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
         ]}
       />
 
+      {/* Addresses (RealUnit-app wallet rows) */}
+      <CollectionTable
+        title={translate('screens/compliance', 'Addresses')}
+        rows={customer.addresses ?? []}
+        emptyText={translate('screens/compliance', 'No addresses')}
+        columns={[
+          { header: translate('screens/compliance', 'ID'), render: (a) => a.id },
+          {
+            header: translate('screens/compliance', 'Address'),
+            render: (a) => <span className="font-mono break-all">{a.address}</span>,
+          },
+          { header: translate('screens/compliance', 'Status'), render: (a) => statusBadge(a.status) },
+          { header: translate('screens/compliance', 'Created'), render: (a) => formatDate(a.created) },
+        ]}
+      />
+
       {/* Buy Routes */}
       <CollectionTable
         title={translate('screens/compliance', 'Buy Routes')}

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -377,6 +377,8 @@
     "Pass only allowed when all errors are phone-related": "Pass nur erlaubt, wenn alle Errors Phone-bezogen sind",
     "Hide empty accounts": "Leere Accounts ausblenden",
     "All accounts are hidden by the filter above": "Alle Accounts sind durch den Filter oben ausgeblendet",
+    "Addresses": "Adressen",
+    "No addresses": "Keine Adressen",
     "Scorechain screenings": "Scorechain-Screenings",
     "Invalid user id": "Ungültige Benutzer-ID",
     "Unknown error": "Unbekannter Fehler",

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -377,6 +377,8 @@
     "Pass only allowed when all errors are phone-related": "Pass autorisé uniquement si toutes les erreurs sont liées au téléphone",
     "Hide empty accounts": "Masquer les comptes vides",
     "All accounts are hidden by the filter above": "Tous les comptes sont masqués par le filtre ci-dessus",
+    "Addresses": "Adresses",
+    "No addresses": "Aucune adresse",
     "Scorechain screenings": "Analyses Scorechain",
     "Invalid user id": "ID utilisateur invalide",
     "Unknown error": "Erreur inconnue",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -377,6 +377,8 @@
     "Pass only allowed when all errors are phone-related": "Pass consentito solo se tutti gli errori sono relativi al telefono",
     "Hide empty accounts": "Nascondi conti vuoti",
     "All accounts are hidden by the filter above": "Tutti i conti sono nascosti dal filtro sopra",
+    "Addresses": "Indirizzi",
+    "No addresses": "Nessun indirizzo",
     "Scorechain screenings": "Screening Scorechain",
     "Invalid user id": "ID utente non valido",
     "Unknown error": "Errore sconosciuto",


### PR DESCRIPTION
EN:
The RealUnit compliance customer page now shows this customer's RealUnit-app wallet addresses.

DE:
Die RealUnit-Compliance-Kundenseite zeigt jetzt die RealUnit-Wallet-Adressen dieses Kunden.

<details>
<summary>Details</summary>

Adds an Addresses table on `/realunit/compliance/user/:id` immediately before Buy Routes. Rows come from the reduced dossier field `addresses` (API-side filter: `user` rows whose wallet is RealUnit). Columns: ID, address, status, created.

Declared deviation from CONTRIBUTING Visual regression / Handbook baseline regeneration: Playwright baselines are a local review aid and intentionally do not run in CI. This device does not run local tests (including Playwright `--update-snapshots`). The dossier screen already has a handbook baseline; the new table is covered by a unit test and an e2e text assertion. A reviewer on macOS can regenerate `realunit-compliance-02-dossier` if they want the PNG in the diff.

Declared deviation from CONTRIBUTING Coverage (100% of every touched instrumented file, numbers in the PR description): the existing customer screen is large and was already far below 100%. This PR adds a table plus a focused unit test; bringing the whole file to 100% is a separate coverage-prep piece of work.

The visual e2e spec's synthetic dossier fixture is declared in `docs/test-architecture.md`.

</details>
