### PR TITLE
01a08940 - Document the 200 REALU referral first-buy minimum in the handbook

### DIFF
--- a/scripts/handbook/metadata.json
+++ b/scripts/handbook/metadata.json
@@ -101,7 +101,7 @@
   },
   "realunit-referral": {
     "title": "RealUnit Referral",
-    "description": "RealUnit-Referral-Admin: Maske zum Starten eines Promo-Codes (Code, Einlösungslimit, Mindestkauf, Gültigkeit) und leere Promo-Liste; gefüllte Promo-Zeile mit Direktlink realunit.app/promo/{code} und QR-Dialog (Ansicht plus Download SVG/PNG/JPG); Beziehungsliste mit Filter „nur zu prüfende\", Detail mit Prüf-/Auszahlungsverlauf und Aktionen Genehmigen/Ablehnen/Manuelle Prämie (jeweils mit Pflicht-Begründung). Aktive/deaktivierte Promo-Zeilen sind in den Unit-Tests abgedeckt."
+    "description": "RealUnit-Referral-Admin: Maske zum Starten eines Promo-Codes (Code, Einlösungslimit, Mindestkauf, Gültigkeit) und leere Promo-Liste; gefüllte Promo-Zeile mit Direktlink realunit.app/promo/{code} und QR-Dialog (Ansicht plus Download SVG/PNG/JPG); Beziehungsliste mit Filter „nur zu prüfende\", Detail mit Prüf-/Auszahlungsverlauf und Aktionen Genehmigen/Ablehnen/Manuelle Prämie (jeweils mit Pflicht-Begründung). Die Referral-Prämie entsteht erst, wenn der erste abgeschlossene REALU-Kauf der eingeladenen Person mindestens 200 REALU beträgt (serverseitig geprüft); Promo-Codes haben zusätzlich ein eigenes Mindestkauf-Feld. Aktive/deaktivierte Promo-Zeilen sind in den Unit-Tests abgedeckt."
   },
   "realunit-dashboard": {
     "title": "RealUnit Dashboard",


### PR DESCRIPTION
EN:
The RealUnit referral handbook chapter now states that the referral prize is only due when the invitee's first completed REALU buy is at least 200, checked on the server. Promo codes keep their own min-buy field.

DE:
Das RealUnit-Referral-Handbuch-Kapitel sagt jetzt, dass die Referral-Prämie erst fällig ist, wenn der erste abgeschlossene REALU-Kauf der eingeladenen Person mindestens 200 beträgt, serverseitig geprüft. Promo-Codes behalten ihr eigenes Mindestkauf-Feld.

<details>
<summary>Details</summary>

Dani noted the 200 REALU floor was documented on the promo-code form, not on the referral prize. The prize is a backend parameter (`minBuyRealu` default 200 on the first completed buy), so it belongs in the chapter description rather than a new form field.

</details>