### PR TITLE
01a05d03 - Join overlapping KYC continue calls after ident

### DIFF
--- a/src/screens/kyc.screen.tsx
+++ b/src/screens/kyc.screen.tsx
@@ -128,7 +128,8 @@ export default function KycScreen(): JSX.Element {
   const [showLinkHint, setShowLinkHint] = useState(false);
   const [isCanceling, setIsCanceling] = useState(false);
   const { rootRef } = useLayoutContext();
-  const loadFlight = useRef(createSingleFlight());
+  const continueFlight = useRef(createSingleFlight());
+  const infoFlight = useRef(createSingleFlight());
 
   const mode = pathname.includes('/profile') ? Mode.PROFILE : pathname.includes('/contact') ? Mode.CONTACT : Mode.KYC;
   const urlParams = new URLSearchParams(search);
@@ -214,7 +215,8 @@ export default function KycScreen(): JSX.Element {
   async function onLoad(next: boolean): Promise<void> {
     if (!kycCode) return;
 
-    return loadFlight.current(() => {
+    const flight = next ? continueFlight : infoFlight;
+    return flight.current(() => {
       setIsSubmitting(true);
       setError(undefined);
       setShowLinkHint(false);

--- a/src/screens/kyc.screen.tsx
+++ b/src/screens/kyc.screen.tsx
@@ -70,7 +70,7 @@ import {
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
 import SumsubWebSdk from '@sumsub/websdk-react';
-import { RefObject, useEffect, useState } from 'react';
+import { RefObject, useEffect, useRef, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { useForm, useWatch } from 'react-hook-form';
 import { Trans } from 'react-i18next';
@@ -90,6 +90,7 @@ import { useUserGuard } from '../hooks/guard.hook';
 import { useKycHelper } from '../hooks/kyc-helper.hook';
 import { useLayoutOptions } from '../hooks/layout-config.hook';
 import { useNavigation } from '../hooks/navigation.hook';
+import { createSingleFlight } from '../util/single-flight';
 import { delay, toBase64, url } from '../util/utils';
 import { AddressZipValidation } from '../util/validation-rules';
 import { IframeMessageType } from './kyc-redirect.screen';
@@ -127,6 +128,7 @@ export default function KycScreen(): JSX.Element {
   const [showLinkHint, setShowLinkHint] = useState(false);
   const [isCanceling, setIsCanceling] = useState(false);
   const { rootRef } = useLayoutContext();
+  const loadFlight = useRef(createSingleFlight());
 
   const mode = pathname.includes('/profile') ? Mode.PROFILE : pathname.includes('/contact') ? Mode.CONTACT : Mode.KYC;
   const urlParams = new URLSearchParams(search);
@@ -212,14 +214,16 @@ export default function KycScreen(): JSX.Element {
   async function onLoad(next: boolean): Promise<void> {
     if (!kycCode) return;
 
-    setIsSubmitting(true);
-    setError(undefined);
-    setShowLinkHint(false);
-    setConsentClient(undefined);
-    return (next ? callKyc(() => continueKyc(kycCode)) : callKyc(() => getKycInfo(kycCode)))
-      .then(handleReload)
-      .catch((error: ApiError) => setError(error.message ?? 'Unknown error'))
-      .finally(() => setIsSubmitting(false));
+    return loadFlight.current(() => {
+      setIsSubmitting(true);
+      setError(undefined);
+      setShowLinkHint(false);
+      setConsentClient(undefined);
+      return (next ? callKyc(() => continueKyc(kycCode)) : callKyc(() => getKycInfo(kycCode)))
+        .then(handleReload)
+        .catch((error: ApiError) => setError(error.message ?? 'Unknown error'))
+        .finally(() => setIsSubmitting(false));
+    });
   }
 
   async function handleInitial(info: KycInfo): Promise<void> {
@@ -1800,23 +1804,30 @@ function Ident({ step, lang, onDone, onBack, onError }: EditProps): JSX.Element 
   const [isDone, setIsDone] = useState(false);
   const [error, setError] = useState<string>();
 
-  useEffect(() => {
-    onDone();
+  const onDoneRef = useRef(onDone);
+  const onBackRef = useRef(onBack);
+  onDoneRef.current = onDone;
+  onBackRef.current = onBack;
 
-    const refreshInterval = setInterval(() => isDone && onDone(), 1000);
+  useEffect(() => {
+    if (!isDone) return;
+
+    onDoneRef.current();
+    const refreshInterval = setInterval(() => onDoneRef.current(), 1000);
     return () => clearInterval(refreshInterval);
   }, [isDone]);
 
-  // listen to close events
   useEffect(() => {
-    window.addEventListener('message', onMessage);
-    return () => window.removeEventListener('keydown', onMessage);
-  }, []);
+    function onMessage(e: Event) {
+      const message = (e as MessageEvent<{ type: string; status: KycStepStatus }>).data;
+      if (message.type === IframeMessageType) {
+        isStepDone(message as KycStepBase) ? onDoneRef.current() : onBackRef.current();
+      }
+    }
 
-  function onMessage(e: Event) {
-    const message = (e as MessageEvent<{ type: string; status: KycStepStatus }>).data;
-    if (message.type === IframeMessageType) isStepDone(message as KycStepBase) ? onDone() : onBack();
-  }
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, []);
 
   return step.session ? (
     error ? (

--- a/src/screens/kyc.screen.tsx
+++ b/src/screens/kyc.screen.tsx
@@ -216,6 +216,7 @@ export default function KycScreen(): JSX.Element {
   async function onLoad(next: boolean): Promise<void> {
     if (!kycCode) return;
 
+    if (!next) continueFlight.current = createSingleFlight();
     const flight = next ? continueFlight : infoFlight;
     return flight.current(() => {
       const gen = ++loadGen.current;
@@ -245,7 +246,7 @@ export default function KycScreen(): JSX.Element {
       if (info.kycLevel >= RequiredKycLevel[mode] || !kycCode) {
         goBack();
       } else {
-        return callKyc(() => continueKyc(kycCode)).then(handleReload);
+        return onLoad(true);
       }
     }
   }

--- a/src/screens/kyc.screen.tsx
+++ b/src/screens/kyc.screen.tsx
@@ -130,6 +130,7 @@ export default function KycScreen(): JSX.Element {
   const { rootRef } = useLayoutContext();
   const continueFlight = useRef(createSingleFlight());
   const infoFlight = useRef(createSingleFlight());
+  const loadGen = useRef(0);
 
   const mode = pathname.includes('/profile') ? Mode.PROFILE : pathname.includes('/contact') ? Mode.CONTACT : Mode.KYC;
   const urlParams = new URLSearchParams(search);
@@ -217,14 +218,23 @@ export default function KycScreen(): JSX.Element {
 
     const flight = next ? continueFlight : infoFlight;
     return flight.current(() => {
+      const gen = ++loadGen.current;
       setIsSubmitting(true);
       setError(undefined);
       setShowLinkHint(false);
       setConsentClient(undefined);
       return (next ? callKyc(() => continueKyc(kycCode)) : callKyc(() => getKycInfo(kycCode)))
-        .then(handleReload)
-        .catch((error: ApiError) => setError(error.message ?? 'Unknown error'))
-        .finally(() => setIsSubmitting(false));
+        .then((info) => {
+          if (gen !== loadGen.current) return;
+          return handleReload(info);
+        })
+        .catch((error: ApiError) => {
+          if (gen !== loadGen.current) return;
+          setError(error.message ?? 'Unknown error');
+        })
+        .finally(() => {
+          if (gen === loadGen.current) setIsSubmitting(false);
+        });
     });
   }
 

--- a/src/screens/kyc.screen.tsx
+++ b/src/screens/kyc.screen.tsx
@@ -205,18 +205,19 @@ export default function KycScreen(): JSX.Element {
         )
           .then(handleReload)
           .then(() => clearParams(['step']))
-      : callKyc(() => getKycInfo(kycCode)).then(handleInitial);
+      : callKyc(() => getKycInfo(kycCode)).then(async (info) => {
+          setError(undefined);
+          await handleInitial(info);
+        });
 
-    request
-      .then(() => setError(undefined))
-      .catch((error: ApiError) => setError(error.message ?? 'Unknown error'))
-      .finally(() => setIsLoading(false));
+    request.catch((error: ApiError) => setError(error.message ?? 'Unknown error')).finally(() => setIsLoading(false));
   }, [kycCode, stepName, stepType]);
 
   async function onLoad(next: boolean): Promise<void> {
     if (!kycCode) return;
 
-    if (!next) continueFlight.current = createSingleFlight();
+    if (next) infoFlight.current = createSingleFlight();
+    else continueFlight.current = createSingleFlight();
     const flight = next ? continueFlight : infoFlight;
     return flight.current(() => {
       const gen = ++loadGen.current;

--- a/src/screens/kyc.screen.tsx
+++ b/src/screens/kyc.screen.tsx
@@ -202,7 +202,10 @@ export default function KycScreen(): JSX.Element {
             stepSequence ? +stepSequence : undefined,
           ),
         )
-          .then(handleReload)
+          .then((session) => {
+            setError(undefined);
+            return handleReload(session);
+          })
           .then(() => clearParams(['step']))
       : callKyc(() => getKycInfo(kycCode)).then(async (info) => {
           setError(undefined);

--- a/src/screens/kyc.screen.tsx
+++ b/src/screens/kyc.screen.tsx
@@ -90,7 +90,7 @@ import { useUserGuard } from '../hooks/guard.hook';
 import { useKycHelper } from '../hooks/kyc-helper.hook';
 import { useLayoutOptions } from '../hooks/layout-config.hook';
 import { useNavigation } from '../hooks/navigation.hook';
-import { createSingleFlight } from '../util/single-flight';
+import { createKeyedSerial } from '../util/single-flight';
 import { delay, toBase64, url } from '../util/utils';
 import { AddressZipValidation } from '../util/validation-rules';
 import { IframeMessageType } from './kyc-redirect.screen';
@@ -128,8 +128,7 @@ export default function KycScreen(): JSX.Element {
   const [showLinkHint, setShowLinkHint] = useState(false);
   const [isCanceling, setIsCanceling] = useState(false);
   const { rootRef } = useLayoutContext();
-  const continueFlight = useRef(createSingleFlight());
-  const infoFlight = useRef(createSingleFlight());
+  const loadSerial = useRef(createKeyedSerial());
   const loadGen = useRef(0);
 
   const mode = pathname.includes('/profile') ? Mode.PROFILE : pathname.includes('/contact') ? Mode.CONTACT : Mode.KYC;
@@ -216,10 +215,7 @@ export default function KycScreen(): JSX.Element {
   async function onLoad(next: boolean): Promise<void> {
     if (!kycCode) return;
 
-    if (next) infoFlight.current = createSingleFlight();
-    else continueFlight.current = createSingleFlight();
-    const flight = next ? continueFlight : infoFlight;
-    return flight.current(() => {
+    return loadSerial.current(next ? 'continue' : 'info', () => {
       const gen = ++loadGen.current;
       setIsSubmitting(true);
       setError(undefined);

--- a/src/util/__tests__/single-flight.test.ts
+++ b/src/util/__tests__/single-flight.test.ts
@@ -14,6 +14,7 @@ describe('createKeyedSerial', () => {
 
     const first = run('continue', fn);
     const second = run('continue', fn);
+    await Promise.resolve();
     expect(calls).toBe(1);
 
     resolveFirst('ok');
@@ -39,6 +40,7 @@ describe('createKeyedSerial', () => {
       return Promise.resolve('info');
     });
 
+    await Promise.resolve();
     expect(continueCalls).toBe(1);
     expect(infoCalls).toBe(0);
 
@@ -65,6 +67,7 @@ describe('createKeyedSerial', () => {
       return Promise.resolve('second');
     });
 
+    await Promise.resolve();
     expect(continueCalls).toBe(1);
     resolveContinue('put');
     await expect(first).resolves.toBe('put');
@@ -120,6 +123,7 @@ describe('createKeyedSerial', () => {
       });
     });
 
+    await Promise.resolve();
     expect(aCalls).toBe(1);
     expect(bCalls).toBe(1);
 

--- a/src/util/__tests__/single-flight.test.ts
+++ b/src/util/__tests__/single-flight.test.ts
@@ -48,6 +48,31 @@ describe('createKeyedSerial', () => {
     expect(infoCalls).toBe(1);
   });
 
+  it('joins a second continue while an info load is queued', async () => {
+    const run = createKeyedSerial();
+    let continueCalls = 0;
+    let resolveContinue: (value: string) => void = () => undefined;
+
+    const first = run('continue', () => {
+      continueCalls += 1;
+      return new Promise<string>((resolve) => {
+        resolveContinue = resolve;
+      });
+    });
+    const infoP = run('info', () => Promise.resolve('info'));
+    const second = run('continue', () => {
+      continueCalls += 1;
+      return Promise.resolve('second');
+    });
+
+    expect(continueCalls).toBe(1);
+    resolveContinue('put');
+    await expect(first).resolves.toBe('put');
+    await expect(second).resolves.toBe('put');
+    await expect(infoP).resolves.toBe('info');
+    expect(continueCalls).toBe(1);
+  });
+
   it('invokes fn again after the previous call with the same key resolves', async () => {
     const run = createKeyedSerial();
     let calls = 0;

--- a/src/util/__tests__/single-flight.test.ts
+++ b/src/util/__tests__/single-flight.test.ts
@@ -1,0 +1,80 @@
+import { createSingleFlight } from '../single-flight';
+
+describe('createSingleFlight', () => {
+  it('joins overlapping calls and invokes fn once', async () => {
+    const run = createSingleFlight();
+    let calls = 0;
+    let resolveFirst: (value: string) => void = () => undefined;
+    const fn = () => {
+      calls += 1;
+      return new Promise<string>((resolve) => {
+        resolveFirst = resolve;
+      });
+    };
+
+    const first = run(fn);
+    const second = run(fn);
+    expect(calls).toBe(1);
+
+    resolveFirst('ok');
+    await expect(first).resolves.toBe('ok');
+    await expect(second).resolves.toBe('ok');
+    expect(calls).toBe(1);
+  });
+
+  it('invokes fn again after the previous call resolves', async () => {
+    const run = createSingleFlight();
+    let calls = 0;
+    const fn = () => {
+      calls += 1;
+      return Promise.resolve(calls);
+    };
+
+    await expect(run(fn)).resolves.toBe(1);
+    await expect(run(fn)).resolves.toBe(2);
+    expect(calls).toBe(2);
+  });
+
+  it('invokes fn again after the previous call rejects', async () => {
+    const run = createSingleFlight();
+    let calls = 0;
+    const fn = () => {
+      calls += 1;
+      return calls === 1 ? Promise.reject(new Error('boom')) : Promise.resolve('recovered');
+    };
+
+    await expect(run(fn)).rejects.toThrow('boom');
+    await expect(run(fn)).resolves.toBe('recovered');
+    expect(calls).toBe(2);
+  });
+
+  it('does not share in-flight state between instances', async () => {
+    const a = createSingleFlight();
+    const b = createSingleFlight();
+    let aCalls = 0;
+    let bCalls = 0;
+    let resolveA: (value: string) => void = () => undefined;
+    let resolveB: (value: string) => void = () => undefined;
+
+    const pA = a(() => {
+      aCalls += 1;
+      return new Promise<string>((resolve) => {
+        resolveA = resolve;
+      });
+    });
+    const pB = b(() => {
+      bCalls += 1;
+      return new Promise<string>((resolve) => {
+        resolveB = resolve;
+      });
+    });
+
+    expect(aCalls).toBe(1);
+    expect(bCalls).toBe(1);
+
+    resolveA('a');
+    resolveB('b');
+    await expect(pA).resolves.toBe('a');
+    await expect(pB).resolves.toBe('b');
+  });
+});

--- a/src/util/__tests__/single-flight.test.ts
+++ b/src/util/__tests__/single-flight.test.ts
@@ -1,8 +1,8 @@
-import { createSingleFlight } from '../single-flight';
+import { createKeyedSerial } from '../single-flight';
 
-describe('createSingleFlight', () => {
-  it('joins overlapping calls and invokes fn once', async () => {
-    const run = createSingleFlight();
+describe('createKeyedSerial', () => {
+  it('joins overlapping calls with the same key and invokes fn once', async () => {
+    const run = createKeyedSerial();
     let calls = 0;
     let resolveFirst: (value: string) => void = () => undefined;
     const fn = () => {
@@ -12,8 +12,8 @@ describe('createSingleFlight', () => {
       });
     };
 
-    const first = run(fn);
-    const second = run(fn);
+    const first = run('continue', fn);
+    const second = run('continue', fn);
     expect(calls).toBe(1);
 
     resolveFirst('ok');
@@ -22,47 +22,73 @@ describe('createSingleFlight', () => {
     expect(calls).toBe(1);
   });
 
-  it('invokes fn again after the previous call resolves', async () => {
-    const run = createSingleFlight();
+  it('queues a different key behind the in-flight one', async () => {
+    const run = createKeyedSerial();
+    let continueCalls = 0;
+    let infoCalls = 0;
+    let resolveContinue: (value: string) => void = () => undefined;
+
+    const continueP = run('continue', () => {
+      continueCalls += 1;
+      return new Promise<string>((resolve) => {
+        resolveContinue = resolve;
+      });
+    });
+    const infoP = run('info', () => {
+      infoCalls += 1;
+      return Promise.resolve('info');
+    });
+
+    expect(continueCalls).toBe(1);
+    expect(infoCalls).toBe(0);
+
+    resolveContinue('put');
+    await expect(continueP).resolves.toBe('put');
+    await expect(infoP).resolves.toBe('info');
+    expect(infoCalls).toBe(1);
+  });
+
+  it('invokes fn again after the previous call with the same key resolves', async () => {
+    const run = createKeyedSerial();
     let calls = 0;
     const fn = () => {
       calls += 1;
       return Promise.resolve(calls);
     };
 
-    await expect(run(fn)).resolves.toBe(1);
-    await expect(run(fn)).resolves.toBe(2);
+    await expect(run('continue', fn)).resolves.toBe(1);
+    await expect(run('continue', fn)).resolves.toBe(2);
     expect(calls).toBe(2);
   });
 
   it('invokes fn again after the previous call rejects', async () => {
-    const run = createSingleFlight();
+    const run = createKeyedSerial();
     let calls = 0;
     const fn = () => {
       calls += 1;
       return calls === 1 ? Promise.reject(new Error('boom')) : Promise.resolve('recovered');
     };
 
-    await expect(run(fn)).rejects.toThrow('boom');
-    await expect(run(fn)).resolves.toBe('recovered');
+    await expect(run('continue', fn)).rejects.toThrow('boom');
+    await expect(run('continue', fn)).resolves.toBe('recovered');
     expect(calls).toBe(2);
   });
 
   it('does not share in-flight state between instances', async () => {
-    const a = createSingleFlight();
-    const b = createSingleFlight();
+    const a = createKeyedSerial();
+    const b = createKeyedSerial();
     let aCalls = 0;
     let bCalls = 0;
     let resolveA: (value: string) => void = () => undefined;
     let resolveB: (value: string) => void = () => undefined;
 
-    const pA = a(() => {
+    const pA = a('continue', () => {
       aCalls += 1;
       return new Promise<string>((resolve) => {
         resolveA = resolve;
       });
     });
-    const pB = b(() => {
+    const pB = b('continue', () => {
       bCalls += 1;
       return new Promise<string>((resolve) => {
         resolveB = resolve;

--- a/src/util/single-flight.ts
+++ b/src/util/single-flight.ts
@@ -1,23 +1,19 @@
 export function createKeyedSerial(): <T>(key: string, fn: () => Promise<T>) => Promise<T> {
   let tail: Promise<void> = Promise.resolve();
-  let currentKey: string | undefined;
-  let current: Promise<unknown> | undefined;
+  const inflight = new Map<string, Promise<unknown>>();
 
   return function run<T>(key: string, fn: () => Promise<T>): Promise<T> {
-    if (current && currentKey === key) return current as Promise<T>;
+    const existing = inflight.get(key);
+    if (existing) return existing as Promise<T>;
 
     const next = tail.then(fn, fn);
-    currentKey = key;
-    current = next;
+    inflight.set(key, next);
     tail = next.then(
       () => undefined,
       () => undefined,
     );
-    next.finally(() => {
-      if (current === next) {
-        current = undefined;
-        currentKey = undefined;
-      }
+    void next.finally(() => {
+      if (inflight.get(key) === next) inflight.delete(key);
     });
     return next;
   };

--- a/src/util/single-flight.ts
+++ b/src/util/single-flight.ts
@@ -12,9 +12,8 @@ export function createKeyedSerial(): <T>(key: string, fn: () => Promise<T>) => P
       () => undefined,
       () => undefined,
     );
-    void next.finally(() => {
-      if (inflight.get(key) === next) inflight.delete(key);
-    });
+    const cleanup = () => inflight.delete(key);
+    void next.then(cleanup, cleanup);
     return next;
   };
 }

--- a/src/util/single-flight.ts
+++ b/src/util/single-flight.ts
@@ -1,0 +1,13 @@
+export function createSingleFlight(): <T>(fn: () => Promise<T>) => Promise<T> {
+  let inflight: Promise<unknown> | undefined;
+
+  return function run<T>(fn: () => Promise<T>): Promise<T> {
+    if (inflight) return inflight as Promise<T>;
+
+    const next = fn().finally(() => {
+      inflight = undefined;
+    });
+    inflight = next;
+    return next;
+  };
+}

--- a/src/util/single-flight.ts
+++ b/src/util/single-flight.ts
@@ -1,13 +1,24 @@
-export function createSingleFlight(): <T>(fn: () => Promise<T>) => Promise<T> {
-  let inflight: Promise<unknown> | undefined;
+export function createKeyedSerial(): <T>(key: string, fn: () => Promise<T>) => Promise<T> {
+  let tail: Promise<void> = Promise.resolve();
+  let currentKey: string | undefined;
+  let current: Promise<unknown> | undefined;
 
-  return function run<T>(fn: () => Promise<T>): Promise<T> {
-    if (inflight) return inflight as Promise<T>;
+  return function run<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    if (current && currentKey === key) return current as Promise<T>;
 
-    const next = fn().finally(() => {
-      inflight = undefined;
+    const next = tail.then(fn, fn);
+    currentKey = key;
+    current = next;
+    tail = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    next.finally(() => {
+      if (current === next) {
+        current = undefined;
+        currentKey = undefined;
+      }
     });
-    inflight = next;
     return next;
   };
 }


### PR DESCRIPTION
EN:
The ident screen was sending many parallel continue requests when Sumsub finished. This change joins overlapping continue calls, queues a different kind of load behind them, and only continues after ident is actually done.

DE:
Der Ident-Screen hat nach Sumsub viele parallele Continue-Requests geschickt. Überlappende Continues werden zusammengeführt, ein anderer Load-Typ wartet dahinter, und Continue läuft erst, wenn die Ident wirklich fertig ist.

<details>
<summary>Details</summary>

The Ident step called continue on mount, polled every second, and leaked a window `message` listener because cleanup used `keydown`. Concurrent continues raced on creating the next KYC step.

- `createKeyedSerial()` joins overlapping work with the same key and queues a different key.
- `onLoad` uses keys `continue` and `info` plus a generation so stale replies are ignored.
- Ident calls continue only when `isDone` is true, keeps the 1s poll for webhook lag, and removes the `message` listener correctly.
- Unit tests cover same-key join, different-key queue, retry after resolve/reject, and independent instances.

Coverage (review gate, not CI):

- `src/util/single-flight.ts`: 100% statements / branches / functions / lines by inspection of `src/util/__tests__/single-flight.test.ts`.
- `src/screens/kyc.screen.tsx`: not 100%. Declared deviation from CONTRIBUTING unit-test coverage: this screen is a long-neglected file (~2800 lines, no existing unit suite). The failure mode is tested at the lowest layer (`createKeyedSerial`). Bringing the whole screen to 100% is out of scope for this continue-race fix.

</details>