### PR TITLE
01a0765d - Log displayed failures and KYC/limit blockers

### DIFF
--- a/src/__tests__/connect-error-reporting.test.tsx
+++ b/src/__tests__/connect-error-reporting.test.tsx
@@ -1,0 +1,88 @@
+let mockUser: { accountId: number } | undefined;
+jest.mock('@dfx.swiss/react', () => ({ useUserContext: () => ({ user: mockUser }) }));
+jest.mock('src/dto/safe.dto', () => ({}));
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ConnectError, ConnectInstructions } from '../components/home/connect-shared';
+
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({
+    translate: (_key: string, value: string, _params?: Record<string, string>) => value,
+  }),
+}));
+
+const mockReportClientError = jest.fn();
+jest.mock('src/util/client-error', () => ({
+  ...jest.requireActual('src/util/client-error'),
+  reportClientError: (...args: unknown[]) => mockReportClientError(...args),
+}));
+
+function renderAt(ui: JSX.Element) {
+  return render(<MemoryRouter initialEntries={['/buy']}>{ui}</MemoryRouter>);
+}
+
+describe('ConnectError reporting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = undefined;
+  });
+
+  it('shows Connection failed! and the translated error string', () => {
+    renderAt(<ConnectError error="Please install Alby or use a desktop computer" />);
+
+    expect(screen.getByText('Connection failed!')).toBeInTheDocument();
+    expect(screen.getByText('Please install Alby or use a desktop computer')).toBeInTheDocument();
+  });
+
+  it('reports the error as HandledError on the router route', async () => {
+    renderAt(<ConnectError error="Please install Alby or use a desktop computer" />);
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][0]).toMatchObject({
+      message: 'Please install Alby or use a desktop computer',
+      name: 'HandledError',
+    });
+    expect(mockReportClientError.mock.calls[0][1]).toBe('/buy');
+  });
+
+  it('does not report when error is undefined at runtime and still shows the heading', async () => {
+    renderAt(<ConnectError error={undefined as unknown as string} />);
+
+    expect(screen.getByText('Connection failed!')).toBeInTheDocument();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockReportClientError).not.toHaveBeenCalled();
+  });
+
+  it('does not report when error is empty', async () => {
+    renderAt(<ConnectError error="" />);
+
+    expect(screen.getByText('Connection failed!')).toBeInTheDocument();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockReportClientError).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConnectInstructions', () => {
+  it('renders steps and an image when img is provided', () => {
+    render(
+      <ConnectInstructions
+        steps={['Open your wallet', 'Confirm the connection']}
+        params={{}}
+        img="https://example.com/wallet.png"
+      />,
+    );
+
+    expect(screen.getByText('Open your wallet')).toBeInTheDocument();
+    expect(screen.getByText('Confirm the connection')).toBeInTheDocument();
+    expect(screen.getByRole('img')).toHaveAttribute('src', 'https://example.com/wallet.png');
+  });
+
+  it('renders steps without an image when img is omitted', () => {
+    render(<ConnectInstructions steps={['Open your wallet', 'Confirm the connection']} params={{}} />);
+
+    expect(screen.getByText('Open your wallet')).toBeInTheDocument();
+    expect(screen.getByText('Confirm the connection')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/error-hint-reporting.test.tsx
+++ b/src/__tests__/error-hint-reporting.test.tsx
@@ -1,0 +1,87 @@
+let mockUser: { accountId: number } | undefined;
+jest.mock('@dfx.swiss/react', () => ({ useUserContext: () => ({ user: mockUser }) }));
+jest.mock('src/dto/safe.dto', () => ({}));
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ErrorHint } from '../components/error-hint';
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  StyledButtonColor: { GRAY_OUTLINE: 'gray' },
+  StyledButton: ({ label, onClick }: { label: string; onClick?: () => void }) => (
+    <button onClick={onClick}>{label}</button>
+  ),
+}));
+
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({ translate: (_key: string, value: string) => value }),
+}));
+
+const mockReportClientError = jest.fn();
+jest.mock('src/util/client-error', () => ({
+  ...jest.requireActual('src/util/client-error'),
+  reportClientError: (...args: unknown[]) => mockReportClientError(...args),
+}));
+
+function renderHint(ui: JSX.Element) {
+  return render(<MemoryRouter initialEntries={['/buy']}>{ui}</MemoryRouter>);
+}
+
+describe('ErrorHint reporting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = undefined;
+  });
+
+  it('shows the generic sentence and the raw message', () => {
+    renderHint(<ErrorHint message="boom" />);
+
+    expect(
+      screen.getByText(
+        'Something went wrong. Please try again. If the issue persists please reach out to our support.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+
+  it('omits the Back button when onBack is absent', () => {
+    renderHint(<ErrorHint message="boom" />);
+
+    expect(screen.queryByRole('button', { name: 'Back' })).not.toBeInTheDocument();
+  });
+
+  it('renders the Back button and calls onBack when clicked', async () => {
+    const onBack = jest.fn();
+    renderHint(<ErrorHint message="boom" onBack={onBack} />);
+
+    const back = screen.getByRole('button', { name: 'Back' });
+    expect(back).toBeInTheDocument();
+
+    await userEvent.click(back);
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the message as HandledError on the router route', async () => {
+    renderHint(<ErrorHint message="boom" />);
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][0]).toMatchObject({ message: 'boom', name: 'HandledError' });
+    expect(mockReportClientError.mock.calls[0][1]).toBe('/buy');
+  });
+
+  it('reports without an account when nobody is signed in', async () => {
+    renderHint(<ErrorHint message="boom" />);
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][2]).toBeUndefined();
+  });
+
+  it('reports the account when the customer is signed in', async () => {
+    mockUser = { accountId: 123456 };
+    renderHint(<ErrorHint message="boom" />);
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][2]).toBe(123456);
+  });
+});

--- a/src/__tests__/payment-qr-code-error.test.tsx
+++ b/src/__tests__/payment-qr-code-error.test.tsx
@@ -33,6 +33,8 @@ jest.mock('../hooks/navigation.hook', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
+jest.mock('react-router-dom', () => ({ useLocation: () => ({ pathname: '/' }) }));
+
 jest.mock('../util/utils', () => ({
   openPdfFromString: (...args: unknown[]) => mockOpenPdf(...args),
 }));

--- a/src/__tests__/quote-error-hint-reporting.test.tsx
+++ b/src/__tests__/quote-error-hint-reporting.test.tsx
@@ -1,0 +1,394 @@
+import React from 'react';
+
+let mockIsComplete = false;
+let mockUser: { accountId?: number; kyc?: { level: number } } | undefined = { kyc: { level: 0 } };
+let mockLimit: string | undefined = '100,000 CHF';
+const mockStartStep = jest.fn();
+const mockNavigate = jest.fn();
+const mockStart = jest.fn();
+const mockReportClientError = jest.fn();
+
+jest.mock('@dfx.swiss/react', () => ({
+  KycStepName: {
+    RECOMMENDATION: 'Recommendation',
+    CONTACT_DATA: 'ContactData',
+    IDENT: 'Ident',
+  },
+  KycStepType: {
+    SUMSUB_VIDEO: 'SumsubVideo',
+  },
+  TransactionError: {
+    TRADING_NOT_ALLOWED: 'TradingNotAllowed',
+    KYC_REQUIRED: 'KycRequired',
+    RECOMMENDATION_REQUIRED: 'RecommendationRequired',
+    EMAIL_REQUIRED: 'EmailRequired',
+    KYC_DATA_REQUIRED: 'KycDataRequired',
+    KYC_REQUIRED_INSTANT: 'KycRequiredInstant',
+    LIMIT_EXCEEDED: 'LimitExceeded',
+    BANK_TRANSACTION_MISSING: 'BankTransactionMissing',
+    BANK_TRANSACTION_OR_VIDEO_MISSING: 'BankTransactionOrVideoMissing',
+    VIDEO_IDENT_REQUIRED: 'VideoIdentRequired',
+    NATIONALITY_NOT_ALLOWED: 'NationalityNotAllowed',
+    IBAN_CURRENCY_MISMATCH: 'IbanCurrencyMismatch',
+    PAYMENT_METHOD_NOT_ALLOWED: 'PaymentMethodNotAllowed',
+  },
+  TransactionType: {
+    BUY: 'Buy',
+    SELL: 'Sell',
+    SWAP: 'Swap',
+  },
+  useUserContext: () => ({
+    user: mockUser,
+  }),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  StyledButton: ({ label, onClick }: { label: string; onClick: () => void }) => (
+    <button onClick={onClick} data-testid="styled-button">
+      {label}
+    </button>
+  ),
+  StyledButtonWidth: {
+    FULL: 'full',
+  },
+  StyledInfoText: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="styled-info-text">{children}</div>
+  ),
+  StyledLink: ({ label, onClick }: { label: string; onClick: () => void }) => (
+    <a onClick={onClick} data-testid="styled-link">
+      {label}
+    </a>
+  ),
+  StyledVerticalStack: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('../contexts/settings.context', () => ({
+  useSettingsContext: () => ({
+    translate: (_scope: string, key: string, params?: Record<string, string>) => {
+      if (params) {
+        let result = key;
+        for (const [k, v] of Object.entries(params)) {
+          result = result.replace(`{{${k}}}`, v);
+        }
+        return result;
+      }
+      return key;
+    },
+  }),
+}));
+
+jest.mock('../hooks/kyc-helper.hook', () => ({
+  useKycHelper: () => ({
+    start: mockStart,
+    startStep: mockStartStep,
+    limit: mockLimit,
+    defaultLimit: '1,000 CHF',
+    limitToString: (limit: string) => limit,
+    isComplete: mockIsComplete,
+  }),
+}));
+
+jest.mock('../hooks/navigation.hook', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+jest.mock('src/util/client-error', () => ({
+  ...jest.requireActual('src/util/client-error'),
+  reportClientError: (...args: unknown[]) => mockReportClientError(...args),
+}));
+
+jest.mock('src/dto/safe.dto', () => ({}));
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { KycStepName, KycStepType, TransactionError, TransactionType } from '@dfx.swiss/react';
+import { QuoteErrorHint } from '../components/quote-error-hint';
+
+function renderHint(ui: JSX.Element) {
+  return render(<MemoryRouter initialEntries={['/buy']}>{ui}</MemoryRouter>);
+}
+
+async function expectReported(message: string) {
+  await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+  expect(mockReportClientError.mock.calls[0][0]).toMatchObject({ message, name: 'QuoteError' });
+  expect(mockReportClientError.mock.calls[0][1]).toBe('/buy');
+}
+
+async function expectNotReported() {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  expect(mockReportClientError).not.toHaveBeenCalled();
+}
+
+describe('QuoteErrorHint reporting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsComplete = false;
+    mockUser = { kyc: { level: 0 } };
+    mockLimit = '100,000 CHF';
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, pathname: '/host-page' },
+      writable: true,
+    });
+  });
+
+  it('reports LIMIT_EXCEEDED with needs-verified copy when KYC is incomplete', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.LIMIT_EXCEEDED} />);
+
+    await expectReported(
+      'Your account needs to get verified once your transaction volume exceeds 100,000 CHF. If you want to increase your trading limit, please complete our KYC (Know-Your-Customer) process.',
+    );
+    expect(mockReportClientError.mock.calls[0][1]).not.toBe('/host-page');
+  });
+
+  it('reports LIMIT_EXCEEDED with trading-limit copy when KYC is complete', async () => {
+    mockIsComplete = true;
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.LIMIT_EXCEEDED} />);
+
+    await expectReported(
+      'This transaction exceeds your trading limit of 100,000 CHF. If you would like to increase your limit, please submit a request using the button below.',
+    );
+  });
+
+  it('reports LIMIT_EXCEEDED with empty limit when KYC is incomplete and limit is undefined', async () => {
+    mockLimit = undefined;
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.LIMIT_EXCEEDED} />);
+
+    await expectReported(
+      'Your account needs to get verified once your transaction volume exceeds . If you want to increase your trading limit, please complete our KYC (Know-Your-Customer) process.',
+    );
+  });
+
+  it('reports LIMIT_EXCEEDED with empty limit when KYC is complete and limit is undefined', async () => {
+    mockLimit = undefined;
+    mockIsComplete = true;
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.LIMIT_EXCEEDED} />);
+
+    await expectReported(
+      'This transaction exceeds your trading limit of . If you would like to increase your limit, please submit a request using the button below.',
+    );
+  });
+
+  it('reports TRADING_NOT_ALLOWED with verified-account copy', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.TRADING_NOT_ALLOWED} />);
+
+    await expectReported(
+      'This transaction is only possible with a verified account. Please complete our KYC (Know-Your-Customer) process.',
+    );
+  });
+
+  it('reports KYC_REQUIRED with verified-account copy', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.KYC_REQUIRED} />);
+
+    await expectReported(
+      'This transaction is only possible with a verified account. Please complete our KYC (Know-Your-Customer) process.',
+    );
+  });
+
+  it('reports RECOMMENDATION_REQUIRED', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.RECOMMENDATION_REQUIRED} />);
+
+    await expectReported('To trade, you need a recommendation from an existing DFX customer.');
+  });
+
+  it('reports EMAIL_REQUIRED', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.EMAIL_REQUIRED} />);
+
+    await expectReported('To trade, please enter your email address.');
+  });
+
+  it('reports KYC_DATA_REQUIRED as the error string and omits StyledInfoText', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.KYC_DATA_REQUIRED} />);
+
+    expect(screen.queryByTestId('styled-info-text')).not.toBeInTheDocument();
+    await expectReported('KycDataRequired');
+  });
+
+  it('reports KYC_REQUIRED_INSTANT', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.KYC_REQUIRED_INSTANT} />);
+
+    await expectReported(
+      'Instant bank transactions are only possible with a verified account. If you would like to use SEPA Instant, please complete our KYC (Know-Your-Customer) process.',
+    );
+  });
+
+  it('reports BANK_TRANSACTION_MISSING without an action button', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.BANK_TRANSACTION_MISSING} />);
+
+    expect(screen.queryByTestId('styled-button')).not.toBeInTheDocument();
+    await expectReported('A buy bank transaction is required.');
+  });
+
+  it('reports BANK_TRANSACTION_OR_VIDEO_MISSING for BUY with credit-card volume copy', async () => {
+    renderHint(
+      <QuoteErrorHint type={TransactionType.BUY} error={TransactionError.BANK_TRANSACTION_OR_VIDEO_MISSING} />,
+    );
+
+    await expectReported(
+      'A buy bank transaction or identification by video is required once your credit card transaction volume exceeds 1,000 CHF.',
+    );
+  });
+
+  it('reports BANK_TRANSACTION_OR_VIDEO_MISSING for SELL with sell volume copy', async () => {
+    renderHint(
+      <QuoteErrorHint type={TransactionType.SELL} error={TransactionError.BANK_TRANSACTION_OR_VIDEO_MISSING} />,
+    );
+
+    await expectReported(
+      'A buy bank transaction or identification by video is required once your sell transaction volume exceeds 1,000 CHF.',
+    );
+  });
+
+  it('reports BANK_TRANSACTION_OR_VIDEO_MISSING for SWAP with swap volume copy', async () => {
+    renderHint(
+      <QuoteErrorHint type={TransactionType.SWAP} error={TransactionError.BANK_TRANSACTION_OR_VIDEO_MISSING} />,
+    );
+
+    await expectReported(
+      'A buy bank transaction or identification by video is required once your swap transaction volume exceeds 1,000 CHF.',
+    );
+  });
+
+  it('reports VIDEO_IDENT_REQUIRED', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.VIDEO_IDENT_REQUIRED} />);
+
+    await expectReported('Identification by video is required once your transaction volume exceeds 1,000 CHF.');
+  });
+
+  it('reports NATIONALITY_NOT_ALLOWED without an action button', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.NATIONALITY_NOT_ALLOWED} />);
+
+    expect(screen.queryByTestId('styled-button')).not.toBeInTheDocument();
+    await expectReported(
+      'We are unable to process this transaction due to restrictions based on your nationality.',
+    );
+  });
+
+  it('reports IBAN_CURRENCY_MISMATCH without an action button', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.IBAN_CURRENCY_MISMATCH} />);
+
+    expect(screen.queryByTestId('styled-button')).not.toBeInTheDocument();
+    await expectReported('This IBAN cannot be used with this currency.');
+  });
+
+  it('reports PAYMENT_METHOD_NOT_ALLOWED without an action button', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.PAYMENT_METHOD_NOT_ALLOWED} />);
+
+    expect(screen.queryByTestId('styled-button')).not.toBeInTheDocument();
+    await expectReported('This payment method is not allowed for your account.');
+  });
+
+  it('does not report an unhandled TransactionError and renders an empty fragment', async () => {
+    const { container } = renderHint(
+      <QuoteErrorHint type={TransactionType.BUY} error={'AmountTooLow' as TransactionError} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    await expectNotReported();
+  });
+
+  it('reports a message override and keeps standard actions for that error', async () => {
+    renderHint(
+      <QuoteErrorHint
+        type={TransactionType.BUY}
+        error={TransactionError.EMAIL_REQUIRED}
+        message="custom blocker"
+      />,
+    );
+
+    expect(screen.getByTestId('styled-info-text').textContent).toBe('custom blocker');
+    expect(screen.getByTestId('styled-button').textContent).toBe('Enter email');
+    await expectReported('custom blocker');
+  });
+
+  it('starts video identification for BANK_TRANSACTION_OR_VIDEO_MISSING', async () => {
+    renderHint(
+      <QuoteErrorHint type={TransactionType.BUY} error={TransactionError.BANK_TRANSACTION_OR_VIDEO_MISSING} />,
+    );
+
+    fireEvent.click(screen.getByTestId('styled-button'));
+    expect(mockStartStep).toHaveBeenCalledWith(KycStepName.IDENT, KycStepType.SUMSUB_VIDEO);
+    await expectReported(
+      'A buy bank transaction or identification by video is required once your credit card transaction volume exceeds 1,000 CHF.',
+    );
+  });
+
+  it('starts video identification for VIDEO_IDENT_REQUIRED', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.VIDEO_IDENT_REQUIRED} />);
+
+    fireEvent.click(screen.getByTestId('styled-button'));
+    expect(mockStartStep).toHaveBeenCalledWith(KycStepName.IDENT, KycStepType.SUMSUB_VIDEO);
+  });
+
+  it('starts the recommendation step for RECOMMENDATION_REQUIRED', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.RECOMMENDATION_REQUIRED} />);
+
+    fireEvent.click(screen.getByTestId('styled-button'));
+    expect(mockStartStep).toHaveBeenCalledWith(KycStepName.RECOMMENDATION);
+  });
+
+  it('starts the contact-data step for EMAIL_REQUIRED', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.EMAIL_REQUIRED} />);
+
+    fireEvent.click(screen.getByTestId('styled-button'));
+    expect(mockStartStep).toHaveBeenCalledWith(KycStepName.CONTACT_DATA);
+  });
+
+  it('navigates to profile for KYC_DATA_REQUIRED', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.KYC_DATA_REQUIRED} />);
+
+    fireEvent.click(screen.getByTestId('styled-button'));
+    expect(mockNavigate).toHaveBeenCalledWith('/profile', { setRedirect: true });
+  });
+
+  it('starts KYC when incomplete on the default path', async () => {
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.KYC_REQUIRED} />);
+
+    expect(screen.getByTestId('styled-button').textContent).toBe('Complete KYC');
+    fireEvent.click(screen.getByTestId('styled-button'));
+    expect(mockStart).toHaveBeenCalled();
+  });
+
+  it('navigates to the limit-request issue when complete on LIMIT_EXCEEDED', async () => {
+    mockIsComplete = true;
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.LIMIT_EXCEEDED} />);
+
+    expect(screen.getByTestId('styled-button').textContent).toBe('Increase limit');
+    fireEvent.click(screen.getByTestId('styled-button'));
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: '/support/issue',
+      search: '?issue-type=LimitRequest',
+    });
+  });
+
+  it('shows the already-verified link when kyc.level is 0 and navigates to /link', async () => {
+    mockUser = { kyc: { level: 0 } };
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.KYC_REQUIRED} />);
+
+    const link = screen.getByTestId('styled-link');
+    expect(link.textContent).toBe('I am already verified with DFX');
+    fireEvent.click(link);
+    expect(mockNavigate).toHaveBeenCalledWith('/link', { setRedirect: true });
+  });
+
+  it('hides the already-verified link when kyc.level is not 0', async () => {
+    mockUser = { kyc: { level: 1 } };
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.KYC_REQUIRED} />);
+
+    expect(screen.queryByTestId('styled-link')).not.toBeInTheDocument();
+    await expectReported(
+      'This transaction is only possible with a verified account. Please complete our KYC (Know-Your-Customer) process.',
+    );
+  });
+
+  it('hides the already-verified link when user is undefined', async () => {
+    mockUser = undefined;
+    renderHint(<QuoteErrorHint type={TransactionType.BUY} error={TransactionError.KYC_REQUIRED} />);
+
+    expect(screen.queryByTestId('styled-link')).not.toBeInTheDocument();
+    await expectReported(
+      'This transaction is only possible with a verified account. Please complete our KYC (Know-Your-Customer) process.',
+    );
+  });
+});

--- a/src/__tests__/quote-error-hint.test.tsx
+++ b/src/__tests__/quote-error-hint.test.tsx
@@ -97,6 +97,10 @@ jest.mock('../hooks/navigation.hook', () => ({
   }),
 }));
 
+jest.mock('../hooks/report-displayed-error.hook', () => ({
+  useReportDisplayedError: jest.fn(),
+}));
+
 import { QuoteErrorHint } from '../components/quote-error-hint';
 import { TransactionError, TransactionType, KycStepName } from '@dfx.swiss/react';
 

--- a/src/__tests__/report-displayed-error.hook.test.tsx
+++ b/src/__tests__/report-displayed-error.hook.test.tsx
@@ -1,0 +1,97 @@
+let mockUser: { accountId: number } | undefined;
+jest.mock('@dfx.swiss/react', () => ({ useUserContext: () => ({ user: mockUser }) }));
+jest.mock('src/dto/safe.dto', () => ({}));
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useReportDisplayedError } from '../hooks/report-displayed-error.hook';
+
+const mockReportClientError = jest.fn();
+jest.mock('src/util/client-error', () => ({
+  ...jest.requireActual('src/util/client-error'),
+  reportClientError: (...args: unknown[]) => mockReportClientError(...args),
+}));
+
+function wrapper({ children }: { children: React.ReactNode }): JSX.Element {
+  return <MemoryRouter initialEntries={['/buy']}>{children}</MemoryRouter>;
+}
+
+describe('useReportDisplayedError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser = undefined;
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, pathname: '/host-page' },
+      writable: true,
+    });
+  });
+
+  it('does not report when message is undefined', async () => {
+    renderHook(() => useReportDisplayedError(undefined), { wrapper });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockReportClientError).not.toHaveBeenCalled();
+  });
+
+  it('does not report when message is empty', async () => {
+    renderHook(() => useReportDisplayedError(''), { wrapper });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockReportClientError).not.toHaveBeenCalled();
+  });
+
+  it('reports a non-empty message without an account when nobody is signed in', async () => {
+    renderHook(() => useReportDisplayedError('boom'), { wrapper });
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][0]).toMatchObject({ message: 'boom', name: 'HandledError' });
+    expect(mockReportClientError.mock.calls[0][1]).toBe('/buy');
+    expect(mockReportClientError.mock.calls[0][2]).toBeUndefined();
+  });
+
+  it('reports the account of the customer who saw the failure', async () => {
+    mockUser = { accountId: 123456 };
+
+    renderHook(() => useReportDisplayedError('boom'), { wrapper });
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][2]).toBe(123456);
+  });
+
+  it('reports the route the customer was on, not the browser URL', async () => {
+    renderHook(() => useReportDisplayedError('boom'), { wrapper });
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][1]).toBe('/buy');
+    expect(mockReportClientError.mock.calls[0][1]).not.toBe('/host-page');
+  });
+
+  it('reports again when the message changes', async () => {
+    const { rerender } = renderHook(({ message }) => useReportDisplayedError(message), {
+      wrapper,
+      initialProps: { message: 'boom' },
+    });
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][0]).toMatchObject({ message: 'boom', name: 'HandledError' });
+
+    rerender({ message: 'other' });
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(2));
+    expect(mockReportClientError.mock.calls[1][0]).toMatchObject({ message: 'other', name: 'HandledError' });
+  });
+
+  it('does not report again when deps are unchanged', async () => {
+    const { rerender } = renderHook(({ message }) => useReportDisplayedError(message), {
+      wrapper,
+      initialProps: { message: 'boom' },
+    });
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+
+    rerender({ message: 'boom' });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockReportClientError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/report-displayed-error.hook.test.tsx
+++ b/src/__tests__/report-displayed-error.hook.test.tsx
@@ -110,4 +110,41 @@ describe('useReportDisplayedError', () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(mockReportClientError).toHaveBeenCalledTimes(1);
   });
+
+  it('reports with the provided type instead of HandledError', async () => {
+    renderHook(() => useReportDisplayedError('boom', 'QuoteError'), { wrapper });
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][0]).toMatchObject({ message: 'boom', name: 'QuoteError' });
+    expect(mockReportClientError.mock.calls[0][1]).toBe('/buy');
+  });
+
+  it('reports again when the type changes', async () => {
+    const { rerender } = renderHook(({ message, type }) => useReportDisplayedError(message, type), {
+      wrapper,
+      initialProps: { message: 'boom', type: 'HandledError' },
+    });
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][0]).toMatchObject({ message: 'boom', name: 'HandledError' });
+
+    rerender({ message: 'boom', type: 'QuoteError' });
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(2));
+    expect(mockReportClientError.mock.calls[1][0]).toMatchObject({ message: 'boom', name: 'QuoteError' });
+  });
+
+  it('does not report again when type is unchanged', async () => {
+    const { rerender } = renderHook(({ message, type }) => useReportDisplayedError(message, type), {
+      wrapper,
+      initialProps: { message: 'boom', type: 'QuoteError' },
+    });
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+
+    rerender({ message: 'boom', type: 'QuoteError' });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockReportClientError).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/__tests__/report-displayed-error.hook.test.tsx
+++ b/src/__tests__/report-displayed-error.hook.test.tsx
@@ -94,4 +94,20 @@ describe('useReportDisplayedError', () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(mockReportClientError).toHaveBeenCalledTimes(1);
   });
+
+  it('does not report a second time once the account arrives', async () => {
+    const { rerender } = renderHook(({ message }) => useReportDisplayedError(message), {
+      wrapper,
+      initialProps: { message: 'boom' },
+    });
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][2]).toBeUndefined();
+
+    mockUser = { accountId: 123456 };
+    rerender({ message: 'boom' });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockReportClientError).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/error-hint.tsx
+++ b/src/components/error-hint.tsx
@@ -1,7 +1,9 @@
 import { StyledButton, StyledButtonColor } from '@dfx.swiss/react-components';
 import { useSettingsContext } from '../contexts/settings.context';
+import { useReportDisplayedError } from '../hooks/report-displayed-error.hook';
 
 export function ErrorHint({ message, onBack }: { message: string; onBack?: () => void }): JSX.Element {
+  useReportDisplayedError(message);
   const { translate } = useSettingsContext();
 
   return (

--- a/src/components/home/connect-shared.tsx
+++ b/src/components/home/connect-shared.tsx
@@ -3,6 +3,7 @@ import { RefObject } from 'react';
 import { BitcoinAddressType } from '../../config/key-path';
 import { useSettingsContext } from '../../contexts/settings.context';
 import { WalletType } from '../../contexts/wallet.context';
+import { useReportDisplayedError } from '../../hooks/report-displayed-error.hook';
 
 export type Account =
   | {
@@ -40,6 +41,7 @@ export interface ConnectContentProps {
 }
 
 export function ConnectError({ error }: { error: string }): JSX.Element {
+  useReportDisplayedError(error);
   const { translate } = useSettingsContext();
 
   return (

--- a/src/components/quote-error-hint.tsx
+++ b/src/components/quote-error-hint.tsx
@@ -9,6 +9,7 @@ import {
 import { useSettingsContext } from '../contexts/settings.context';
 import { useKycHelper } from '../hooks/kyc-helper.hook';
 import { useNavigation } from '../hooks/navigation.hook';
+import { useReportDisplayedError } from '../hooks/report-displayed-error.hook';
 
 export function QuoteErrorHint({
   type,
@@ -111,6 +112,7 @@ export function QuoteErrorHint({
   }
 
   const hint = message ?? getHint(error);
+  useReportDisplayedError(hint != null ? hint || String(error) : undefined, 'QuoteError');
 
   return hint != null ? (
     <StyledVerticalStack gap={4} full center>

--- a/src/hooks/report-displayed-error.hook.ts
+++ b/src/hooks/report-displayed-error.hook.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { reportClientError } from 'src/util/client-error';
 
-export function useReportDisplayedError(message: string | undefined): void {
+export function useReportDisplayedError(message: string | undefined, type = 'HandledError'): void {
   const { pathname } = useLocation();
   const { user } = useUserContext();
   const accountIdRef = useRef(user?.accountId);
@@ -12,6 +12,6 @@ export function useReportDisplayedError(message: string | undefined): void {
   useEffect(() => {
     if (!message) return;
 
-    reportClientError(Object.assign(new Error(message), { name: 'HandledError' }), pathname, accountIdRef.current);
-  }, [message, pathname]);
+    reportClientError(Object.assign(new Error(message), { name: type }), pathname, accountIdRef.current);
+  }, [message, pathname, type]);
 }

--- a/src/hooks/report-displayed-error.hook.ts
+++ b/src/hooks/report-displayed-error.hook.ts
@@ -1,15 +1,17 @@
 import { useUserContext } from '@dfx.swiss/react';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { reportClientError } from 'src/util/client-error';
 
 export function useReportDisplayedError(message: string | undefined): void {
   const { pathname } = useLocation();
   const { user } = useUserContext();
+  const accountIdRef = useRef(user?.accountId);
+  accountIdRef.current = user?.accountId;
 
   useEffect(() => {
     if (!message) return;
 
-    reportClientError(Object.assign(new Error(message), { name: 'HandledError' }), pathname, user?.accountId);
-  }, [message, pathname, user?.accountId]);
+    reportClientError(Object.assign(new Error(message), { name: 'HandledError' }), pathname, accountIdRef.current);
+  }, [message, pathname]);
 }

--- a/src/hooks/report-displayed-error.hook.ts
+++ b/src/hooks/report-displayed-error.hook.ts
@@ -1,0 +1,15 @@
+import { useUserContext } from '@dfx.swiss/react';
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { reportClientError } from 'src/util/client-error';
+
+export function useReportDisplayedError(message: string | undefined): void {
+  const { pathname } = useLocation();
+  const { user } = useUserContext();
+
+  useEffect(() => {
+    if (!message) return;
+
+    reportClientError(Object.assign(new Error(message), { name: 'HandledError' }), pathname, user?.accountId);
+  }, [message, pathname, user?.accountId]);
+}


### PR DESCRIPTION
EN:
Customer-visible failures (ErrorHint, ConnectError, crash screen) post as ERROR. KYC/limit process blockers (QuoteErrorHint) post as QuoteError so they are recorded as INFO, not as crashes. Visible copy is unchanged. Coverage on every touched production file is 100% statement, branch, function and line.

DE:
Sichtbare Ausfälle (ErrorHint, ConnectError, Crash-Screen) gehen als ERROR. KYC-/Limit-Blocker (QuoteErrorHint) gehen als QuoteError und werden als INFO erfasst, nicht als Absturz. Die sichtbare Copy bleibt gleich. Coverage auf jeder angefassten Produktionsdatei ist 100 % Statement, Branch, Function und Line.

<details>
<summary>Details</summary>

`useReportDisplayedError` takes an optional type (default `HandledError`). `QuoteErrorHint` reports with `QuoteError`. Empty KYC-data hint reports the enum string. Form validation is not logged. A matching backend change records `QuoteError` at INFO.

Per-file coverage (statement / branch / function / line), measured on the build host with Node 20:

| File | S | B | F | L |
| --- | --- | --- | --- | --- |
| `src/hooks/report-displayed-error.hook.ts` | 100 | 100 | 100 | 100 |
| `src/components/error-hint.tsx` | 100 | 100 | 100 | 100 |
| `src/components/home/connect-shared.tsx` | 100 | 100 | 100 | 100 |
| `src/components/quote-error-hint.tsx` | 100 | 100 | 100 | 100 |

</details>