### PR TITLE
fix(support): count a bot auto-response as an answer in the open-ticket grouping

### DIFF
--- a/e2e/realunit-support.spec.ts
+++ b/e2e/realunit-support.spec.ts
@@ -131,7 +131,7 @@ interface SupportMessageInfo {
 }
 
 // Open issues (states Created/Pending) returned by realunit/support/list for the default Open tab. Spread across
-// the two groups the screen renders: "Awaiting reply" (customer or bot wrote last) and "Answered" (we wrote last).
+// the two groups the screen renders: "Awaiting reply" (customer wrote last) and "Answered" (we or the bot wrote last).
 const OPEN_ISSUES: SupportIssueListItem[] = [
   // Awaiting reply (customer waiting) — sorted by lastMessageDate desc by the screen
   {

--- a/src/__tests__/support-issue-table.test.tsx
+++ b/src/__tests__/support-issue-table.test.tsx
@@ -230,7 +230,7 @@ describe('GroupedIssueTable', () => {
           needsReply: [
             issue({ id: 1, name: 'Fresh', lastMessageAuthor: 'Customer', lastMessageDate: hoursAgo(0.5) }),
             issue({ id: 2, name: 'Half day', lastMessageAuthor: 'Customer', lastMessageDate: hoursAgo(13) }),
-            issue({ id: 3, name: 'Escalated', lastMessageAuthor: 'AutoResponder', lastMessageDate: hoursAgo(30) }),
+            issue({ id: 3, name: 'Escalated', lastMessageAuthor: 'Customer', lastMessageDate: hoursAgo(30) }),
             issue({ id: 4, name: 'No message yet', lastMessageAuthor: undefined, lastMessageDate: undefined }),
           ],
           answered: [],

--- a/src/__tests__/support-stats.test.ts
+++ b/src/__tests__/support-stats.test.ts
@@ -77,11 +77,11 @@ describe('support-helpers customer waiting', () => {
     ).toBeCloseTo(5);
   });
 
-  it('returns null when we replied last (timer resets on author flip) or there are no messages', () => {
+  it('returns null when we or the bot replied last (timer resets on author flip) or there are no messages', () => {
     expect(customerWaitingHours(issue({ lastMessageAuthor: 'Josh', lastMessageDate: hoursAgo(40) }), NOW)).toBeNull();
     expect(
       customerWaitingHours(issue({ lastMessageAuthor: 'AutoResponder', lastMessageDate: hoursAgo(2) }), NOW),
-    ).toBeCloseTo(2, 5);
+    ).toBeNull();
     expect(customerWaitingHours(issue({ messageCount: 0 }), NOW)).toBeNull();
     expect(customerWaitingHours(issue({ lastMessageAuthor: 'Customer', lastMessageDate: undefined }), NOW)).toBeNull();
   });
@@ -278,15 +278,24 @@ describe('groupOpenIssues', () => {
     expect(groups.answered.map((i) => i.id)).toEqual([2, 1]);
   });
 
-  it('treats a bot auto-response and a ticket without any message as still awaiting a human reply', () => {
+  it('counts a bot auto-response as an answer and a ticket without any message as awaiting a reply', () => {
     const groups = groupOpenIssues([
       issue({ id: 1, lastMessageAuthor: 'AutoResponder', lastMessageDate: '2026-08-30T11:00:00Z' }),
       issue({ id: 2, lastMessageAuthor: 'Jana', lastMessageDate: '2026-08-31T09:00:00Z' }),
       issue({ id: 3, created: '2026-08-29T10:00:00Z', lastMessageAuthor: undefined, messageCount: 0 }),
     ]);
 
-    expect(groups.needsReply.map((i) => i.id)).toEqual([1, 3]);
-    expect(groups.answered.map((i) => i.id)).toEqual([2]);
+    expect(groups.needsReply.map((i) => i.id)).toEqual([3]);
+    expect(groups.answered.map((i) => i.id)).toEqual([2, 1]);
+  });
+
+  it('brings a bot-answered ticket back once the customer writes again', () => {
+    const groups = groupOpenIssues([
+      issue({ id: 1, lastMessageAuthor: 'Customer', lastMessageDate: '2026-08-30T12:00:00Z', messageCount: 3 }),
+    ]);
+
+    expect(groups.needsReply.map((i) => i.id)).toEqual([1]);
+    expect(groups.answered).toEqual([]);
   });
 
   it('falls back to the creation date for tickets without a message', () => {

--- a/src/util/support-stats.ts
+++ b/src/util/support-stats.ts
@@ -36,10 +36,8 @@ export function daysSince(date: string | Date, now: Date = new Date()): number {
 }
 
 // Hours the customer has been waiting for a reply, or null if the ball is on our side
-// (we answered last, or there are no messages yet). The clock restarts on every
+// (we or the bot answered last, or there are no messages yet). The clock restarts on every
 // customer message because `lastMessageDate` always points at the latest message.
-// A bot auto-response keeps the ticket waiting; its timestamp is then used as a close
-// approximation of the customer's message (the bot answers within minutes).
 export function customerWaitingHours(issue: SupportIssueListItem, now: Date = new Date()): number | null {
   if (!needsReply(issue) || !issue.lastMessageDate) return null;
   return hoursSince(issue.lastMessageDate, now);
@@ -57,20 +55,16 @@ export function formatElapsed(hours: number): string {
 // --- Open-ticket grouping ---
 
 export interface OpenIssueGroups {
-  needsReply: SupportIssueListItem[]; // the customer (or only the bot) wrote last: our turn
-  answered: SupportIssueListItem[]; // a staff member wrote last: the customer's turn
+  needsReply: SupportIssueListItem[]; // the customer wrote last: our turn
+  answered: SupportIssueListItem[]; // a staff member or the bot wrote last: the customer's turn
 }
 
-// A ticket needs a human reply while the last message came from the customer or from the bot,
-// or while it has no message at all (a ticket a clerk opened, or an automatically filed limit
-// request). A fresh customer ticket starts with a customer message, so new tickets land here as
-// well; a bot auto-response does not count as an answer.
+// A ticket needs a reply while the last message came from the customer, or while it has no
+// message at all (a ticket a clerk opened, or an automatically filed limit request). A fresh
+// customer ticket starts with a customer message, so new tickets land here as well. A bot
+// auto-response counts as an answer: the ticket only comes back once the customer writes again.
 export function needsReply(issue: SupportIssueListItem): boolean {
-  return (
-    !issue.lastMessageAuthor ||
-    issue.lastMessageAuthor === CustomerAuthor ||
-    issue.lastMessageAuthor === AutoResponderAuthor
-  );
+  return !issue.lastMessageAuthor || issue.lastMessageAuthor === CustomerAuthor;
 }
 
 // A ticket nobody has picked up yet: no clerk, or only the bot (the backend stamps the bot as


### PR DESCRIPTION
EN:
A ticket the AutoResponder replied to last was listed under Awaiting reply with a waiting badge (see #1455), although the customer already got an answer. A bot reply now counts as an answer: the ticket sits under Answered and only returns to Awaiting reply once the customer writes again, as it did before the regrouping.

DE:
Ein Ticket, auf das zuletzt der AutoResponder geantwortet hat, stand unter Awaiting reply mit Warte-Badge (siehe #1455), obwohl der Kunde bereits eine Antwort erhalten hat. Eine Bot-Antwort gilt jetzt als Antwort: Das Ticket liegt unter Answered und kommt erst zurück nach Awaiting reply, wenn der Kunde erneut schreibt, wie vor der Neugruppierung.

<details>
<summary>Details</summary>

Change: `needsReply` in `src/util/support-stats.ts` no longer treats `AutoResponder` as "our turn". `customerWaitingHours` (waiting badge in the ticket table, escalation tiles on the overview) uses the same function, so bot-answered tickets no longer show a waiting time either. `isUnassigned` is unchanged (bot as clerk still renders Unassigned). Tickets without any message stay in Awaiting reply.

Tests: `support-stats.test.ts` (bot reply = answered, ticket returns on the next customer message, waiting timer null after a bot reply), `support-issue-table.test.tsx` (escalated badge sample now uses a customer message). Measured coverage on Node 20 for `support-stats.ts` and `issue-table.tsx`: 100/100/100/100. Full Jest suite: 135 suites, 2058 tests green (`LC_ALL=en_US.UTF-8`, see #1460).

Declared: no Playwright baseline change (no rendered screen changes; the local seed has no bot-answered tickets). The `e2e/realunit-support.spec.ts` grouping comment is updated, the fixture data and assertions are unaffected (no bot-authored issue in the fixture).

Overlap: #1427 touches `support-dashboard-overview.screen.tsx`, not the files changed here.

</details>
