### PR TITLE
01a07197 - Refresh the E2E test image on every stack startup

### DIFF
--- a/e2e-stack/README.md
+++ b/e2e-stack/README.md
@@ -141,13 +141,18 @@ and the workflow that drives the stack against API changes live in the API repos
 
 **Spec changes not picked up**
 
-If you edit a spec file and start the test run by hand via `docker compose ... run --rm tests` (bypassing `npm run e2e:stack`, which rebuilds the image automatically via `run.sh`), you **must** rebuild the tests image first:
+`up.sh` rebuilds the `tests` image on every stack start. Compose never rebuilds an existing
+image on its own, and the image `COPY`s specs at build time with no bind mounts — so without
+that step a reused Compose project (including a CI path that starts the stack with `up.sh`
+and runs tests from a separate shell) silently keeps the old specs. `npm run e2e:stack` /
+`e2e:stack:up` go through `up.sh`, so they are covered. If you start tests by hand with
+`docker compose ... run --rm tests` and skip `up.sh`, rebuild explicitly first:
 
 ```bash
 docker compose -p <project> -f e2e-stack/compose.yml -f e2e-stack/compose.tests.yml build tests
 ```
 
-Otherwise the **old** spec content runs silently: the image `COPY`s spec files in at build time, and there are no bind mounts in this environment. This exact mistake has already cost several people a full test run each.
+Otherwise the **old** spec content runs silently.
 
 **frontend-widget image not rebuilt**
 

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -16,7 +16,6 @@ if ! compose config --services | grep -qx tests; then
   exit 1
 fi
 
-build_tests_image
 log_info "Running e2e tests..."
 # Declares that every spec is in scope, which is what lets the coverage gate check that each route
 # was actually opened rather than merely claimed. A filtered run instead gets only the gate's

--- a/e2e-stack/scripts/up.sh
+++ b/e2e-stack/scripts/up.sh
@@ -112,6 +112,14 @@ else
   log_info "Using prebuilt frontend-widget image ${E2E_WIDGET_IMAGE} - skipping the local build."
 fi
 
+# Rebuild the tests image here (not only from run.sh): Compose never rebuilds an *existing*
+# image on its own, and specs are COPY'd at build time with no bind mounts. A shared stack
+# started by up.sh and exercised from a separate shell — including a CI rerun that reuses the
+# same Compose project — would otherwise keep running a stale tests image while the checkout
+# already has newer specs. Always rebuild, even when frontend/widget images are prebuilt;
+# normal Docker layer cache still applies.
+build_tests_image
+
 log_info "Starting stack (db, api, frontend, proxy)..."
 compose up -d db api frontend proxy
 


### PR DESCRIPTION
EN:
Refresh the Playwright test image on every stack startup so repeated runs use the current checked-out tests. Move the existing build from run.sh into up.sh and update the troubleshooting documentation.

DE:
Das Playwright-Test-Image bei jedem Stack-Start aktualisieren, damit wiederholte Läufe die aktuell ausgecheckten Tests verwenden. Der vorhandene Build wird von run.sh nach up.sh verschoben und die Fehlerbehebungs-Dokumentation angepasst.

<details>
<summary>Cause, change and validation</summary>

Compose builds a missing tests image but reuses an existing image even when the checkout has changed. The specs are copied into the image, without bind mounts. A CI path that calls up.sh and then runs tests in a separate shell could therefore silently execute old specs when reusing a Compose project.

Call the existing build_tests_image helper from up.sh after frontend/widget image handling and before service startup. Remove the redundant invocation from run.sh, which already calls up.sh. This also applies when the frontend images are prebuilt; normal Docker build caching remains enabled and a build error still stops startup.

The defect was confirmed by inspecting a reused image: it lacked the two synchronization regressions already present in the checkout, and its run executed 262 rather than 264 cases. This follow-up prevents that stale-image path at its shared entry point.

Validation: full GitHub-hosted CI 34027975470 passed at 7da6991fb4b35cca319fd8305a5a89f15bd0b189. The log proves the tests-image build inside up.sh and 264 E2E cases: 256 ordinary passes, 5 expected failures and 3 skips, with both synchronization regressions passing. All 1,828 unit tests, lint, Markdown, application/widget builds and harness type-check passed; CodeQL and the configured review workflow also succeeded. No local App CI is run, as requested. No production code, dependency, workflow or test-assertion changes. Existing expected failures and skipped cases remain explicit.

Independent final reviews were explicitly waived by the requester: 0 independent final-review approvals are claimed. The preceding PR #1451 is already merged, so this correction is a separate follow-up PR.

</details>
