### PR TITLE
01a07faa - Locate the compliance search KYC Level header via thead text

### DIFF
--- a/e2e-stack/specs/compliance.spec.ts
+++ b/e2e-stack/specs/compliance.spec.ts
@@ -168,7 +168,8 @@ test.describe('Compliance area (overview)', () => {
 
     // The KYC Level column shows the seeded level (30) in the customer's row
     const customersTable = page.getByText('Customers', { exact: true }).locator('xpath=following::table[1]');
-    await expect(customersTable.getByRole('columnheader', { name: 'KYC Level', exact: true })).toBeVisible();
+    // thead <th> cells map to ARIA role "cell" in this app, not "columnheader".
+    await expect(customersTable.locator('thead').getByText('KYC Level', { exact: true })).toBeVisible();
     const customerRow = customersTable
       .getByRole('row')
       .filter({ hasText: String(customer.userDataId) })


### PR DESCRIPTION
EN:
The develop-to-main release Full-stack E2E failed on the compliance search test: it looked for a columnheader named KYC Level, and Chromium never exposes this app's thead cells as that role. The column was on the page; the locator was wrong. This uses the same thead text query as the financial-dashboard and RealUnit specs, still scoped to the Customers table. Merging this into develop is what turns the release PR green.

DE:
Die Full-stack-E2E des Develop-nach-Main-Releases ist am Compliance-Suchtest gescheitert: er suchte eine columnheader namens KYC Level, und Chromium gibt die thead-Zellen dieser App nicht in dieser Rolle aus. Die Spalte war auf der Seite; der Locator war falsch. Der Test nutzt dieselbe thead-Textabfrage wie Financial-Dashboard und RealUnit, weiter auf die Customers-Tabelle begrenzt. Der Merge nach develop macht den Release-PR grün.

<details>
<summary>Details</summary>

The failing assertion in `e2e-stack/specs/compliance.spec.ts` was:

```ts
await expect(customersTable.getByRole('columnheader', { name: 'KYC Level', exact: true })).toBeVisible();
```

Playwright's Chromium accessibility snapshot of the failure showed the header as role `cell`. Production markup already uses `<thead><th>`. The same mapping is documented in `e2e-stack/specs/dashboard-financial.spec.ts` and `e2e-stack/specs/realunit.spec.ts`.

Replacement, still scoped to the Customers table so a Pending Transactions header cannot match:

```ts
// thead <th> cells map to ARIA role "cell" in this app, not "columnheader".
await expect(customersTable.locator('thead').getByText('KYC Level', { exact: true })).toBeVisible();
```

No production UI change. The seeded KYC level `30` row assertion is unchanged.

This does not land on `develop` by itself. The open release PR (`develop` → `main`) updates after this merge.

</details>