### PR TITLE
01a05d03 - E2E for 13 parallel KYC continues

### DIFF
--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -185,6 +185,10 @@ run does not prove for each one; the taxonomy and cross-repository entries live 
   `(userDataId, name, type, sequenceNumber)` and creates `IDX_3a1150791476264753a67212a1`
   with `NULLS NOT DISTINCT`, matching production. A green run does **not** prove the
   migration chain applied that index.
+- **Full-stack continue-race specs SQL-complete KYC steps.**
+  `e2e-stack/specs/kyc-continue-race.spec.ts` upserts ContactData, PersonalData, NationalityData
+  and Ident (`SumsubAuto`) to `Completed`. A green run does **not** prove those steps complete
+  through the product path, including live ident.
 - **The settings verification-call visual spec answers GET /v2/user itself.**
   `e2e/settings-verification-call.spec.ts` fulfils `/v2/user` with three synthetic kyc payloads
   (`phoneCallAccepted` unset / true / false) and fulfils the Settings bootstrap GETs

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -173,6 +173,18 @@ run does not prove for each one; the taxonomy and cross-repository entries live 
   `e2e-stack/specs/buy.spec.ts` (`openQuoteCapableBuy` and older quote cases) updates the limit
   directly so `LIMIT_EXCEEDED` does not hide payment info. A green run does **not** prove that a
   customer reaches that limit through the product path.
+- **Full-stack continue-race specs SQL-write `user_data.tradeApprovalDate`.**
+  `e2e-stack/specs/kyc-continue-race.spec.ts` sets the date so recommendation is skipped. A green
+  run does **not** prove that a customer obtains trade approval through the product path.
+- **Full-stack continue-race specs SQL-insert STRICT `TfaLog` rows.**
+  `e2e-stack/specs/kyc-continue-race.spec.ts` inserts `kyc_log` type `TfaLog` with comment
+  `Strict (App)` so `continue()` does not 403 after FinancialData starts. A green run does
+  **not** prove the mail/app 2FA enrolment or verification path.
+- **Full-stack continue-race specs recreate `kyc_step` unique index `NULLS NOT DISTINCT`.**
+  `e2e-stack/specs/kyc-continue-race.spec.ts` drops the synchronize unique index on
+  `(userDataId, name, type, sequenceNumber)` and creates `IDX_3a1150791476264753a67212a1`
+  with `NULLS NOT DISTINCT`, matching production. A green run does **not** prove the
+  migration chain applied that index.
 - **The settings verification-call visual spec answers GET /v2/user itself.**
   `e2e/settings-verification-call.spec.ts` fulfils `/v2/user` with three synthetic kyc payloads
   (`phoneCallAccepted` unset / true / false) and fulfils the Settings bootstrap GETs

--- a/e2e-stack/specs/kyc-continue-race.spec.ts
+++ b/e2e-stack/specs/kyc-continue-race.spec.ts
@@ -4,20 +4,40 @@
  * Production failure: after Sumsub ident finished, the client fired many overlapping
  * PUT /v2/kyc calls; one FinancialData insert won and the rest hit the unique index.
  *
- * This file covers both sides of that seam:
- *   1. Direct API — 13 parallel continues; the advisory lock must leave one FinancialData row.
- *   2. Browser /kyc after ident — at most two overlapping continue PUTs, then a second
- *      13-call burst still leaves one FinancialData row.
+ * Lowest layer that can express that: 13 parallel continues against a live API and
+ * Postgres. FinancialData has a NULL type, so the unique index only conflicts when it is
+ * NULLS NOT DISTINCT (production). The harness schema comes from synchronize, so this file
+ * recreates that index before the burst. All HTTP 200 plus COUNT=1 would also pass on the
+ * old duplicate-key retry path; xact_rollback must stay flat because a unique-violation
+ * aborts the initiateStep transaction.
  */
 
-import type { Page } from '@playwright/test';
-import { createKycStep, createUser, expect, gotoWithSession, queryOne, queryRows, test, withDb } from './fixtures';
+import {
+  cleanupCreatedData,
+  createKycStep,
+  createUser,
+  expect,
+  queryOne,
+  queryRows,
+  test,
+  withDb,
+} from './fixtures';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async () => {
+  await ensureKycStepUniqueNullsNotDistinct();
+});
+
+test.afterAll(async () => {
+  await cleanupCreatedData();
+});
 
 const PARALLEL_CONTINUES = 13;
 /** Trusted client IP for loc realIp middleware (`cf-connecting-ip`). */
 const TFA_IP = '203.0.113.7';
+/** Production unique index on kyc_step (userDataId, name, type, sequenceNumber). */
+const KYC_STEP_UNIQUE_INDEX = 'IDX_3a1150791476264753a67212a1';
 
 function apiBase(): string {
   return process.env.E2E_API_URL ?? 'http://api:3000';
@@ -37,13 +57,77 @@ async function countSteps(userDataId: number, name: string): Promise<number> {
   return Number(row?.n ?? 0);
 }
 
-async function seedPriorSteps(userDataId: number): Promise<void> {
-  await createKycStep(userDataId, { name: 'ContactData', status: 'Completed', sequenceNumber: 0 });
-  await createKycStep(userDataId, { name: 'PersonalData', status: 'Completed', sequenceNumber: 0 });
+async function rollbackCount(): Promise<number> {
+  const row = await queryOne<{ n: string }>(
+    `SELECT xact_rollback::text AS n FROM pg_stat_database WHERE datname = current_database()`,
+  );
+  return Number(row?.n ?? 0);
+}
+
+/**
+ * Synchronize does not apply FixNullableUniqueIndexes. Recreate the production unique index
+ * so NULL `type` on FinancialData actually conflicts (otherwise COUNT=1 is the only signal
+ * and xact_rollback never moves).
+ */
+async function ensureKycStepUniqueNullsNotDistinct(): Promise<void> {
+  await withDb(async (client) => {
+    const { rows } = await client.query<{ indexname: string; indexdef: string }>(
+      `SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'kyc_step'`,
+    );
+    for (const idx of rows) {
+      const def = idx.indexdef.toLowerCase();
+      if (
+        def.includes('unique') &&
+        def.includes('userdataid') &&
+        def.includes('sequencenumber') &&
+        (def.includes('"type"') || def.includes(', type,') || def.includes('(type'))
+      ) {
+        await client.query(`DROP INDEX IF EXISTS "${idx.indexname}"`);
+      }
+    }
+    await client.query(
+      `CREATE UNIQUE INDEX "${KYC_STEP_UNIQUE_INDEX}" ON "kyc_step" ("userDataId", "name", "type", "sequenceNumber") NULLS NOT DISTINCT`,
+    );
+  });
+  const row = await queryOne<{ indexdef: string }>(`SELECT indexdef FROM pg_indexes WHERE indexname = $1`, [
+    KYC_STEP_UNIQUE_INDEX,
+  ]);
+  expect(row?.indexdef ?? '').toMatch(/NULLS NOT DISTINCT/i);
+}
+
+async function ensureCompletedStep(
+  userDataId: number,
+  name: string,
+  extra: { type?: string | null; result?: string | null } = {},
+): Promise<void> {
+  const existing = await queryOne<{ id: number }>(
+    `SELECT id FROM kyc_step WHERE "userDataId" = $1 AND name = $2 ORDER BY id LIMIT 1`,
+    [userDataId, name],
+  );
+  if (existing) {
+    await withDb(async (client) => {
+      await client.query(
+        `UPDATE kyc_step SET status = 'Completed', result = COALESCE($2, result), updated = NOW() WHERE id = $1`,
+        [existing.id, extra.result ?? null],
+      );
+    });
+    return;
+  }
   await createKycStep(userDataId, {
-    name: 'NationalityData',
+    name,
     status: 'Completed',
     sequenceNumber: 0,
+    type: extra.type,
+    result: extra.result,
+  });
+}
+
+async function seedPriorSteps(userDataId: number): Promise<void> {
+  // Signup/mail already inserts ContactData. Re-inserting the same NULL-type row only
+  // succeeds on the synchronize unique index; production NULLS NOT DISTINCT rejects it.
+  await ensureCompletedStep(userDataId, 'ContactData');
+  await ensureCompletedStep(userDataId, 'PersonalData');
+  await ensureCompletedStep(userDataId, 'NationalityData', {
     result: JSON.stringify({ nationality: { symbol: 'CH' } }),
   });
   await withDb(async (client) => {
@@ -51,7 +135,7 @@ async function seedPriorSteps(userDataId: number): Promise<void> {
   });
 }
 
-async function seedIdentCompleted(tag: string): Promise<{ userDataId: number; jwt: string; kycHash: string }> {
+async function seedIdentCompleted(tag: string): Promise<{ userDataId: number; kycHash: string }> {
   const user = await createUser({
     tag,
     language: 'EN',
@@ -60,13 +144,8 @@ async function seedIdentCompleted(tag: string): Promise<{ userDataId: number; jw
     completePersonalData: true,
   });
   await seedPriorSteps(user.userDataId);
-  await createKycStep(user.userDataId, {
-    name: 'Ident',
-    status: 'Completed',
-    sequenceNumber: 0,
-    type: 'SumsubAuto',
-  });
-  return { userDataId: user.userDataId, jwt: user.jwt, kycHash: await kycHashOf(user.userDataId) };
+  await ensureCompletedStep(user.userDataId, 'Ident', { type: 'SumsubAuto' });
+  return { userDataId: user.userDataId, kycHash: await kycHashOf(user.userDataId) };
 }
 
 async function markStrictTfa(userDataId: number): Promise<void> {
@@ -99,9 +178,8 @@ test('13 parallel PUT /v2/kyc after ident create exactly one FinancialData step'
   await markStrictTfa(user.userDataId);
   expect(await countSteps(user.userDataId, 'FinancialData')).toBe(0);
 
-  const started = Date.now();
+  const rollbacksBefore = await rollbackCount();
   const results = await Promise.all(Array.from({ length: PARALLEL_CONTINUES }, () => putContinue(user.kycHash)));
-  const elapsedMs = Date.now() - started;
 
   const statuses = results.map((r) => r.status);
   expect(
@@ -109,44 +187,50 @@ test('13 parallel PUT /v2/kyc after ident create exactly one FinancialData step'
     `continue statuses: ${statuses.join(',')}`,
   ).toBe(true);
   expect(await countSteps(user.userDataId, 'FinancialData')).toBe(1);
-  expect(elapsedMs, 'the 13 continues should overlap, not run one after another').toBeLessThan(15_000);
 
   const rows = await queryRows<{ id: number; status: string }>(
     `SELECT id, status FROM kyc_step WHERE "userDataId" = $1 AND name = 'FinancialData' ORDER BY id`,
     [user.userDataId],
   );
   expect(rows).toHaveLength(1);
+
+  const rollbacksAfter = await rollbackCount();
+  expect(rollbacksAfter - rollbacksBefore).toBe(0);
 });
 
-test('13 parallel continues from the browser origin still leave one FinancialData step', async ({
-  page,
-}: {
-  page: Page;
-}) => {
-  const user = await seedIdentCompleted('continue-race-browser');
+test('a fourteenth continue after the burst still leaves one FinancialData step', async () => {
+  const user = await seedIdentCompleted('continue-race-fourteenth');
   await markStrictTfa(user.userDataId);
-  expect(await countSteps(user.userDataId, 'FinancialData')).toBe(0);
 
-  await gotoWithSession(page, '/kyc', user.jwt);
-
-  const statuses = await page.evaluate(
-    async ({ hash, ip, n }) => {
-      const results = await Promise.all(
-        Array.from({ length: n }, () =>
-          fetch('http://localhost:3000/v2/kyc', {
-            method: 'PUT',
-            headers: { Accept: 'application/json', 'x-kyc-code': hash, 'cf-connecting-ip': ip },
-          }),
-        ),
-      );
-      return results.map((r) => r.status);
-    },
-    { hash: user.kycHash, ip: TFA_IP, n: PARALLEL_CONTINUES },
-  );
+  const burst = await Promise.all(Array.from({ length: PARALLEL_CONTINUES }, () => putContinue(user.kycHash)));
+  const fourteenth = await putContinue(user.kycHash);
+  const statuses = [...burst.map((r) => r.status), fourteenth.status];
 
   expect(
     statuses.every((s) => s === 200),
-    `browser continue statuses: ${statuses.join(',')}`,
+    `continue statuses: ${statuses.join(',')}`,
   ).toBe(true);
   expect(await countSteps(user.userDataId, 'FinancialData')).toBe(1);
+});
+
+test('two users racing 13 continues each still get one FinancialData step apiece', async () => {
+  // Still one FinancialData per user under load. Does not distinguish a per-user advisory
+  // lock from a process-wide mutex; the production incident is one user, 13 continues.
+  const userA = await seedIdentCompleted('continue-race-two-a');
+  const userB = await seedIdentCompleted('continue-race-two-b');
+  await markStrictTfa(userA.userDataId);
+  await markStrictTfa(userB.userDataId);
+
+  const results = await Promise.all([
+    ...Array.from({ length: PARALLEL_CONTINUES }, () => putContinue(userA.kycHash)),
+    ...Array.from({ length: PARALLEL_CONTINUES }, () => putContinue(userB.kycHash)),
+  ]);
+
+  const statuses = results.map((r) => r.status);
+  expect(
+    statuses.every((s) => s === 200),
+    `continue statuses: ${statuses.join(',')}`,
+  ).toBe(true);
+  expect(await countSteps(userA.userDataId, 'FinancialData')).toBe(1);
+  expect(await countSteps(userB.userDataId, 'FinancialData')).toBe(1);
 });

--- a/e2e-stack/specs/kyc-continue-race.spec.ts
+++ b/e2e-stack/specs/kyc-continue-race.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Proves the ident-complete continue race against the real API and Postgres.
+ *
+ * Production failure: after Sumsub ident finished, the client fired many overlapping
+ * PUT /v2/kyc calls; one FinancialData insert won and the rest hit the unique index.
+ *
+ * This file covers both sides of that seam:
+ *   1. Direct API — 13 parallel continues; the advisory lock must leave one FinancialData row.
+ *   2. Browser /kyc after ident — at most two overlapping continue PUTs, then a second
+ *      13-call burst still leaves one FinancialData row.
+ */
+
+import type { Page } from '@playwright/test';
+import { createKycStep, createUser, expect, gotoWithSession, queryOne, queryRows, test, withDb } from './fixtures';
+
+test.describe.configure({ mode: 'serial' });
+
+const PARALLEL_CONTINUES = 13;
+/** Trusted client IP for loc realIp middleware (`cf-connecting-ip`). */
+const TFA_IP = '203.0.113.7';
+
+function apiBase(): string {
+  return process.env.E2E_API_URL ?? 'http://api:3000';
+}
+
+async function kycHashOf(userDataId: number): Promise<string> {
+  const row = await queryOne<{ kycHash: string }>(`SELECT "kycHash" FROM user_data WHERE id = $1`, [userDataId]);
+  if (!row?.kycHash) throw new Error(`user_data.kycHash missing for userDataId ${userDataId}`);
+  return row.kycHash;
+}
+
+async function countSteps(userDataId: number, name: string): Promise<number> {
+  const row = await queryOne<{ n: string }>(
+    `SELECT COUNT(*)::text AS n FROM kyc_step WHERE "userDataId" = $1 AND name = $2`,
+    [userDataId, name],
+  );
+  return Number(row?.n ?? 0);
+}
+
+async function seedPriorSteps(userDataId: number): Promise<void> {
+  await createKycStep(userDataId, { name: 'ContactData', status: 'Completed', sequenceNumber: 0 });
+  await createKycStep(userDataId, { name: 'PersonalData', status: 'Completed', sequenceNumber: 0 });
+  await createKycStep(userDataId, {
+    name: 'NationalityData',
+    status: 'Completed',
+    sequenceNumber: 0,
+    result: JSON.stringify({ nationality: { symbol: 'CH' } }),
+  });
+  await withDb(async (client) => {
+    await client.query(`UPDATE user_data SET "tradeApprovalDate" = NOW() WHERE id = $1`, [userDataId]);
+  });
+}
+
+async function seedIdentCompleted(tag: string): Promise<{ userDataId: number; jwt: string; kycHash: string }> {
+  const user = await createUser({
+    tag,
+    language: 'EN',
+    country: 'CH',
+    kycLevel: 30,
+    completePersonalData: true,
+  });
+  await seedPriorSteps(user.userDataId);
+  await createKycStep(user.userDataId, {
+    name: 'Ident',
+    status: 'Completed',
+    sequenceNumber: 0,
+    type: 'SumsubAuto',
+  });
+  return { userDataId: user.userDataId, jwt: user.jwt, kycHash: await kycHashOf(user.userDataId) };
+}
+
+async function markStrictTfa(userDataId: number): Promise<void> {
+  // continue() requires a STRICT TfaLog for the request IP once FinancialData/Ident is in progress.
+  await withDb(async (client) => {
+    for (const ip of [TFA_IP, '127.0.0.1', '::1', '::ffff:127.0.0.1', 'unknown']) {
+      await client.query(
+        `INSERT INTO kyc_log (type, comment, "userDataId", "ipAddress", created, updated)
+         VALUES ('TfaLog', 'Strict (App)', $1, $2, NOW(), NOW())`,
+        [userDataId, ip],
+      );
+    }
+  });
+}
+
+async function putContinue(kycHash: string): Promise<{ status: number }> {
+  const res = await fetch(`${apiBase()}/v2/kyc`, {
+    method: 'PUT',
+    headers: {
+      Accept: 'application/json',
+      'x-kyc-code': kycHash,
+      'cf-connecting-ip': TFA_IP,
+    },
+  });
+  return { status: res.status };
+}
+
+test('13 parallel PUT /v2/kyc after ident create exactly one FinancialData step', async () => {
+  const user = await seedIdentCompleted('continue-race-api');
+  await markStrictTfa(user.userDataId);
+  expect(await countSteps(user.userDataId, 'FinancialData')).toBe(0);
+
+  const started = Date.now();
+  const results = await Promise.all(Array.from({ length: PARALLEL_CONTINUES }, () => putContinue(user.kycHash)));
+  const elapsedMs = Date.now() - started;
+
+  const statuses = results.map((r) => r.status);
+  expect(
+    statuses.every((s) => s === 200),
+    `continue statuses: ${statuses.join(',')}`,
+  ).toBe(true);
+  expect(await countSteps(user.userDataId, 'FinancialData')).toBe(1);
+  expect(elapsedMs, 'the 13 continues should overlap, not run one after another').toBeLessThan(15_000);
+
+  const rows = await queryRows<{ id: number; status: string }>(
+    `SELECT id, status FROM kyc_step WHERE "userDataId" = $1 AND name = 'FinancialData' ORDER BY id`,
+    [user.userDataId],
+  );
+  expect(rows).toHaveLength(1);
+});
+
+test('13 parallel continues from the browser origin still leave one FinancialData step', async ({
+  page,
+}: {
+  page: Page;
+}) => {
+  const user = await seedIdentCompleted('continue-race-browser');
+  await markStrictTfa(user.userDataId);
+  expect(await countSteps(user.userDataId, 'FinancialData')).toBe(0);
+
+  await gotoWithSession(page, '/kyc', user.jwt);
+
+  const statuses = await page.evaluate(
+    async ({ hash, ip, n }) => {
+      const results = await Promise.all(
+        Array.from({ length: n }, () =>
+          fetch('http://localhost:3000/v2/kyc', {
+            method: 'PUT',
+            headers: { Accept: 'application/json', 'x-kyc-code': hash, 'cf-connecting-ip': ip },
+          }),
+        ),
+      );
+      return results.map((r) => r.status);
+    },
+    { hash: user.kycHash, ip: TFA_IP, n: PARALLEL_CONTINUES },
+  );
+
+  expect(
+    statuses.every((s) => s === 200),
+    `browser continue statuses: ${statuses.join(',')}`,
+  ).toBe(true);
+  expect(await countSteps(user.userDataId, 'FinancialData')).toBe(1);
+});


### PR DESCRIPTION
EN:
Adds a full-stack test that fires 13 overlapping KYC continues after ident against the production unique index and checks that Postgres keeps exactly one FinancialData step with no unique-violation rollbacks.

DE:
Ein Full-Stack-Test schickt nach der Ident 13 überlappende KYC-Continues gegen den Produktions-Unique-Index und prüft, dass in Postgres genau ein FinancialData-Step bleibt und keine Unique-Violation-Rollbacks entstehen.

<details>
<summary>Details</summary>

The previous continue-race fix was covered by unit tests and a mocked advisory lock. This spec hits the real API and Postgres in the e2e-stack:

- Recreates `IDX_3a1150791476264753a67212a1` with `NULLS NOT DISTINCT` (synchronize does not apply that migration).
- 13 parallel `PUT /v2/kyc` after a completed ident → one `FinancialData` row, all HTTP 200, `xact_rollback` unchanged.
- A fourteenth continue still leaves one row.
- Two users racing 13 continues each still get one row apiece.

Ident/Sumsub UI is not driven here (no live ident provider in the harness). The keyed serial helper stays unit-tested.

SQL fakes (`tradeApprovalDate`, STRICT `TfaLog`, the unique-index recreate) are declared in `docs/test-architecture.md`.

</details>