### PR TITLE
01a0895a - Add RealUnit prize-wallet low-balance alerts

### DIFF
--- a/src/__tests__/prize-wallet-alert-panel.test.tsx
+++ b/src/__tests__/prize-wallet-alert-panel.test.tsx
@@ -41,6 +41,7 @@ const ALERT = {
 const NOTIFY = 'Bei niedrigem Bestand benachrichtigen';
 
 async function openForm() {
+  await waitFor(() => expect(screen.getByRole('button', { name: NOTIFY })).not.toBeDisabled());
   fireEvent.click(screen.getByRole('button', { name: NOTIFY }));
   await waitFor(() => expect(screen.getByLabelText('Asset')).toBeInTheDocument());
 }
@@ -65,6 +66,12 @@ describe('RealunitPrizeWalletAlertPanel', () => {
     expect(screen.getByRole('button', { name: NOTIFY })).toBeInTheDocument();
     expect(screen.getByTestId('prize-wallet-alert-loading')).toHaveTextContent('Loading');
     expect(screen.queryByLabelText('Asset')).not.toBeInTheDocument();
+  });
+
+  it('keeps Notify disabled while alerts are still loading', () => {
+    mockListPrizeWalletAlerts.mockImplementation(() => new Promise(() => undefined));
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    expect(screen.getByRole('button', { name: NOTIFY })).toBeDisabled();
   });
 
   it('toggles the form open and closed', async () => {
@@ -119,6 +126,37 @@ describe('RealunitPrizeWalletAlertPanel', () => {
 
     fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '0' } });
     expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('rejects comma-separated and whitespace-separated mail', async () => {
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
+    await openForm();
+
+    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '0.05' } });
+    const form = screen.getByRole('button', { name: 'Submit' }).closest('form') as HTMLFormElement;
+
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'a@b,c@d' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+    fireEvent.submit(form);
+    expect(mockCreatePrizeWalletAlert).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'a@b c@d' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+    fireEvent.submit(form);
+    expect(mockCreatePrizeWalletAlert).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'a@@b' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: '@b' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'a@' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'a@b' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Submit' })).not.toBeDisabled());
   });
 
   it('does not create on form submit when the form is incomplete', async () => {
@@ -209,6 +247,39 @@ describe('RealunitPrizeWalletAlertPanel', () => {
     mockListPrizeWalletAlerts.mockRejectedValue(new Error('list-fail'));
     render(<RealunitPrizeWalletAlertPanel translate={translate} />);
     await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('list-fail'));
+  });
+
+  it('keeps Submit disabled after the alert list fails to load', async () => {
+    mockListPrizeWalletAlerts.mockRejectedValue(new Error('list-fail'));
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('list-fail'));
+    await openForm();
+    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '0.05' } });
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'ops@example.com' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('clears listError after a successful create', async () => {
+    mockListPrizeWalletAlerts.mockRejectedValue(new Error('list-fail'));
+    mockCreatePrizeWalletAlert.mockResolvedValue(ALERT);
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('list-fail'));
+    await openForm();
+    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '0.05' } });
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'ops@example.com' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+
+    fireEvent.submit(screen.getByRole('button', { name: 'Submit' }).closest('form') as HTMLFormElement);
+
+    await waitFor(() =>
+      expect(mockCreatePrizeWalletAlert).toHaveBeenCalledWith({
+        asset: RealUnitPrizeWalletAlertAsset.ETH,
+        threshold: 0.05,
+        mail: 'ops@example.com',
+      }),
+    );
+    await waitFor(() => expect(screen.queryByText('list-fail')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
   });
 
   it('falls back to Unknown error when the alert list rejects without a message', async () => {

--- a/src/__tests__/prize-wallet-alert-panel.test.tsx
+++ b/src/__tests__/prize-wallet-alert-panel.test.tsx
@@ -128,7 +128,7 @@ describe('RealunitPrizeWalletAlertPanel', () => {
     expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
   });
 
-  it('rejects comma-separated and whitespace-separated mail', async () => {
+  it('rejects comma-separated, semicolon-separated, and whitespace-separated mail', async () => {
     render(<RealunitPrizeWalletAlertPanel translate={translate} />);
     await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
     await openForm();
@@ -137,6 +137,11 @@ describe('RealunitPrizeWalletAlertPanel', () => {
     const form = screen.getByRole('button', { name: 'Submit' }).closest('form') as HTMLFormElement;
 
     fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'a@b,c@d' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+    fireEvent.submit(form);
+    expect(mockCreatePrizeWalletAlert).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'a@b;c@d' } });
     expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
     fireEvent.submit(form);
     expect(mockCreatePrizeWalletAlert).not.toHaveBeenCalled();
@@ -174,11 +179,13 @@ describe('RealunitPrizeWalletAlertPanel', () => {
     await fillValidEthForm();
     fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
-    await waitFor(() => expect(mockCreatePrizeWalletAlert).toHaveBeenCalledWith({
-      asset: RealUnitPrizeWalletAlertAsset.ETH,
-      threshold: 0.05,
-      mail: 'ops@example.com',
-    }));
+    await waitFor(() =>
+      expect(mockCreatePrizeWalletAlert).toHaveBeenCalledWith({
+        asset: RealUnitPrizeWalletAlertAsset.ETH,
+        threshold: 0.05,
+        mail: 'ops@example.com',
+      }),
+    );
     await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
     expect(screen.queryByLabelText('Asset')).not.toBeInTheDocument();
   });
@@ -247,29 +254,19 @@ describe('RealunitPrizeWalletAlertPanel', () => {
     mockListPrizeWalletAlerts.mockRejectedValue(new Error('list-fail'));
     render(<RealunitPrizeWalletAlertPanel translate={translate} />);
     await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('list-fail'));
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 
-  it('keeps Submit disabled after the alert list fails to load', async () => {
-    mockListPrizeWalletAlerts.mockRejectedValue(new Error('list-fail'));
-    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
-    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('list-fail'));
-    await openForm();
-    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '0.05' } });
-    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'ops@example.com' } });
-    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
-  });
-
-  it('clears listError after a successful create', async () => {
+  it('keeps Submit enabled after the alert list fails and clears listError on successful create', async () => {
     mockListPrizeWalletAlerts.mockRejectedValue(new Error('list-fail'));
     mockCreatePrizeWalletAlert.mockResolvedValue(ALERT);
     render(<RealunitPrizeWalletAlertPanel translate={translate} />);
     await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('list-fail'));
     await openForm();
-    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '0.05' } });
-    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'ops@example.com' } });
-    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+    await fillValidEthForm();
+    expect(screen.getByRole('button', { name: 'Submit' })).not.toBeDisabled();
 
-    fireEvent.submit(screen.getByRole('button', { name: 'Submit' }).closest('form') as HTMLFormElement);
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
     await waitFor(() =>
       expect(mockCreatePrizeWalletAlert).toHaveBeenCalledWith({
@@ -280,6 +277,20 @@ describe('RealunitPrizeWalletAlertPanel', () => {
     );
     await waitFor(() => expect(screen.queryByText('list-fail')).not.toBeInTheDocument());
     await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+  });
+
+  it('retries the alert list after a load failure', async () => {
+    mockListPrizeWalletAlerts.mockRejectedValueOnce(new Error('list-fail')).mockResolvedValueOnce([ALERT]);
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('list-fail'));
+    expect(mockListPrizeWalletAlerts).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByText('list-fail')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
   });
 
   it('falls back to Unknown error when the alert list rejects without a message', async () => {
@@ -312,6 +323,26 @@ describe('RealunitPrizeWalletAlertPanel', () => {
 
     await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('nope'));
     expect(screen.getByText('ops@example.com')).toBeInTheDocument();
+  });
+
+  it('clears a leftover delete error after a successful create', async () => {
+    const created = { ...ALERT, id: 11, mail: 'new@example.com' };
+    mockListPrizeWalletAlerts.mockResolvedValue([ALERT]);
+    mockDeletePrizeWalletAlert.mockRejectedValue(new Error('nope'));
+    mockCreatePrizeWalletAlert.mockResolvedValue(created);
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('nope'));
+
+    await openForm();
+    await fillValidEthForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(mockCreatePrizeWalletAlert).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByText('nope')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('new@example.com')).toBeInTheDocument());
   });
 
   it('falls back to Unknown error when delete rejects without a message', async () => {

--- a/src/__tests__/prize-wallet-alert-panel.test.tsx
+++ b/src/__tests__/prize-wallet-alert-panel.test.tsx
@@ -38,7 +38,7 @@ const ALERT = {
   created: '2026-09-10T00:00:00.000Z',
 };
 
-const NOTIFY = 'Bei niedrigem Bestand benachrichtigen';
+const NOTIFY = 'Notify on low balance';
 
 async function openForm() {
   await waitFor(() => expect(screen.getByRole('button', { name: NOTIFY })).not.toBeDisabled());
@@ -356,6 +356,12 @@ describe('RealunitPrizeWalletAlertPanel', () => {
     await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('Unknown error'));
   });
 
+  it('exposes Notify on low balance as the notify button accessible name', async () => {
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
+    expect(screen.getByRole('button', { name: 'Notify on low balance' })).toBeInTheDocument();
+  });
+
   it('ignores a second Submit click while create is in flight', async () => {
     const deferred: { resolve: (value: typeof ALERT) => void } = { resolve: () => undefined };
     mockCreatePrizeWalletAlert.mockImplementation(
@@ -373,6 +379,28 @@ describe('RealunitPrizeWalletAlertPanel', () => {
     fireEvent.click(submit);
     fireEvent.click(submit);
     expect(mockCreatePrizeWalletAlert).toHaveBeenCalledTimes(1);
+
+    deferred.resolve(ALERT);
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+  });
+
+  it('disables Retry while create is in flight', async () => {
+    mockListPrizeWalletAlerts.mockRejectedValueOnce(new Error('list-fail'));
+    const deferred: { resolve: (value: typeof ALERT) => void } = { resolve: () => undefined };
+    mockCreatePrizeWalletAlert.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          deferred.resolve = resolve;
+        }),
+    );
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('list-fail'));
+    await openForm();
+    await fillValidEthForm();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() => expect(mockCreatePrizeWalletAlert).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeDisabled();
 
     deferred.resolve(ALERT);
     await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());

--- a/src/__tests__/prize-wallet-alert-panel.test.tsx
+++ b/src/__tests__/prize-wallet-alert-panel.test.tsx
@@ -1,0 +1,322 @@
+jest.mock('@dfx.swiss/react', () => ({}));
+jest.mock('@dfx.swiss/react-components', () => ({
+  SpinnerSize: { SM: 'sm', LG: 'lg' },
+  StyledButtonWidth: { MIN: 'min' },
+  StyledLoadingSpinner: () => <div data-testid="loading-spinner" />,
+  StyledButton: ({ label, onClick, disabled }: { label: string; onClick: () => void; disabled?: boolean }) => (
+    <button type="button" disabled={disabled} onClick={onClick}>
+      {label}
+    </button>
+  ),
+}));
+jest.mock('src/components/error-hint', () => ({
+  ErrorHint: ({ message }: { message: string }) => <div data-testid="error-hint">{message}</div>,
+}));
+
+const mockListPrizeWalletAlerts = jest.fn();
+const mockCreatePrizeWalletAlert = jest.fn();
+const mockDeletePrizeWalletAlert = jest.fn();
+jest.mock('src/hooks/realunit-referral.hook', () => ({
+  useRealunitReferral: () => ({
+    listPrizeWalletAlerts: (...args: unknown[]) => mockListPrizeWalletAlerts(...args),
+    createPrizeWalletAlert: (...args: unknown[]) => mockCreatePrizeWalletAlert(...args),
+    deletePrizeWalletAlert: (...args: unknown[]) => mockDeletePrizeWalletAlert(...args),
+  }),
+}));
+
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { RealunitPrizeWalletAlertPanel } from 'src/components/realunit/prize-wallet-alert-panel';
+import { RealUnitPrizeWalletAlertAsset } from 'src/dto/realunit-referral.dto';
+
+const translate = (_ns: string, key: string) => key;
+
+const ALERT = {
+  id: 3,
+  asset: RealUnitPrizeWalletAlertAsset.ETH,
+  threshold: 0.05,
+  mail: 'ops@example.com',
+  created: '2026-09-10T00:00:00.000Z',
+};
+
+const NOTIFY = 'Bei niedrigem Bestand benachrichtigen';
+
+async function openForm() {
+  fireEvent.click(screen.getByRole('button', { name: NOTIFY }));
+  await waitFor(() => expect(screen.getByLabelText('Asset')).toBeInTheDocument());
+}
+
+async function fillValidEthForm() {
+  fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '0.05' } });
+  fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'ops@example.com' } });
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Submit' })).not.toBeDisabled());
+}
+
+describe('RealunitPrizeWalletAlertPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListPrizeWalletAlerts.mockResolvedValue([]);
+    mockCreatePrizeWalletAlert.mockResolvedValue(ALERT);
+    mockDeletePrizeWalletAlert.mockResolvedValue(undefined);
+  });
+
+  it('shows the notify button and a loading spinner while alerts load', () => {
+    mockListPrizeWalletAlerts.mockImplementation(() => new Promise(() => undefined));
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    expect(screen.getByRole('button', { name: NOTIFY })).toBeInTheDocument();
+    expect(screen.getByTestId('prize-wallet-alert-loading')).toHaveTextContent('Loading');
+    expect(screen.queryByLabelText('Asset')).not.toBeInTheDocument();
+  });
+
+  it('toggles the form open and closed', async () => {
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
+    expect(screen.queryByLabelText('Asset')).not.toBeInTheDocument();
+
+    await openForm();
+    expect(screen.getByLabelText('Threshold')).toHaveAttribute('step', 'any');
+    expect(screen.getByLabelText('Threshold')).not.toHaveAttribute('min');
+
+    fireEvent.click(screen.getByRole('button', { name: NOTIFY }));
+    expect(screen.queryByLabelText('Asset')).not.toBeInTheDocument();
+  });
+
+  it('switches threshold constraints when REALU is selected', async () => {
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
+    await openForm();
+
+    fireEvent.change(screen.getByLabelText('Asset'), { target: { value: RealUnitPrizeWalletAlertAsset.REALU } });
+    expect(screen.getByLabelText('Threshold')).toHaveAttribute('step', '1');
+    expect(screen.getByLabelText('Threshold')).toHaveAttribute('min', '1');
+  });
+
+  it('keeps Submit disabled for invalid ETH, REALU, and mail values', async () => {
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
+    await openForm();
+
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'ops@example.com' } });
+    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '0' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '-1' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: 'Infinity' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '0.05' } });
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'not-an-email' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: '   ' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Asset'), { target: { value: RealUnitPrizeWalletAlertAsset.REALU } });
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: 'ops@example.com' } });
+    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '1.5' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '0' } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('does not create on form submit when the form is incomplete', async () => {
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
+    await openForm();
+    fireEvent.submit(screen.getByRole('button', { name: 'Submit' }).closest('form') as HTMLFormElement);
+    expect(mockCreatePrizeWalletAlert).not.toHaveBeenCalled();
+  });
+
+  it('creates an ETH alert, prepends it, resets and closes the form', async () => {
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
+    await openForm();
+    await fillValidEthForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(mockCreatePrizeWalletAlert).toHaveBeenCalledWith({
+      asset: RealUnitPrizeWalletAlertAsset.ETH,
+      threshold: 0.05,
+      mail: 'ops@example.com',
+    }));
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+    expect(screen.queryByLabelText('Asset')).not.toBeInTheDocument();
+  });
+
+  it('creates a REALU alert via form submit', async () => {
+    const created = {
+      ...ALERT,
+      id: 9,
+      asset: RealUnitPrizeWalletAlertAsset.REALU,
+      threshold: 10,
+      mail: 'realu@example.com',
+    };
+    mockCreatePrizeWalletAlert.mockResolvedValue(created);
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
+    await openForm();
+
+    fireEvent.change(screen.getByLabelText('Asset'), { target: { value: RealUnitPrizeWalletAlertAsset.REALU } });
+    fireEvent.change(screen.getByLabelText('Threshold'), { target: { value: '10' } });
+    fireEvent.change(screen.getByLabelText('Mail'), { target: { value: ' realu@example.com ' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Submit' })).not.toBeDisabled());
+    fireEvent.submit(screen.getByRole('button', { name: 'Submit' }).closest('form') as HTMLFormElement);
+
+    await waitFor(() =>
+      expect(mockCreatePrizeWalletAlert).toHaveBeenCalledWith({
+        asset: RealUnitPrizeWalletAlertAsset.REALU,
+        threshold: 10,
+        mail: 'realu@example.com',
+      }),
+    );
+    await waitFor(() => expect(screen.getByText('realu@example.com')).toBeInTheDocument());
+  });
+
+  it('shows a form error when create fails', async () => {
+    mockCreatePrizeWalletAlert.mockRejectedValue(new Error('taken'));
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
+    await openForm();
+    await fillValidEthForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('taken'));
+    expect(screen.getByLabelText('Asset')).toBeInTheDocument();
+  });
+
+  it('falls back to Unknown error when create rejects without a message', async () => {
+    mockCreatePrizeWalletAlert.mockRejectedValue({ message: undefined });
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
+    await openForm();
+    await fillValidEthForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('Unknown error'));
+  });
+
+  it('shows loaded alerts in the list', async () => {
+    mockListPrizeWalletAlerts.mockResolvedValue([ALERT]);
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+    expect(screen.getByText('ETH')).toBeInTheDocument();
+    expect(screen.getByText('0.05')).toBeInTheDocument();
+  });
+
+  it('shows a list error when alerts fail to load', async () => {
+    mockListPrizeWalletAlerts.mockRejectedValue(new Error('list-fail'));
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('list-fail'));
+  });
+
+  it('falls back to Unknown error when the alert list rejects without a message', async () => {
+    mockListPrizeWalletAlerts.mockRejectedValue({ message: undefined });
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('Unknown error'));
+  });
+
+  it('deletes an alert and removes the row', async () => {
+    const other = { ...ALERT, id: 4, mail: 'keep@example.com' };
+    mockListPrizeWalletAlerts.mockResolvedValue([ALERT, other]);
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+
+    const row = screen.getByText('ops@example.com').closest('tr') as HTMLElement;
+    fireEvent.click(within(row).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(mockDeletePrizeWalletAlert).toHaveBeenCalledWith(3));
+    await waitFor(() => expect(screen.queryByText('ops@example.com')).not.toBeInTheDocument());
+    expect(screen.getByText('keep@example.com')).toBeInTheDocument();
+  });
+
+  it('shows a list error when delete fails', async () => {
+    mockListPrizeWalletAlerts.mockResolvedValue([ALERT]);
+    mockDeletePrizeWalletAlert.mockRejectedValue(new Error('nope'));
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('nope'));
+    expect(screen.getByText('ops@example.com')).toBeInTheDocument();
+  });
+
+  it('falls back to Unknown error when delete rejects without a message', async () => {
+    mockListPrizeWalletAlerts.mockResolvedValue([ALERT]);
+    mockDeletePrizeWalletAlert.mockRejectedValue({ message: undefined });
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(screen.getByTestId('error-hint')).toHaveTextContent('Unknown error'));
+  });
+
+  it('ignores a second Submit click while create is in flight', async () => {
+    const deferred: { resolve: (value: typeof ALERT) => void } = { resolve: () => undefined };
+    mockCreatePrizeWalletAlert.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          deferred.resolve = resolve;
+        }),
+    );
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(mockListPrizeWalletAlerts).toHaveBeenCalled());
+    await openForm();
+    await fillValidEthForm();
+
+    const submit = screen.getByRole('button', { name: 'Submit' });
+    fireEvent.click(submit);
+    fireEvent.click(submit);
+    expect(mockCreatePrizeWalletAlert).toHaveBeenCalledTimes(1);
+
+    deferred.resolve(ALERT);
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+  });
+
+  it('allows deleting two rows in parallel', async () => {
+    const other = { ...ALERT, id: 4, mail: 'keep@example.com' };
+    mockListPrizeWalletAlerts.mockResolvedValue([ALERT, other]);
+    const resolvers: Record<number, (value?: unknown) => void> = {};
+    mockDeletePrizeWalletAlert.mockImplementation(
+      (id: number) =>
+        new Promise((resolve) => {
+          resolvers[id] = resolve;
+        }),
+    );
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+
+    const firstRow = screen.getByText('ops@example.com').closest('tr') as HTMLElement;
+    const secondRow = screen.getByText('keep@example.com').closest('tr') as HTMLElement;
+    fireEvent.click(within(firstRow).getByRole('button', { name: 'Delete' }));
+
+    expect(within(firstRow).getByRole('button', { name: 'Delete' })).toHaveAttribute('aria-disabled', 'true');
+    expect(within(secondRow).getByRole('button', { name: 'Delete' })).toHaveAttribute('aria-disabled', 'false');
+
+    fireEvent.click(within(secondRow).getByRole('button', { name: 'Delete' }));
+    expect(mockDeletePrizeWalletAlert).toHaveBeenCalledTimes(2);
+
+    resolvers[3]();
+    await waitFor(() => expect(screen.queryByText('ops@example.com')).not.toBeInTheDocument());
+    resolvers[4]();
+    await waitFor(() => expect(screen.queryByText('keep@example.com')).not.toBeInTheDocument());
+  });
+
+  it('ignores a second Delete click on the same row while in flight', async () => {
+    mockListPrizeWalletAlerts.mockResolvedValue([ALERT]);
+    mockDeletePrizeWalletAlert.mockImplementation(() => new Promise(() => undefined));
+    render(<RealunitPrizeWalletAlertPanel translate={translate} />);
+    await waitFor(() => expect(screen.getByText('ops@example.com')).toBeInTheDocument());
+
+    const row = screen.getByText('ops@example.com').closest('tr') as HTMLElement;
+    const del = within(row).getByRole('button', { name: 'Delete' });
+    fireEvent.click(del);
+    fireEvent.click(del);
+
+    expect(mockDeletePrizeWalletAlert).toHaveBeenCalledTimes(1);
+    expect(mockDeletePrizeWalletAlert).toHaveBeenCalledWith(3);
+  });
+});

--- a/src/__tests__/realunit-referral.hook.test.ts
+++ b/src/__tests__/realunit-referral.hook.test.ts
@@ -14,6 +14,7 @@ jest.mock('../hooks/navigation.hook', () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
 }));
 
+import { RealUnitPrizeWalletAlertAsset } from '../dto/realunit-referral.dto';
 import { useRealunitReferral } from '../hooks/realunit-referral.hook';
 
 describe('useRealunitReferral', () => {
@@ -72,6 +73,43 @@ describe('useRealunitReferral', () => {
 
     await expect(result.current.getPrizeWallet()).resolves.toEqual({ address: '0xprize', eth: 1.5, realu: 20 });
     expect(mockCall).toHaveBeenCalledWith({ url: 'realunit/referral/admin/prize-wallet', method: 'GET' });
+  });
+
+  it('lists prize-wallet alerts', async () => {
+    mockCall.mockResolvedValue([]);
+    const { result } = renderHook(() => useRealunitReferral());
+
+    await result.current.listPrizeWalletAlerts();
+
+    expect(mockCall).toHaveBeenCalledWith({ url: 'realunit/referral/admin/prize-wallet/alerts', method: 'GET' });
+  });
+
+  it('creates a prize-wallet alert', async () => {
+    const { result } = renderHook(() => useRealunitReferral());
+    const body = {
+      asset: RealUnitPrizeWalletAlertAsset.ETH,
+      threshold: 0.05,
+      mail: 'ops@example.com',
+    };
+
+    await result.current.createPrizeWalletAlert(body);
+
+    expect(mockCall).toHaveBeenCalledWith({
+      url: 'realunit/referral/admin/prize-wallet/alerts',
+      method: 'POST',
+      data: body,
+    });
+  });
+
+  it('soft-deletes a prize-wallet alert', async () => {
+    const { result } = renderHook(() => useRealunitReferral());
+
+    await result.current.deletePrizeWalletAlert(4);
+
+    expect(mockCall).toHaveBeenCalledWith({
+      url: 'realunit/referral/admin/prize-wallet/alerts/4/delete',
+      method: 'PUT',
+    });
   });
 
   it('lists promo codes', async () => {

--- a/src/__tests__/realunit.screen.test.tsx
+++ b/src/__tests__/realunit.screen.test.tsx
@@ -60,9 +60,15 @@ jest.mock('src/hooks/guard.hook', () => ({
 }));
 
 const mockGetPrizeWallet = jest.fn();
+const mockListPrizeWalletAlerts = jest.fn();
+const mockCreatePrizeWalletAlert = jest.fn();
+const mockDeletePrizeWalletAlert = jest.fn();
 jest.mock('src/hooks/realunit-referral.hook', () => ({
   useRealunitReferral: () => ({
     getPrizeWallet: (...args: unknown[]) => mockGetPrizeWallet(...args),
+    listPrizeWalletAlerts: (...args: unknown[]) => mockListPrizeWalletAlerts(...args),
+    createPrizeWalletAlert: (...args: unknown[]) => mockCreatePrizeWalletAlert(...args),
+    deletePrizeWalletAlert: (...args: unknown[]) => mockDeletePrizeWalletAlert(...args),
   }),
 }));
 
@@ -96,7 +102,7 @@ jest.mock('src/util/utils', () => ({
 }));
 
 import { StrictMode } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import RealunitScreen from 'src/screens/realunit.screen';
 
 const HOLDER = {
@@ -137,6 +143,26 @@ const TX = {
 async function renderScreen() {
   const view = render(<RealunitScreen />);
   await waitFor(() => expect(mockGetPrizeWallet).toHaveBeenCalled());
+  let wallet: unknown;
+  try {
+    wallet = await mockGetPrizeWallet.mock.results[0].value;
+  } catch {
+    wallet = undefined;
+  }
+  if (wallet) {
+    // Alert panel mounts only on the main dashboard branch once the wallet card is shown.
+    await waitFor(() => {
+      if (!screen.queryByText('Bonus and Referral')) return;
+      expect(mockListPrizeWalletAlerts).toHaveBeenCalled();
+    });
+  } else {
+    await waitFor(() => {
+      if (!screen.queryByText('Bonus and Referral')) return;
+      expect(
+        screen.queryByText('Prize wallet is not configured') || screen.queryByTestId('error-hint'),
+      ).toBeTruthy();
+    });
+  }
   return view;
 }
 
@@ -181,6 +207,15 @@ describe('RealunitScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetPrizeWallet.mockResolvedValue({ address: '0xprizewallet', eth: 0.5, realu: 80 });
+    mockListPrizeWalletAlerts.mockResolvedValue([]);
+    mockCreatePrizeWalletAlert.mockResolvedValue({
+      id: 1,
+      asset: 'ETH',
+      threshold: 0.1,
+      mail: 'ops@example.com',
+      created: '2026-09-10T00:00:00.000Z',
+    });
+    mockDeletePrizeWalletAlert.mockResolvedValue(undefined);
     setContext();
   });
 
@@ -358,7 +393,11 @@ describe('RealunitScreen', () => {
     }
     fireEvent.click(holderButton);
     expect(mockNavigate).toHaveBeenCalledWith(`/realunit/user/${encodeURIComponent(HOLDER.address)}`);
-    fireEvent.click(screen.getAllByTestId('copy-button')[0]);
+    const holderRow = holderButton.closest('tr');
+    if (!holderRow) {
+      throw new Error('holder row missing');
+    }
+    fireEvent.click(within(holderRow).getByTestId('copy-button'));
     expect(mockCopy).toHaveBeenCalledWith(HOLDER.address);
     fireEvent.click(screen.getByRole('button', { name: 'More' }));
     expect(mockNavigate).toHaveBeenCalledWith('/realunit/holders');
@@ -505,6 +544,14 @@ describe('RealunitScreen', () => {
   it('shows the payouts panel with dashboard content', async () => {
     await renderScreen();
     expect(screen.getByTestId('payouts-panel')).toBeInTheDocument();
+  });
+
+  it('shows the low-balance notify button when the prize wallet loaded', async () => {
+    await renderScreen();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Bei niedrigem Bestand benachrichtigen' })).toBeInTheDocument(),
+    );
+    expect(mockListPrizeWalletAlerts).toHaveBeenCalled();
   });
 
   it('shows a not-configured hint when the prize wallet is missing', async () => {

--- a/src/__tests__/realunit.screen.test.tsx
+++ b/src/__tests__/realunit.screen.test.tsx
@@ -158,9 +158,7 @@ async function renderScreen() {
   } else {
     await waitFor(() => {
       if (!screen.queryByText('Bonus and Referral')) return;
-      expect(
-        screen.queryByText('Prize wallet is not configured') || screen.queryByTestId('error-hint'),
-      ).toBeTruthy();
+      expect(screen.queryByText('Prize wallet is not configured') || screen.queryByTestId('error-hint')).toBeTruthy();
     });
   }
   return view;
@@ -548,9 +546,7 @@ describe('RealunitScreen', () => {
 
   it('shows the low-balance notify button when the prize wallet loaded', async () => {
     await renderScreen();
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Bei niedrigem Bestand benachrichtigen' })).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Notify on low balance' })).toBeInTheDocument());
     expect(mockListPrizeWalletAlerts).toHaveBeenCalled();
   });
 

--- a/src/components/realunit/prize-wallet-alert-panel.tsx
+++ b/src/components/realunit/prize-wallet-alert-panel.tsx
@@ -16,9 +16,9 @@ function isThresholdValid(asset: RealUnitPrizeWalletAlertAsset, raw: string): bo
   return Number.isInteger(value) && value >= 1;
 }
 
-/** One address only: no commas/whitespace lists; exactly one @; non-empty local and domain (a@b min). */
+/** One address only: no commas/semicolons/whitespace lists; exactly one @; non-empty local and domain (a@b min). */
 function isMailValid(value: string): boolean {
-  if (!value || value.includes(',') || /\s/.test(value)) return false;
+  if (!value || value.includes(',') || value.includes(';') || /\s/.test(value)) return false;
   const at = value.indexOf('@');
   if (at <= 0 || at !== value.lastIndexOf('@') || at === value.length - 1) return false;
   return true;
@@ -43,6 +43,10 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
   const [mail, setMail] = useState('');
 
   useEffect(() => {
+    loadAlerts();
+  }, []);
+
+  function loadAlerts(): void {
     setIsLoading(true);
     setListError(undefined);
     listPrizeWalletAlerts()
@@ -52,11 +56,10 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
         setListError(e.message ?? 'Unknown error');
       })
       .finally(() => setIsLoading(false));
-  }, []);
+  }
 
   const trimmedMail = mail.trim();
-  const canSubmit =
-    !isLoading && !listError && isThresholdValid(asset, threshold) && isMailValid(trimmedMail);
+  const canSubmit = !isLoading && isThresholdValid(asset, threshold) && isMailValid(trimmedMail);
 
   function resetForm(): void {
     setAsset(RealUnitPrizeWalletAlertAsset.ETH);
@@ -71,6 +74,7 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
     isSubmittingRef.current = true;
     setIsSubmitting(true);
     setFormError(undefined);
+    setActionError(undefined);
     createPrizeWalletAlert({
       asset,
       threshold: Number(threshold),
@@ -78,6 +82,7 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
     })
       .then((created) => {
         setListError(undefined);
+        setActionError(undefined);
         setAlerts((prev) => [created, ...prev]);
         resetForm();
         setShowForm(false);
@@ -159,10 +164,17 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
       )}
       {formError && <ErrorHint message={formError} />}
 
-      {isLoading && (
-        <div data-testid="prize-wallet-alert-loading">{translate('screens/referral', 'Loading')}</div>
+      {isLoading && <div data-testid="prize-wallet-alert-loading">{translate('screens/referral', 'Loading')}</div>}
+      {listError && !isLoading && (
+        <>
+          <ErrorHint message={listError} />
+          <StyledButton
+            label={translate('general/actions', 'Retry')}
+            onClick={loadAlerts}
+            width={StyledButtonWidth.MIN}
+          />
+        </>
       )}
-      {listError && <ErrorHint message={listError} />}
       {actionError && <ErrorHint message={actionError} />}
       {alerts.length > 0 && (
         <div className="overflow-auto">

--- a/src/components/realunit/prize-wallet-alert-panel.tsx
+++ b/src/components/realunit/prize-wallet-alert-panel.tsx
@@ -16,6 +16,14 @@ function isThresholdValid(asset: RealUnitPrizeWalletAlertAsset, raw: string): bo
   return Number.isInteger(value) && value >= 1;
 }
 
+/** One address only: no commas/whitespace lists; exactly one @; non-empty local and domain (a@b min). */
+function isMailValid(value: string): boolean {
+  if (!value || value.includes(',') || /\s/.test(value)) return false;
+  const at = value.indexOf('@');
+  if (at <= 0 || at !== value.lastIndexOf('@') || at === value.length - 1) return false;
+  return true;
+}
+
 export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPanelProps): JSX.Element {
   const { listPrizeWalletAlerts, createPrizeWalletAlert, deletePrizeWalletAlert } = useRealunitReferral();
 
@@ -47,7 +55,8 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
   }, []);
 
   const trimmedMail = mail.trim();
-  const canSubmit = isThresholdValid(asset, threshold) && trimmedMail.length > 0 && trimmedMail.includes('@');
+  const canSubmit =
+    !isLoading && !listError && isThresholdValid(asset, threshold) && isMailValid(trimmedMail);
 
   function resetForm(): void {
     setAsset(RealUnitPrizeWalletAlertAsset.ETH);
@@ -58,7 +67,7 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
   function onSubmit(event?: FormEvent): void {
     event?.preventDefault();
     if (isSubmittingRef.current) return;
-    if (!canSubmit) return;
+    if (isLoading || !isThresholdValid(asset, threshold) || !isMailValid(trimmedMail)) return;
     isSubmittingRef.current = true;
     setIsSubmitting(true);
     setFormError(undefined);
@@ -68,6 +77,7 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
       mail: trimmedMail,
     })
       .then((created) => {
+        setListError(undefined);
         setAlerts((prev) => [created, ...prev]);
         resetForm();
         setShowForm(false);
@@ -101,6 +111,7 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
         label={translate('screens/referral', 'Bei niedrigem Bestand benachrichtigen')}
         onClick={() => setShowForm((open) => !open)}
         width={StyledButtonWidth.MIN}
+        disabled={isLoading}
       />
 
       {showForm && (

--- a/src/components/realunit/prize-wallet-alert-panel.tsx
+++ b/src/components/realunit/prize-wallet-alert-panel.tsx
@@ -37,6 +37,7 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
   const [deletingIds, setDeletingIds] = useState<Set<number>>(new Set());
   const isSubmittingRef = useRef(false);
   const deactivatingIdsRef = useRef<Set<number>>(new Set());
+  const loadGenRef = useRef(0);
 
   const [asset, setAsset] = useState<RealUnitPrizeWalletAlertAsset>(RealUnitPrizeWalletAlertAsset.ETH);
   const [threshold, setThreshold] = useState('');
@@ -47,15 +48,23 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
   }, []);
 
   function loadAlerts(): void {
+    const gen = ++loadGenRef.current;
     setIsLoading(true);
     setListError(undefined);
     listPrizeWalletAlerts()
-      .then(setAlerts)
+      .then((rows) => {
+        if (gen !== loadGenRef.current) return;
+        setAlerts(rows);
+      })
       .catch((e: Error) => {
+        if (gen !== loadGenRef.current) return;
         setAlerts([]);
         setListError(e.message ?? 'Unknown error');
       })
-      .finally(() => setIsLoading(false));
+      .finally(() => {
+        if (gen !== loadGenRef.current) return;
+        setIsLoading(false);
+      });
   }
 
   const trimmedMail = mail.trim();
@@ -81,6 +90,7 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
       mail: trimmedMail,
     })
       .then((created) => {
+        loadGenRef.current += 1;
         setListError(undefined);
         setActionError(undefined);
         setAlerts((prev) => [created, ...prev]);
@@ -113,7 +123,7 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
   return (
     <div className="bg-white rounded-lg shadow-sm p-4 flex flex-col gap-4 text-left w-full">
       <StyledButton
-        label={translate('screens/referral', 'Bei niedrigem Bestand benachrichtigen')}
+        label={translate('screens/referral', 'Notify on low balance')}
         onClick={() => setShowForm((open) => !open)}
         width={StyledButtonWidth.MIN}
         disabled={isLoading}
@@ -172,6 +182,7 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
             label={translate('general/actions', 'Retry')}
             onClick={loadAlerts}
             width={StyledButtonWidth.MIN}
+            disabled={isSubmitting}
           />
         </>
       )}
@@ -206,7 +217,7 @@ export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPan
                       aria-disabled={deletingIds.has(row.id)}
                       onClick={() => onDelete(row.id)}
                     >
-                      {translate('screens/referral', 'Delete')}
+                      {translate('general/actions', 'Delete')}
                     </button>
                   </td>
                 </tr>

--- a/src/components/realunit/prize-wallet-alert-panel.tsx
+++ b/src/components/realunit/prize-wallet-alert-panel.tsx
@@ -1,0 +1,197 @@
+import { StyledButton, StyledButtonWidth } from '@dfx.swiss/react-components';
+import { FormEvent, useEffect, useRef, useState } from 'react';
+import { ErrorHint } from 'src/components/error-hint';
+import { RealUnitPrizeWalletAlert, RealUnitPrizeWalletAlertAsset } from 'src/dto/realunit-referral.dto';
+import { useRealunitReferral } from 'src/hooks/realunit-referral.hook';
+
+interface PrizeWalletAlertPanelProps {
+  translate: (ns: string, key: string) => string;
+}
+
+function isThresholdValid(asset: RealUnitPrizeWalletAlertAsset, raw: string): boolean {
+  const value = Number(raw);
+  if (asset === RealUnitPrizeWalletAlertAsset.ETH) {
+    return Number.isFinite(value) && value > 0;
+  }
+  return Number.isInteger(value) && value >= 1;
+}
+
+export function RealunitPrizeWalletAlertPanel({ translate }: PrizeWalletAlertPanelProps): JSX.Element {
+  const { listPrizeWalletAlerts, createPrizeWalletAlert, deletePrizeWalletAlert } = useRealunitReferral();
+
+  const [alerts, setAlerts] = useState<RealUnitPrizeWalletAlert[]>([]);
+  const [listError, setListError] = useState<string>();
+  const [formError, setFormError] = useState<string>();
+  const [actionError, setActionError] = useState<string>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [deletingIds, setDeletingIds] = useState<Set<number>>(new Set());
+  const isSubmittingRef = useRef(false);
+  const deactivatingIdsRef = useRef<Set<number>>(new Set());
+
+  const [asset, setAsset] = useState<RealUnitPrizeWalletAlertAsset>(RealUnitPrizeWalletAlertAsset.ETH);
+  const [threshold, setThreshold] = useState('');
+  const [mail, setMail] = useState('');
+
+  useEffect(() => {
+    setIsLoading(true);
+    setListError(undefined);
+    listPrizeWalletAlerts()
+      .then(setAlerts)
+      .catch((e: Error) => {
+        setAlerts([]);
+        setListError(e.message ?? 'Unknown error');
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const trimmedMail = mail.trim();
+  const canSubmit = isThresholdValid(asset, threshold) && trimmedMail.length > 0 && trimmedMail.includes('@');
+
+  function resetForm(): void {
+    setAsset(RealUnitPrizeWalletAlertAsset.ETH);
+    setThreshold('');
+    setMail('');
+  }
+
+  function onSubmit(event?: FormEvent): void {
+    event?.preventDefault();
+    if (isSubmittingRef.current) return;
+    if (!canSubmit) return;
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
+    setFormError(undefined);
+    createPrizeWalletAlert({
+      asset,
+      threshold: Number(threshold),
+      mail: trimmedMail,
+    })
+      .then((created) => {
+        setAlerts((prev) => [created, ...prev]);
+        resetForm();
+        setShowForm(false);
+      })
+      .catch((e: Error) => setFormError(e.message ?? 'Unknown error'))
+      .finally(() => {
+        isSubmittingRef.current = false;
+        setIsSubmitting(false);
+      });
+  }
+
+  function onDelete(id: number): void {
+    if (deactivatingIdsRef.current.has(id)) return;
+    deactivatingIdsRef.current.add(id);
+    setDeletingIds(new Set(deactivatingIdsRef.current));
+    setActionError(undefined);
+    deletePrizeWalletAlert(id)
+      .then(() => setAlerts((prev) => prev.filter((row) => row.id !== id)))
+      .catch((e: Error) => setActionError(e.message ?? 'Unknown error'))
+      .finally(() => {
+        deactivatingIdsRef.current.delete(id);
+        setDeletingIds(new Set(deactivatingIdsRef.current));
+      });
+  }
+
+  const isRealu = asset === RealUnitPrizeWalletAlertAsset.REALU;
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-4 flex flex-col gap-4 text-left w-full">
+      <StyledButton
+        label={translate('screens/referral', 'Bei niedrigem Bestand benachrichtigen')}
+        onClick={() => setShowForm((open) => !open)}
+        width={StyledButtonWidth.MIN}
+      />
+
+      {showForm && (
+        <form className="grid grid-cols-1 md:grid-cols-2 gap-3 items-end" onSubmit={onSubmit}>
+          <label className="flex flex-col gap-1 text-sm text-dfxBlue-800">
+            {translate('screens/referral', 'Asset')}
+            <select
+              className="border border-dfxGray-400 rounded px-2 py-1"
+              value={asset}
+              onChange={(e) => setAsset(e.target.value as RealUnitPrizeWalletAlertAsset)}
+            >
+              <option value={RealUnitPrizeWalletAlertAsset.ETH}>{translate('screens/referral', 'ETH')}</option>
+              <option value={RealUnitPrizeWalletAlertAsset.REALU}>{translate('screens/referral', 'REALU')}</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-dfxBlue-800">
+            {translate('screens/referral', 'Threshold')}
+            <input
+              className="border border-dfxGray-400 rounded px-2 py-1"
+              type="number"
+              step={isRealu ? 1 : 'any'}
+              min={isRealu ? 1 : undefined}
+              value={threshold}
+              onChange={(e) => setThreshold(e.target.value)}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-dfxBlue-800">
+            {translate('screens/referral', 'Mail')}
+            <input
+              className="border border-dfxGray-400 rounded px-2 py-1"
+              type="email"
+              value={mail}
+              onChange={(e) => setMail(e.target.value)}
+              autoComplete="off"
+            />
+          </label>
+          <StyledButton
+            label={translate('screens/referral', 'Submit')}
+            onClick={() => onSubmit()}
+            width={StyledButtonWidth.MIN}
+            disabled={!canSubmit}
+            isLoading={isSubmitting}
+          />
+        </form>
+      )}
+      {formError && <ErrorHint message={formError} />}
+
+      {isLoading && (
+        <div data-testid="prize-wallet-alert-loading">{translate('screens/referral', 'Loading')}</div>
+      )}
+      {listError && <ErrorHint message={listError} />}
+      {actionError && <ErrorHint message={actionError} />}
+      {alerts.length > 0 && (
+        <div className="overflow-auto">
+          <table className="w-full border-collapse text-sm">
+            <thead className="bg-dfxGray-300">
+              <tr>
+                <th className="px-3 py-2 text-left font-semibold text-dfxBlue-800">
+                  {translate('screens/referral', 'Asset')}
+                </th>
+                <th className="px-3 py-2 text-left font-semibold text-dfxBlue-800">
+                  {translate('screens/referral', 'Threshold')}
+                </th>
+                <th className="px-3 py-2 text-left font-semibold text-dfxBlue-800">
+                  {translate('screens/referral', 'Mail')}
+                </th>
+                <th className="px-3 py-2 text-left font-semibold text-dfxBlue-800" />
+              </tr>
+            </thead>
+            <tbody>
+              {alerts.map((row) => (
+                <tr key={row.id} className="border-b border-dfxGray-300">
+                  <td className="px-3 py-2 text-dfxBlue-800">{row.asset}</td>
+                  <td className="px-3 py-2 text-dfxBlue-800">{row.threshold}</td>
+                  <td className="px-3 py-2 text-dfxBlue-800 break-all">{row.mail}</td>
+                  <td className="px-3 py-2">
+                    <button
+                      type="button"
+                      className={`text-dfxRed-100 underline text-sm${deletingIds.has(row.id) ? ' opacity-50' : ''}`}
+                      aria-disabled={deletingIds.has(row.id)}
+                      onClick={() => onDelete(row.id)}
+                    >
+                      {translate('screens/referral', 'Delete')}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/dto/realunit-referral.dto.ts
+++ b/src/dto/realunit-referral.dto.ts
@@ -73,6 +73,25 @@ export interface RealUnitPrizeWallet {
   realu: number;
 }
 
+export enum RealUnitPrizeWalletAlertAsset {
+  ETH = 'ETH',
+  REALU = 'REALU',
+}
+
+export interface RealUnitPrizeWalletAlert {
+  id: number;
+  asset: RealUnitPrizeWalletAlertAsset;
+  threshold: number;
+  mail: string;
+  created: string; // ISO
+}
+
+export interface CreateRealUnitPrizeWalletAlert {
+  asset: RealUnitPrizeWalletAlertAsset;
+  threshold: number;
+  mail: string;
+}
+
 export interface RealUnitPromoCode {
   id: number;
   code: string;

--- a/src/hooks/realunit-referral.hook.ts
+++ b/src/hooks/realunit-referral.hook.ts
@@ -1,9 +1,11 @@
 import { useMemo } from 'react';
 import {
+  CreateRealUnitPrizeWalletAlert,
   CreateRealUnitPromoBatch,
   CreateRealUnitPromoCode,
   RealUnitAdminPayout,
   RealUnitPrizeWallet,
+  RealUnitPrizeWalletAlert,
   RealUnitPromoCode,
   RealUnitReferralRelation,
 } from 'src/dto/realunit-referral.dto';
@@ -53,6 +55,28 @@ export function useRealunitReferral() {
     });
   }
 
+  async function listPrizeWalletAlerts(): Promise<RealUnitPrizeWalletAlert[]> {
+    return call<RealUnitPrizeWalletAlert[]>({
+      url: 'realunit/referral/admin/prize-wallet/alerts',
+      method: 'GET',
+    });
+  }
+
+  async function createPrizeWalletAlert(body: CreateRealUnitPrizeWalletAlert): Promise<RealUnitPrizeWalletAlert> {
+    return call<RealUnitPrizeWalletAlert>({
+      url: 'realunit/referral/admin/prize-wallet/alerts',
+      method: 'POST',
+      data: body,
+    });
+  }
+
+  async function deletePrizeWalletAlert(id: number): Promise<void> {
+    return call<void>({
+      url: `realunit/referral/admin/prize-wallet/alerts/${id}/delete`,
+      method: 'PUT',
+    });
+  }
+
   async function getPromoCodes(): Promise<RealUnitPromoCode[]> {
     return call<RealUnitPromoCode[]>({
       url: 'realunit/referral/promo',
@@ -97,6 +121,9 @@ export function useRealunitReferral() {
       rejectRelation,
       createManualPrize,
       getPrizeWallet,
+      listPrizeWalletAlerts,
+      createPrizeWalletAlert,
+      deletePrizeWalletAlert,
       getPromoCodes,
       createPromoCode,
       createPromoCodes,

--- a/src/screens/realunit.screen.tsx
+++ b/src/screens/realunit.screen.tsx
@@ -15,6 +15,7 @@ import { CopyableAddress } from 'src/components/realunit/copyable-address';
 import { HolderCountChart } from 'src/components/realunit/holder-count-chart';
 import { PayoutsPanel } from 'src/components/realunit/payouts-panel';
 import { PriceHistoryChart } from 'src/components/realunit/price-history-chart';
+import { RealunitPrizeWalletAlertPanel } from 'src/components/realunit/prize-wallet-alert-panel';
 import { RegistrationFunnel } from 'src/components/realunit/registration-funnel';
 import { useRealunitContext } from 'src/contexts/realunit.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
@@ -161,22 +162,25 @@ export default function RealunitScreen(): JSX.Element {
           <div className="mb-6">
             <h2 className="text-dfxGray-700 mb-2">{translate('screens/referral', 'Bonus and Referral')}</h2>
             {prizeWalletLoading ? null : prizeWallet ? (
-              <div className="bg-white rounded-lg shadow-sm p-4 flex flex-col md:flex-row gap-4 items-start">
-                <QrCopy data={prizeWallet.address} />
-                <div className="flex flex-col gap-2 text-left text-sm text-dfxBlue-800">
-                  <div>
-                    <div className="text-dfxGray-700 mb-1">{translate('screens/realunit', 'Address')}</div>
-                    <CopyableAddress address={prizeWallet.address} displayLength={20} />
-                  </div>
-                  <div>
-                    {translate('screens/referral', 'ETH')}:{' '}
-                    {prizeWallet.eth.toLocaleString(undefined, { maximumFractionDigits: 6 })}
-                  </div>
-                  <div>
-                    {translate('screens/referral', 'REALU')}:{' '}
-                    {prizeWallet.realu.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+              <div className="flex flex-col md:flex-row gap-4 items-start">
+                <div className="bg-white rounded-lg shadow-sm p-4 flex flex-col md:flex-row gap-4 items-start">
+                  <QrCopy data={prizeWallet.address} />
+                  <div className="flex flex-col gap-2 text-left text-sm text-dfxBlue-800">
+                    <div>
+                      <div className="text-dfxGray-700 mb-1">{translate('screens/realunit', 'Address')}</div>
+                      <CopyableAddress address={prizeWallet.address} displayLength={20} />
+                    </div>
+                    <div>
+                      {translate('screens/referral', 'ETH')}:{' '}
+                      {prizeWallet.eth.toLocaleString(undefined, { maximumFractionDigits: 6 })}
+                    </div>
+                    <div>
+                      {translate('screens/referral', 'REALU')}:{' '}
+                      {prizeWallet.realu.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+                    </div>
                   </div>
                 </div>
+                <RealunitPrizeWalletAlertPanel translate={translate} />
               </div>
             ) : prizeWalletError?.includes('not configured') ? (
               <p className="text-sm text-dfxGray-700">

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -1237,6 +1237,12 @@
     "Amount": "Anzahl",
     "CHF": "CHF",
     "Tx hash": "Tx-Hash",
-    "Qualifying buy": "Qualifizierender Kauf"
+    "Qualifying buy": "Qualifizierender Kauf",
+    "Notify on low balance": "Bei niedrigem Bestand benachrichtigen",
+    "Asset": "Asset",
+    "Threshold": "Schwelle",
+    "Mail": "E-Mail",
+    "Submit": "Absenden",
+    "Loading": "Laden"
   }
 }

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -1236,6 +1236,12 @@
     "Amount": "Quantité",
     "CHF": "CHF",
     "Tx hash": "Hash tx",
-    "Qualifying buy": "Achat qualifiant"
+    "Qualifying buy": "Achat qualifiant",
+    "Notify on low balance": "Notifier en cas de stock faible",
+    "Asset": "Actif",
+    "Threshold": "Seuil",
+    "Mail": "E-mail",
+    "Submit": "Envoyer",
+    "Loading": "Chargement"
   }
 }

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -1236,6 +1236,12 @@
     "Amount": "Quantità",
     "CHF": "CHF",
     "Tx hash": "Hash tx",
-    "Qualifying buy": "Acquisto qualificante"
+    "Qualifying buy": "Acquisto qualificante",
+    "Notify on low balance": "Notifica in caso di scorte basse",
+    "Asset": "Asset",
+    "Threshold": "Soglia",
+    "Mail": "E-mail",
+    "Submit": "Invia",
+    "Loading": "Caricamento"
   }
 }


### PR DESCRIPTION
EN:
Staff on /realunit can add a low-balance alert for ETH or REALU with a threshold and a mail address, see the list, and remove it. Each asset and each recipient is a separate alert.

DE:
Staff kann auf /realunit je ETH oder REALU eine Schwelle und eine Mail hinterlegen, die Liste sehen und den Eintrag entfernen. Jedes Asset und jeder Empfänger ist ein eigener Eintrag.

<details>
<summary>Details</summary>

Uses the staff API from DFXswiss/backend#5485:

- GET/POST `realunit/referral/admin/prize-wallet/alerts`
- PUT `realunit/referral/admin/prize-wallet/alerts/:id/delete` (soft-delete)

Button label: Bei niedrigem Bestand benachrichtigen.


Deviation (declared): visual Playwright baselines and full-stack e2e for /realunit are not updated in this PR. The dashboard visual spec already mocks prize-wallet only; the home full-stack test is already marked failing. Unit tests cover the new panel at 100% statements/branches/functions/lines. Regenerating darwin goldens and extending the failing home e2e is a follow-up.

</details>
