### PR TITLE
01a07197 - Stabilize E2E readiness and fix nullable KYC fixture inputs

### DIFF
--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -199,6 +199,13 @@ run does not prove for each one; the taxonomy and cross-repository entries live 
   It does not prove that a live account has those kyc fields, that those bootstrap
   endpoints return real data, that `updateCallSettings` persists, or that
   Completed/Failed hide the section.
+- **Full-stack screen-sync regressions hold delivery of real API responses.**
+  `e2e-stack/specs/screen-sync.spec.ts` intercepts `GET /v2/kyc/file/:id` and
+  `GET /v1/dashboard/financial/latest`, calls `route.fetch()` against the real API, then
+  delays `route.fulfill` of that same response body (no invented success payload). A green
+  run does **not** prove the API's natural latency or that production clients never race; it
+  only proves the wait barriers refuse to conclude while that held real response is still
+  undelivered, and that hub re-navigation does not abort it.
 
 ## Known gaps
 

--- a/e2e-stack/specs/dashboard-financial.spec.ts
+++ b/e2e-stack/specs/dashboard-financial.spec.ts
@@ -7,7 +7,18 @@
  */
 
 import type { Locator, Page } from '@playwright/test';
-import { apiGet, expect, gotoWithSession, loginAs, normPath, openScreen, queryOne, test } from './fixtures';
+import {
+  apiGet,
+  expect,
+  gotoWithSession,
+  loginAs,
+  normPath,
+  openScreen,
+  queryOne,
+  settleFinancialHubDestination,
+  test,
+  waitForFinancialDestinationRequests,
+} from './fixtures';
 
 /** Routes owned by this lane's dashboard half (8 paths). */
 const DASHBOARD_ROUTES = [
@@ -157,8 +168,13 @@ test.describe('Financial dashboard', () => {
       await expect(page.getByText(tile.title, { exact: true })).toBeVisible();
     }
 
+    // URL-only waits let the next openScreen abort in-flight destination GETs
+    // (financial/latest|log|changes, plus shell language/user/asset/bankAccount) with
+    // net::ERR_ABORTED and fail the strict console check. Settle each destination's real
+    // requests + post-load UI before leaving it.
     for (const tile of FINANCIAL_HUB_TILES) {
       await openScreen(page, '/dashboard/financial', jwt);
+      const destinationRequests = waitForFinancialDestinationRequests(page, tile.path);
       await page.getByText(tile.title, { exact: true }).click();
       await expect
         .poll(() => normPath(new URL(page.url()).pathname), {
@@ -166,6 +182,7 @@ test.describe('Financial dashboard', () => {
           timeout: 15000,
         })
         .toBe(tile.path);
+      await settleFinancialHubDestination(page, tile.path, destinationRequests);
     }
 
     assertNoErrors(pageErrors, consoleErrors);

--- a/e2e-stack/specs/fixtures/index.ts
+++ b/e2e-stack/specs/fixtures/index.ts
@@ -8,6 +8,7 @@ export * from './db';
 export * from './factories';
 export * from './mail';
 export * from './routes';
+export * from './screen-sync';
 export * from './test-data';
 export { expect };
 
@@ -34,6 +35,11 @@ export function required<T>(value: T | null | undefined, description: string): T
  * Navigates to `path` with an authenticated session and waits until the screen has actually
  * rendered — not the loading spinner, and not a redirect away from `path` (the latter is the
  * typical symptom of a missing role).
+ *
+ * This is not a guarantee that every post-mount fetch finished. Suspense can detach and
+ * networkidle can briefly hold before a screen's own useEffect GET starts (e.g. /file/:id
+ * getFile). Callers that assert absence of result UI, or that navigate away from a hydrating
+ * destination, must wait for that screen's terminal state — see fixtures/screen-sync.ts.
  */
 export async function openScreen(page: Page, path: string, jwt: string): Promise<void> {
   await gotoWithSession(page, path, jwt);

--- a/e2e-stack/specs/fixtures/screen-sync.ts
+++ b/e2e-stack/specs/fixtures/screen-sync.ts
@@ -1,0 +1,145 @@
+/**
+ * Screen-settled waits for post-mount fetches that outlive openScreen's route-spinner + networkidle
+ * barrier (see openScreen in index.ts). Callers that assert absence of result UI, or that re-navigate
+ * while a destination is hydrating, must use these rather than treating openScreen / URL-only polls
+ * as proof that the screen finished loading.
+ */
+import type { Page, Response, Route } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export const KYC_FILE_ERROR_TEXT =
+  'Something went wrong. Please try again. If the issue persists please reach out to our support.';
+
+function urlPathname(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
+}
+
+/** True when `url` is the KYC file metadata GET for `fileUid` (not the binary download). */
+export function isKycFileMetadataUrl(url: string, fileUid: string): boolean {
+  const pathname = urlPathname(url);
+  // Metadata is GET /v2/kyc/file/:uid — reject longer paths (e.g. .../file/:uid/something).
+  return pathname === `/v2/kyc/file/${fileUid}`;
+}
+
+/** Register before navigation. Resolves when the metadata GET response arrives (any status). */
+export function waitForKycFileMetadataResponse(page: Page, fileUid: string): Promise<Response> {
+  return page.waitForResponse(
+    (r) => r.request().method() === 'GET' && isKycFileMetadataUrl(r.url(), fileUid),
+    { timeout: 15000 },
+  );
+}
+
+/**
+ * Terminal UI for `src/screens/kyc-file.screen.tsx`: ErrorHint or the View file button.
+ * Loading shows only StyledLoadingSpinner — absence of View file alone is not denial.
+ */
+export async function waitForKycFileScreenSettled(page: Page): Promise<'error' | 'file'> {
+  const errorHint = page.getByText(KYC_FILE_ERROR_TEXT);
+  const viewFile = page.getByRole('button', { name: 'View file' });
+  return Promise.race([
+    errorHint.waitFor({ state: 'visible', timeout: 15000 }).then(() => 'error' as const),
+    viewFile.waitFor({ state: 'visible', timeout: 15000 }).then(() => 'file' as const),
+  ]);
+}
+
+/**
+ * Fetch the real upstream response, wait for `gate` to resolve, then deliver that same body.
+ * Does not invent payloads — used by screen-sync regressions that hold delivery.
+ */
+export async function fulfillRealResponseAfterGate(route: Route, gate: Promise<void>): Promise<void> {
+  const response = await route.fetch();
+  await gate;
+  await route.fulfill({ response });
+}
+
+/**
+ * Destination GET path suffixes (matched as `/v1${part}` or `part`) each financial hub tile
+ * kicks off after navigation. log-validity has no auto-fetch on mount.
+ */
+export function financialDestinationGetUrlParts(path: string): string[] {
+  switch (path) {
+    case '/dashboard/financial/overview':
+      return ['/dashboard/financial/latest', '/dashboard/financial/log'];
+    case '/dashboard/financial/live':
+    case '/dashboard/financial/liquidity':
+      return ['/dashboard/financial/latest'];
+    case '/dashboard/financial/history':
+      return ['/dashboard/financial/log', '/dashboard/financial/changes'];
+    case '/dashboard/financial/history/expenses':
+      return ['/dashboard/financial/changes', '/dashboard/financial/ref-recipients'];
+    case '/dashboard/financial/log-validity':
+      return [];
+    default:
+      throw new Error(`financialDestinationGetUrlParts: unknown path ${path}`);
+  }
+}
+
+/** Exact pathname match for a known /v1 dashboard financial GET (query string ignored). */
+function matchesFinancialGet(url: string, part: string): boolean {
+  const pathname = urlPathname(url);
+  return pathname === part || pathname === `/v1${part}`;
+}
+
+/** Register before clicking a hub tile. Empty for paths with no mount-time fetch. */
+export function waitForFinancialDestinationRequests(page: Page, path: string): Promise<Response[]> {
+  const parts = financialDestinationGetUrlParts(path);
+  return Promise.all(
+    parts.map((part) =>
+      page.waitForResponse(
+        (r) => r.request().method() === 'GET' && matchesFinancialGet(r.url(), part),
+        { timeout: 15000 },
+      ),
+    ),
+  );
+}
+
+/**
+ * Observable post-load UI for each financial destination (markers that only appear after
+ * isLoading clears, except log-validity which has no mount fetch).
+ */
+export async function waitForFinancialDestinationReady(page: Page, path: string): Promise<void> {
+  switch (path) {
+    case '/dashboard/financial/overview':
+      await expect(page.getByRole('heading', { name: 'Total Balance vs BTC Price' })).toBeVisible();
+      return;
+    case '/dashboard/financial/live':
+      await expect(page.getByText('Total Balance', { exact: true })).toBeVisible();
+      return;
+    case '/dashboard/financial/history':
+      await expect(page.getByRole('heading', { name: 'Income / Plus (cumulative)' })).toBeVisible();
+      return;
+    case '/dashboard/financial/history/expenses':
+      await expect(page.getByRole('heading', { name: 'Referral Expenses (cumulative)' })).toBeVisible();
+      return;
+    case '/dashboard/financial/liquidity':
+      await expect(page.getByText('Total Balance', { exact: true })).toBeVisible();
+      return;
+    case '/dashboard/financial/log-validity':
+      await expect(page.getByRole('heading', { name: 'By log ID' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'By financial range / threshold' })).toBeVisible();
+      return;
+    default:
+      throw new Error(`waitForFinancialDestinationReady: unknown path ${path}`);
+  }
+}
+
+/**
+ * After a hub-tile click: destination GETs finished (response body complete), post-load UI
+ * visible, then networkidle to drain shell bootstrap (language/user/asset/bankAccount) before
+ * the next navigation. networkidle alone is not the hydration proof — the request + UI waits are.
+ * URL-only polls are not a substitute: they resolve before held destination bodies arrive.
+ */
+export async function settleFinancialHubDestination(
+  page: Page,
+  path: string,
+  requestWait: Promise<Response[]>,
+): Promise<void> {
+  const responses = await requestWait;
+  await Promise.all(responses.map((r) => r.finished()));
+  await waitForFinancialDestinationReady(page, path);
+  await page.waitForLoadState('networkidle');
+}

--- a/e2e-stack/specs/kyc-continue-race.spec.ts
+++ b/e2e-stack/specs/kyc-continue-race.spec.ts
@@ -117,8 +117,8 @@ async function ensureCompletedStep(
     name,
     status: 'Completed',
     sequenceNumber: 0,
-    type: extra.type,
-    result: extra.result,
+    type: extra.type ?? undefined,
+    result: extra.result ?? undefined,
   });
 }
 

--- a/e2e-stack/specs/kyc.spec.ts
+++ b/e2e-stack/specs/kyc.spec.ts
@@ -13,11 +13,14 @@ import {
   createUser,
   expect,
   gotoWithSession,
+  KYC_FILE_ERROR_TEXT,
   loginAs,
   openScreen,
   queryOne,
   signatureLogin,
   test,
+  waitForKycFileMetadataResponse,
+  waitForKycFileScreenSettled,
   waitForRow,
   withDb,
 } from './fixtures';
@@ -586,10 +589,11 @@ test.describe('KYC area e2e', () => {
   test('/file/:id is readable by its owner and by nobody else', async ({ page }) => {
     // Intended access rule: a stranger must not see another user's customer-uploaded KYC document.
     // Access scope for this document class is open with the team; once fixed, remove test.fail().
-    test.fail(
-      true,
-      'A stranger can currently open another user KYC document; access scope is open with the team.',
-    );
+    //
+    // openScreen can return before getFile's metadata GET starts (route spinner gone, brief
+    // networkidle). Asserting View file count 0 in that window mistakes an unloaded page for
+    // denial and spuriously passes under test.fail. Await the real GET + terminal UI first.
+    // test.fail stays immediately before the product assertion so setup/sync failures stay real.
 
     const owner = await createUser({ tag: 'file-owner', kycLevel: 0, language: 'EN' });
     const ownerHash = await kycHashOf(owner.userDataId);
@@ -605,9 +609,20 @@ test.describe('KYC area e2e', () => {
     expect(fileRow.protected).toBe(false);
 
     const stranger = await createUser({ tag: 'file-stranger', kycLevel: 0, language: 'EN' });
+    const metadata = waitForKycFileMetadataResponse(page, fileRow.uid);
     await openScreen(page, `/file/${fileRow.uid}`, stranger.jwt);
+    await metadata;
+    // Settled is 'file' today (product serves the stranger the document) or 'error' once fixed.
+    await waitForKycFileScreenSettled(page);
 
-    // Correct product behaviour: stranger must not get the document viewer.
+    // Correct product behaviour after the metadata GET completes: stranger must not get the
+    // document viewer — ErrorHint, not View file. Today the API still serves the file, so the
+    // assertions below fail until access scope is fixed.
+    test.fail(
+      true,
+      'A stranger can currently open another user KYC document; access scope is open with the team.',
+    );
     await expect(page.getByRole('button', { name: 'View file' })).toHaveCount(0);
+    await expect(page.getByText(KYC_FILE_ERROR_TEXT)).toBeVisible();
   });
 });

--- a/e2e-stack/specs/screen-sync.spec.ts
+++ b/e2e-stack/specs/screen-sync.spec.ts
@@ -1,0 +1,319 @@
+/**
+ * Deterministic regressions for screen-settled waits.
+ *
+ * Holds delivery of real API responses (route.fetch → gate → fulfill of that same body).
+ * Does not invent success payloads. Declared in docs/test-architecture.md before these holds
+ * were added. Old code fails these: KYC denial asserted during load; hub re-nav aborts held GETs.
+ */
+
+import type { Page } from '@playwright/test';
+import {
+  createKycStep,
+  createUser,
+  expect,
+  fulfillRealResponseAfterGate,
+  gotoWithSession,
+  isKycFileMetadataUrl,
+  loginAs,
+  normPath,
+  openScreen,
+  queryOne,
+  settleFinancialHubDestination,
+  test,
+  waitForFinancialDestinationRequests,
+  waitForKycFileMetadataResponse,
+  waitForKycFileScreenSettled,
+  waitForRow,
+} from './fixtures';
+
+function apiBase(): string {
+  return process.env.E2E_API_URL ?? 'http://api:3000';
+}
+
+const TEST_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+async function kycHashOf(userDataId: number): Promise<string> {
+  const row = await queryOne<{ kycHash: string }>(`SELECT "kycHash" FROM user_data WHERE id = $1`, [userDataId]);
+  if (!row?.kycHash) throw new Error(`user_data.kycHash missing for userDataId ${userDataId}`);
+  return row.kycHash;
+}
+
+/** Same real upload path as kyc.spec.ts — lands a real kyc_file row for /file/:id. */
+async function uploadRealAdditionalDocument(
+  userDataId: number,
+  kycHash: string,
+  tag: string,
+): Promise<void> {
+  const step = await createKycStep(userDataId, { name: 'AdditionalDocuments', sequenceNumber: 910 });
+  const res = await fetch(`${apiBase()}/v2/kyc/data/additional/${step.kycStepId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', 'x-kyc-code': kycHash },
+    body: JSON.stringify({
+      file: `data:image/png;base64,${TEST_PNG_BASE64}`,
+      fileName: `${tag}.png`,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`PUT /v2/kyc/data/additional/${step.kycStepId} failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+/**
+ * Staff roles need KYC clearance before RoleGuard allows guarded APIs.
+ * loginAs sets verifiedName; the in-memory staffKycClearance set syncs asynchronously from the
+ * setting row. Do not rely on dashboard-financial.spec.ts having run first.
+ */
+async function ensureStaffKycClearance(userDataId: number, roleLabel: string): Promise<void> {
+  await queryOne('UPDATE user_data SET "verifiedName" = $1 WHERE id = $2', [`E2E ${roleLabel} Clearance`, userDataId]);
+
+  const timeoutMs = 75_000;
+  const intervalMs = 3_000;
+  const started = Date.now();
+
+  while (Date.now() - started < timeoutMs) {
+    const row = await queryOne<{ value: string | unknown }>('SELECT value FROM setting WHERE key = $1', [
+      'staffKycClearance',
+    ]);
+    if (row?.value != null) {
+      const raw = typeof row.value === 'string' ? row.value : JSON.stringify(row.value);
+      let ids: unknown;
+      try {
+        ids = JSON.parse(raw);
+      } catch {
+        ids = row.value;
+      }
+      if (Array.isArray(ids) && ids.some((id) => Number(id) === userDataId)) {
+        return;
+      }
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+
+  throw new Error(
+    `ensureStaffKycClearance: userDataId ${userDataId} not in staffKycClearance setting within ${timeoutMs}ms`,
+  );
+}
+
+function attachErrorListeners(page: Page): { pageErrors: string[]; consoleErrors: string[] } {
+  const pageErrors: string[] = [];
+  const consoleErrors: string[] = [];
+  page.on('pageerror', (err) => {
+    pageErrors.push(String(err));
+  });
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertNoErrors(pageErrors: string[], consoleErrors: string[]): void {
+  const unexpected = consoleErrors.filter(
+    (msg) => !/^Failed to load resource: the server responded with a status of 4\d\d/.test(msg),
+  );
+  expect(pageErrors, `uncaught pageerror: ${pageErrors.join('; ')}`).toEqual([]);
+  expect(unexpected, `unexpected console error: ${unexpected.join('; ')}`).toEqual([]);
+}
+
+/** Idempotent hold-gate release; marks released before resolving so premature-ready checks are trustworthy. */
+function createHoldGate(): { gate: Promise<void>; release: () => void; isReleased: () => boolean } {
+  let holdReleased = false;
+  let resolveGate!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    resolveGate = resolve;
+  });
+  return {
+    gate,
+    isReleased: () => holdReleased,
+    release: () => {
+      if (holdReleased) return;
+      holdReleased = true;
+      resolveGate();
+    },
+  };
+}
+
+test.describe('Screen-sync regressions (held real API delivery)', () => {
+  test('KYC file authorization outcome is not concluded while metadata GET delivery is held', async ({
+    page,
+  }) => {
+    const owner = await createUser({ tag: 'sync-file-owner', kycLevel: 0, language: 'EN' });
+    const ownerHash = await kycHashOf(owner.userDataId);
+    await uploadRealAdditionalDocument(owner.userDataId, ownerHash, 'sync-owner-doc');
+
+    const fileRow = await waitForRow<{ uid: string }>(
+      `SELECT uid FROM kyc_file WHERE "userDataId" = $1 ORDER BY id DESC LIMIT 1`,
+      [owner.userDataId],
+      15000,
+    );
+
+    const stranger = await createUser({ tag: 'sync-file-stranger', kycLevel: 0, language: 'EN' });
+    const { pageErrors, consoleErrors } = attachErrorListeners(page);
+
+    const { gate, release, isReleased } = createHoldGate();
+    let fetched = false;
+    let routeHandled: Promise<void> | undefined;
+
+    await page.route(`**/v2/kyc/file/${fileRow.uid}*`, async (route) => {
+      if (route.request().method() !== 'GET' || !isKycFileMetadataUrl(route.request().url(), fileRow.uid)) {
+        await route.fallback();
+        return;
+      }
+      fetched = true;
+      routeHandled = fulfillRealResponseAfterGate(route, gate);
+      await routeHandled;
+    });
+
+    try {
+      const metadata = waitForKycFileMetadataResponse(page, fileRow.uid);
+      // Attach rejection handling immediately — test may fail before these are awaited.
+      metadata.catch(() => undefined);
+
+      // gotoWithSession — not openScreen — so a held spinner cannot trip openScreen's 15s detach wait.
+      await gotoWithSession(page, `/file/${fileRow.uid}`, stranger.jwt);
+
+      await expect.poll(() => fetched, { message: 'metadata GET must reach the hold gate' }).toBe(true);
+
+      let settledEarly = false;
+      const settledPromise = waitForKycFileScreenSettled(page).then((state) => {
+        // Gate-release flag, not post-fulfill — browser may render before route.fulfill settles.
+        if (!isReleased()) settledEarly = true;
+        return state;
+      });
+      settledPromise.catch(() => undefined);
+
+      // Hazard the old assertion relied on: View file is absent during load.
+      await expect(page.getByRole('button', { name: 'View file' })).toHaveCount(0);
+      // Observable Playwright roundtrip so an immediately-resolving settled helper flips settledEarly.
+      await page.evaluate(() => true);
+      expect(isReleased(), 'hold gate must still be closed while View file is absent').toBe(false);
+      expect(settledEarly, 'terminal UI wait must not resolve before hold gate release').toBe(false);
+
+      release();
+      await metadata;
+      if (routeHandled) await routeHandled;
+      const settled = await settledPromise;
+
+      expect(settledEarly).toBe(false);
+      // Product currently serves the stranger the file; once access is fixed this becomes 'error'.
+      // Either way the wait must not have concluded during the hold.
+      expect(settled === 'file' || settled === 'error').toBe(true);
+      if (settled === 'file') {
+        await expect(page.getByRole('button', { name: 'View file' })).toBeVisible();
+      }
+      assertNoErrors(pageErrors, consoleErrors);
+    } finally {
+      release();
+    }
+  });
+
+  test('financial hub Live tile does not abort a held destination latest GET', async ({ page }) => {
+    const { jwt, wallet } = await loginAs('Admin');
+    const userRow = await queryOne<{ userDataId: number }>('SELECT "userDataId" FROM "user" WHERE address = $1', [
+      wallet.address,
+    ]);
+    if (userRow?.userDataId == null) {
+      throw new Error(`no userDataId for Admin wallet ${wallet.address}`);
+    }
+    await ensureStaffKycClearance(userRow.userDataId, 'Admin');
+
+    const { pageErrors, consoleErrors } = attachErrorListeners(page);
+
+    const { gate, release, isReleased } = createHoldGate();
+    let fetched = false;
+    let routeHandled: Promise<void> | undefined;
+    let abortedLatest = false;
+
+    page.on('requestfailed', (req) => {
+      const pathname = (() => {
+        try {
+          return new URL(req.url()).pathname;
+        } catch {
+          return req.url();
+        }
+      })();
+      if (pathname !== '/v1/dashboard/financial/latest' && pathname !== '/dashboard/financial/latest') return;
+      const failure = req.failure()?.errorText ?? '';
+      if (/ERR_ABORTED|aborted/i.test(failure)) {
+        abortedLatest = true;
+      }
+    });
+
+    await page.route('**/dashboard/financial/latest**', async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.fallback();
+        return;
+      }
+      const pathname = (() => {
+        try {
+          return new URL(route.request().url()).pathname;
+        } catch {
+          return route.request().url();
+        }
+      })();
+      if (pathname !== '/v1/dashboard/financial/latest' && pathname !== '/dashboard/financial/latest') {
+        await route.fallback();
+        return;
+      }
+      fetched = true;
+      routeHandled = fulfillRealResponseAfterGate(route, gate);
+      await routeHandled;
+    });
+
+    try {
+      const livePath = '/dashboard/financial/live';
+      const hubPath = '/dashboard/financial';
+      await openScreen(page, hubPath, jwt);
+
+      const destinationRequests = waitForFinancialDestinationRequests(page, livePath);
+      destinationRequests.catch(() => undefined);
+      await page.getByText('Live', { exact: true }).click();
+      await expect
+        .poll(() => normPath(new URL(page.url()).pathname), {
+          message: 'Live tile should navigate to /dashboard/financial/live',
+          timeout: 15000,
+        })
+        .toBe(livePath);
+
+      await expect.poll(() => fetched, { message: 'latest GET must reach the hold gate' }).toBe(true);
+      expect(isReleased()).toBe(false);
+      expect(abortedLatest).toBe(false);
+
+      // Start the real settle-then-navigate sequence while the response is still held.
+      // A URL-only settle helper resolves immediately (URL already matches), navigates back
+      // during the hold, aborts the latest GET, and fails the assertions below.
+      let settledWhileHeld = false;
+      let returnedToHubWhileHeld = false;
+      const settleThenReturn = (async () => {
+        await settleFinancialHubDestination(page, livePath, destinationRequests);
+        if (!isReleased()) settledWhileHeld = true;
+        await openScreen(page, hubPath, jwt);
+        if (!isReleased()) returnedToHubWhileHeld = true;
+      })();
+      settleThenReturn.catch(() => undefined);
+
+      // Observable Playwright roundtrip: gives a wrong (URL-only) settle a chance to complete
+      // and navigate before we release.
+      await page.evaluate(() => true);
+      expect(normPath(new URL(page.url()).pathname), 'must still be on live while held').toBe(livePath);
+      expect(isReleased()).toBe(false);
+      expect(settledWhileHeld, 'settle must not finish while destination body is held').toBe(false);
+      expect(returnedToHubWhileHeld, 'must not re-navigate to hub while held').toBe(false);
+      expect(abortedLatest).toBe(false);
+
+      release();
+      await settleThenReturn;
+      if (routeHandled) await routeHandled;
+
+      expect(settledWhileHeld).toBe(false);
+      expect(returnedToHubWhileHeld).toBe(false);
+      expect(abortedLatest, 'settle-then-navigate must not abort held latest').toBe(false);
+      expect(normPath(new URL(page.url()).pathname)).toBe(hubPath);
+      assertNoErrors(pageErrors, consoleErrors);
+    } finally {
+      release();
+    }
+  });
+});


### PR DESCRIPTION
EN:
KYC and financial-dashboard E2E tests now wait for completed responses and the rendered result before checking access or navigating again. Regression tests hold real API responses to expose premature checks and navigation; nullable KYC fixture inputs also now satisfy the harness type check.

DE:
Die E2E-Tests für KYC und das Finanz-Dashboard warten jetzt auf abgeschlossene Antworten und den dargestellten Endzustand, bevor sie Zugriffe prüfen oder weiternavigieren. Regressionstests halten echte API-Antworten zurück, um zu frühe Prüfungen und Seitenwechsel sichtbar zu machen; nullable KYC-Fixture-Eingaben erfüllen zudem den Typcheck.

<details>
<summary>Implementation and validation</summary>

KYC absence assertions could run before the file response arrived, turning an existing expected failure into an unexpected pass. The financial hub test could leave a destination while its requests were still running, producing aborted requests and console errors.

Wait for the KYC response and terminal screen before checking the intended result, and for financial response bodies and destination UI before navigating again. The regressions hold delivery of real API responses and have a matching reality declaration. Removing the two wait barriers makes both regressions fail at the premature-completion assertions.

The KYC race fixture normalizes nullable optional arguments to `undefined`; its factory already converts either nullish value to SQL null, preserving runtime behavior. GitHub found this pre-existing TS2322 in the separate harness type check before E2E execution.

Validation of the initial synchronization commit `a35b632` (completed before the requester selected GitHub-only App CI):
- Node 20 Linux: dependency installation, lint, Markdown check, development app build and development widget build passed.
- Focused real-stack run: 7 ordinary passes and 1 existing expected product failure.
- Mutation control: both regressions reject removed wait barriers; 4 setup tests pass.
- Full fresh-stack run: 264 cases, comprising 256 ordinary passes, 5 existing expected failures and 3 existing skips, in 8.4 minutes; the route-coverage gate passed.
- Final head `f39381fb`: [full GitHub PR CI](https://github.com/DFXswiss/app/actions/runs/34025255364) passed on GitHub-hosted runners with `ci:full`: 1,828 unit tests in 115 suites; lint, Markdown, both builds and harness type check passed; full E2E ran 264 cases (256 ordinary passes, 5 existing expected failures, 3 existing skips, 0 unexpected failures, 0 flaky outcomes) in 10.7 minutes, including the route-coverage gate.
- [Handbook build and container smoke](https://github.com/DFXswiss/app/actions/runs/34025363365), CodeQL and the PR workflow checks passed at the same head. The CI-label helper correctly skipped because `ci:full` was already present; the earlier Draft-only Handbook skip was superseded by the successful Ready-triggered run.

The change is limited to the E2E harness and its documentation. No Jest-instrumented production file or visual flow changes. Existing expected product failures and skipped coverage remain explicitly tracked, including https://github.com/DFXswiss/app/issues/1289 and https://github.com/DFXswiss/app/issues/1290; their resolution is not claimed by this synchronization fix.

Independent final reviews were explicitly waived by the requester: 0 independent final-review approvals are claimed. Downstream consumers of this harness need the fix on `develop` before their next validation uses the corrected tests.

</details>
