### PR TITLE
01a08c17 - Keep the app booting when storage is blocked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/react": "^1.8.0-beta.2",
+        "@dfx.swiss/react": "^1.8.1",
         "@dfx.swiss/react-components": "^1.3.2",
         "@ledgerhq/hw-app-btc": "^6.24.1",
         "@ledgerhq/hw-app-eth": "^6.33.7",
@@ -2635,9 +2635,9 @@
       }
     },
     "node_modules/@dfx.swiss/core": {
-      "version": "0.7.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.7.0-beta.1.tgz",
-      "integrity": "sha512-ZHFkNF5/I63ByI0xYGyMCK/LbwSZRi0DB+b/XvnUd8DQWmeAZcsoEyfgv5q3BnpzmbP3zyQ6uq0wKrYCJBxsJg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.7.1.tgz",
+      "integrity": "sha512-UG7OWOtudUJeJJXVcyuC/K53kSxPLlIAx/lASAZQ8+p+R+wybFQ19hbS53Riqdznw+cTn7GVaYb+ZM6+RdJdEQ==",
       "license": "MIT",
       "dependencies": {
         "ibantools": "^4.2.1",
@@ -2645,12 +2645,12 @@
       }
     },
     "node_modules/@dfx.swiss/react": {
-      "version": "1.8.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.8.0-beta.2.tgz",
-      "integrity": "sha512-Fna2PK9C8O6CTfjVPbgEasqteSkvzePCH4dWtIXatbwN0TDxho7ICpFQCSm12mIMYWiDRMqwgRWpJUV9hLxxUA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.8.1.tgz",
+      "integrity": "sha512-MpKGr4QG5YX2/OBrUNUHlud6sgKHqzDbIMbA0FDplDNaQheCp2ZH+Yi1bdbT0qE04SfkUK1+fSNfBzwTnUbxnw==",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/core": "^0.7.0-beta.1",
+        "@dfx.swiss/core": "^0.7.1",
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "typescript": "^4.9.3"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dfx.swiss/react": "^1.8.0-beta.2",
+    "@dfx.swiss/react": "^1.8.1",
     "@dfx.swiss/react-components": "^1.3.2",
     "@ledgerhq/hw-app-btc": "^6.24.1",
     "@ledgerhq/hw-app-eth": "^6.33.7",

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,8 +1,14 @@
 import { createBrowserRouter } from 'react-router-dom';
 import App from './App';
+import { StorageBlockedBanner } from './components/boot-error-boundary';
 
 function Main() {
-  return <App routerFactory={createBrowserRouter} />;
+  return (
+    <>
+      <StorageBlockedBanner />
+      <App routerFactory={createBrowserRouter} />
+    </>
+  );
 }
 
 export default Main;

--- a/src/Main.widget.tsx
+++ b/src/Main.widget.tsx
@@ -1,10 +1,13 @@
 import { createMemoryRouter } from 'react-router-dom';
 import App, { WidgetParams } from './App';
+import { BootErrorBoundary, StorageBlockedBanner } from './components/boot-error-boundary';
 import { markEmbedded } from './util/client-error';
+import { installStorageFallback } from './util/safe-storage';
 
 // Runs on a third party's page: a chunk failure here is reported, never recovered by reloading
 // their page.
 markEmbedded();
+installStorageFallback();
 
 function MainWidget(params: WidgetParams) {
   return (
@@ -14,10 +17,10 @@ function MainWidget(params: WidgetParams) {
         rel="stylesheet"
         href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
       />
-      <App
-        routerFactory={createMemoryRouter}
-        params={params}
-      />
+      <BootErrorBoundary>
+        <StorageBlockedBanner />
+        <App routerFactory={createMemoryRouter} params={params} />
+      </BootErrorBoundary>
     </>
   );
 }

--- a/src/__tests__/Main.test.tsx
+++ b/src/__tests__/Main.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../App', () => ({
+  __esModule: true,
+  default: function AppStub() {
+    return <div data-testid="app-stub" />;
+  },
+}));
+
+jest.mock('../components/boot-error-boundary', () => ({
+  StorageBlockedBanner: function StorageBlockedBannerStub() {
+    return <div data-testid="storage-banner" />;
+  },
+}));
+
+import Main from '../Main';
+
+describe('Main', () => {
+  it('renders StorageBlockedBanner and App', () => {
+    render(<Main />);
+    expect(screen.getByTestId('storage-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('app-stub')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/Main.widget.test.tsx
+++ b/src/__tests__/Main.widget.test.tsx
@@ -1,0 +1,51 @@
+jest.mock('../util/safe-storage', () => ({
+  installStorageFallback: jest.fn(),
+}));
+
+jest.mock('../util/client-error', () => ({
+  markEmbedded: jest.fn(),
+}));
+
+jest.mock('../App', () => ({
+  __esModule: true,
+  default: function AppStub() {
+    return <div data-testid="app-stub" />;
+  },
+}));
+
+jest.mock('../components/boot-error-boundary', () => ({
+  BootErrorBoundary: function BootErrorBoundaryPassThrough({
+    children,
+  }: {
+    children?: JSX.Element | JSX.Element[] | string | number | boolean | null;
+  }) {
+    return <div data-testid="boot-boundary">{children}</div>;
+  },
+  StorageBlockedBanner: function StorageBlockedBannerStub() {
+    return <div data-testid="storage-banner" />;
+  },
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  createMemoryRouter: jest.fn(),
+}));
+
+import { render, screen, within } from '@testing-library/react';
+import MainWidget from '../Main.widget';
+
+describe('MainWidget', () => {
+  it('renders banner and App inside the boundary and keeps stylesheet links', () => {
+    const { container } = render(<MainWidget />);
+
+    const boundary = screen.getByTestId('boot-boundary');
+    expect(within(boundary).getByTestId('storage-banner')).toBeInTheDocument();
+    expect(within(boundary).getByTestId('app-stub')).toBeInTheDocument();
+
+    const links = container.querySelectorAll('link');
+    expect(Array.from(links).some((link) => link.getAttribute('href') === 'main-widget.css')).toBe(true);
+    expect(
+      Array.from(links).some((link) => (link.getAttribute('href') ?? '').includes('fonts.googleapis.com')),
+    ).toBe(true);
+  });
+});

--- a/src/__tests__/bank-tx-cache.test.ts
+++ b/src/__tests__/bank-tx-cache.test.ts
@@ -1,0 +1,80 @@
+jest.mock('@dfx.swiss/react', () => ({}));
+jest.mock('src/dto/safe.dto', () => ({}));
+
+import * as safeStorage from '../util/safe-storage';
+import { cacheBankTx, readCachedBankTx } from '../util/bank-tx-cache';
+
+const sample = {
+  id: 55,
+  accountServiceRef: 'REF-1',
+  amount: 100,
+  currency: 'CHF',
+  type: 'Credit',
+};
+
+describe('bank-tx-cache', () => {
+  const sessionStorageMock = (() => {
+    let store: Record<string, string> = {};
+    return {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      },
+    };
+  })();
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock, configurable: true });
+    sessionStorageMock.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('caches then reads a bank tx', () => {
+    cacheBankTx(sample);
+    expect(readCachedBankTx('55')).toEqual(sample);
+  });
+
+  it('returns undefined for a missing id', () => {
+    expect(readCachedBankTx('999')).toBeUndefined();
+  });
+
+  it('returns undefined for invalid JSON without throwing', () => {
+    sessionStorageMock.setItem('dfx.bankTx.55', '{kaputt');
+    expect(() => readCachedBankTx('55')).not.toThrow();
+    expect(readCachedBankTx('55')).toBeUndefined();
+  });
+
+  it('cacheBankTx does not throw when sessionStorage setItem throws', () => {
+    Object.defineProperty(window, 'sessionStorage', {
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw new DOMException('Quota exceeded', 'QuotaExceededError');
+        },
+        removeItem: () => undefined,
+        clear: () => undefined,
+      },
+      configurable: true,
+    });
+
+    expect(() => cacheBankTx(sample)).not.toThrow();
+  });
+
+  it('cacheBankTx and readCachedBankTx swallow unexpected helper throws', () => {
+    jest.spyOn(safeStorage, 'storageSetJson').mockImplementation(() => {
+      throw new Error('set failed');
+    });
+    jest.spyOn(safeStorage, 'storageGetJson').mockImplementation(() => {
+      throw new Error('get failed');
+    });
+
+    expect(() => cacheBankTx(sample)).not.toThrow();
+    expect(readCachedBankTx('55')).toBeUndefined();
+  });
+});

--- a/src/__tests__/boot-error-boundary.test.tsx
+++ b/src/__tests__/boot-error-boundary.test.tsx
@@ -1,0 +1,214 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const mockReportClientError = jest.fn();
+const mockResetDfxStorageAndReload = jest.fn();
+const mockIsStorageBlocked = jest.fn();
+const mockIsStorageHardBlocked = jest.fn();
+
+jest.mock('../util/client-error', () => ({
+  reportClientError: (...args: unknown[]) => mockReportClientError(...args),
+}));
+
+jest.mock('../util/safe-storage', () => ({
+  resetDfxStorageAndReload: (...args: unknown[]) => mockResetDfxStorageAndReload(...args),
+  isStorageBlocked: (...args: unknown[]) => mockIsStorageBlocked(...args),
+  isStorageHardBlocked: (...args: unknown[]) => mockIsStorageHardBlocked(...args),
+}));
+
+import {
+  BootErrorBoundary,
+  StorageBlockedBanner,
+  renderHardBlockedPage,
+} from '../components/boot-error-boundary';
+
+function ThrowingChild(): JSX.Element {
+  throw new Error('boot fail');
+}
+
+describe('BootErrorBoundary', () => {
+  const reloadMock = jest.fn();
+  const originalLanguage = navigator.language;
+  const originalLanguages = navigator.languages;
+
+  beforeEach(() => {
+    mockReportClientError.mockClear();
+    mockResetDfxStorageAndReload.mockClear();
+    mockIsStorageBlocked.mockReset().mockReturnValue(false);
+    mockIsStorageHardBlocked.mockReset().mockReturnValue(false);
+    reloadMock.mockClear();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/start', reload: reloadMock, search: '' },
+    });
+    Object.defineProperty(navigator, 'language', { configurable: true, value: 'en-US' });
+    Object.defineProperty(navigator, 'languages', { configurable: true, value: ['en-US'] });
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'language', { configurable: true, value: originalLanguage });
+    Object.defineProperty(navigator, 'languages', { configurable: true, value: originalLanguages });
+    jest.restoreAllMocks();
+  });
+
+  it('renders children when there is no error', () => {
+    render(
+      <BootErrorBoundary>
+        <div data-testid="child">ok</div>
+      </BootErrorBoundary>,
+    );
+    expect(screen.getByTestId('child')).toHaveTextContent('ok');
+  });
+
+  it('catches a child render throw and shows the EN reset button', () => {
+    render(
+      <BootErrorBoundary>
+        <ThrowingChild />
+      </BootErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong while starting the app.');
+    expect(screen.getByRole('button')).toHaveTextContent('Reset saved data and reload');
+    expect(mockReportClientError).toHaveBeenCalledWith(expect.any(Error), '/start');
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(mockResetDfxStorageAndReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows DE copy when navigator.language starts with de', () => {
+    Object.defineProperty(navigator, 'language', { configurable: true, value: 'de-CH' });
+
+    render(
+      <BootErrorBoundary>
+        <ThrowingChild />
+      </BootErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Beim Start der App ist ein Fehler aufgetreten.');
+    expect(screen.getByRole('button')).toHaveTextContent('Gespeicherte Daten zurücksetzen und neu laden');
+  });
+
+  it('uses navigator.languages[0] when language is empty', () => {
+    Object.defineProperty(navigator, 'language', { configurable: true, value: '' });
+    Object.defineProperty(navigator, 'languages', { configurable: true, value: ['de'] });
+
+    render(
+      <BootErrorBoundary>
+        <ThrowingChild />
+      </BootErrorBoundary>,
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('Gespeicherte Daten zurücksetzen und neu laden');
+  });
+
+  it('falls back to EN when language and languages are empty', () => {
+    Object.defineProperty(navigator, 'language', { configurable: true, value: '' });
+    Object.defineProperty(navigator, 'languages', { configurable: true, value: undefined });
+
+    render(
+      <BootErrorBoundary>
+        <ThrowingChild />
+      </BootErrorBoundary>,
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('Reset saved data and reload');
+  });
+
+  it.each([
+    ['fr', "Une erreur s'est produite au démarrage de l'application."],
+    ['it', "Si è verificato un errore all'avvio dell'app."],
+  ])('shows %s copy for the reset panel', (lang, message) => {
+    Object.defineProperty(navigator, 'language', { configurable: true, value: lang });
+
+    render(
+      <BootErrorBoundary>
+        <ThrowingChild />
+      </BootErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent(message);
+  });
+});
+
+describe('StorageBlockedBanner', () => {
+  const reloadMock = jest.fn();
+
+  beforeEach(() => {
+    mockIsStorageBlocked.mockReset().mockReturnValue(false);
+    mockIsStorageHardBlocked.mockReset().mockReturnValue(false);
+    reloadMock.mockClear();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', reload: reloadMock, search: '' },
+    });
+    Object.defineProperty(navigator, 'language', { configurable: true, value: 'en' });
+  });
+
+  it('is null when not blocked', () => {
+    const { container } = render(<StorageBlockedBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('is null when hard-blocked', () => {
+    mockIsStorageBlocked.mockReturnValue(true);
+    mockIsStorageHardBlocked.mockReturnValue(true);
+    const { container } = render(<StorageBlockedBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows instruction and reload when blocked and not hard-blocked', () => {
+    mockIsStorageBlocked.mockReturnValue(true);
+    mockIsStorageHardBlocked.mockReturnValue(false);
+
+    render(<StorageBlockedBanner />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('This browser is blocking saved data');
+    fireEvent.click(screen.getByRole('button', { name: 'Reload' }));
+    expect(reloadMock).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['en', 'This browser is blocking saved data', 'Reload'],
+    ['de', 'Dieser Browser blockiert gespeicherte Daten', 'Neu laden'],
+    ['fr', 'Ce navigateur bloque les données enregistrées', 'Recharger'],
+    ['it', 'Questo browser sta bloccando i dati salvati', 'Ricarica'],
+    ['pt-BR', 'This browser is blocking saved data', 'Reload'],
+    ['xx', 'This browser is blocking saved data', 'Reload'],
+    ['', 'This browser is blocking saved data', 'Reload'],
+  ])('uses %s copy (fallback en for unknown)', (lang, messagePart, button) => {
+    Object.defineProperty(navigator, 'language', { configurable: true, value: lang });
+    mockIsStorageBlocked.mockReturnValue(true);
+    mockIsStorageHardBlocked.mockReturnValue(false);
+
+    render(<StorageBlockedBanner />);
+
+    expect(screen.getByRole('status')).toHaveTextContent(messagePart);
+    expect(screen.getByRole('button')).toHaveTextContent(button);
+  });
+});
+
+describe('renderHardBlockedPage', () => {
+  const reloadMock = jest.fn();
+
+  beforeEach(() => {
+    reloadMock.mockClear();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', reload: reloadMock, search: '' },
+    });
+    Object.defineProperty(navigator, 'language', { configurable: true, value: 'en' });
+  });
+
+  it('writes instruction text and a reload button without React', () => {
+    const root = document.createElement('div');
+    renderHardBlockedPage(root);
+
+    expect(root.textContent).toContain('This browser is blocking saved data');
+    const button = root.querySelector('button');
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toBe('Reload');
+
+    button?.click();
+    expect(reloadMock).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/boot-standalone.test.ts
+++ b/src/__tests__/boot-standalone.test.ts
@@ -1,0 +1,145 @@
+const mockCreateRoot = jest.fn();
+const mockRender = jest.fn();
+const mockInstallStorageFallback = jest.fn();
+const mockIsStorageBlocked = jest.fn();
+const mockIsStorageHardBlocked = jest.fn();
+const mockClearLoginSessionStorage = jest.fn();
+const mockInstallChunkErrorHandling = jest.fn();
+const mockReportClientError = jest.fn();
+const mockRenderHardBlockedPage = jest.fn();
+
+jest.mock('react-dom/client', () => ({
+  createRoot: (...args: unknown[]) => mockCreateRoot(...args),
+}));
+
+jest.mock('../Main', () => ({
+  __esModule: true,
+  default: function MainStub() {
+    return null;
+  },
+}));
+
+jest.mock('../components/boot-error-boundary', () => ({
+  BootErrorBoundary: function BootErrorBoundaryPassThrough({ children }: { children: unknown }) {
+    return children;
+  },
+  renderHardBlockedPage: (...args: unknown[]) => mockRenderHardBlockedPage(...args),
+}));
+
+jest.mock('../util/safe-storage', () => ({
+  installStorageFallback: (...args: unknown[]) => mockInstallStorageFallback(...args),
+  isStorageBlocked: (...args: unknown[]) => mockIsStorageBlocked(...args),
+  isStorageHardBlocked: (...args: unknown[]) => mockIsStorageHardBlocked(...args),
+  clearLoginSessionStorage: (...args: unknown[]) => mockClearLoginSessionStorage(...args),
+}));
+
+jest.mock('../util/client-error', () => ({
+  installChunkErrorHandling: (...args: unknown[]) => mockInstallChunkErrorHandling(...args),
+  reportClientError: (...args: unknown[]) => mockReportClientError(...args),
+}));
+
+import Main from '../Main';
+import { BootErrorBoundary } from '../components/boot-error-boundary';
+import { startStandaloneApp } from '../util/boot-standalone';
+
+describe('startStandaloneApp', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="root"></div>';
+    mockCreateRoot.mockReset().mockReturnValue({ render: mockRender });
+    mockRender.mockReset();
+    mockInstallStorageFallback.mockReset();
+    mockIsStorageBlocked.mockReset().mockReturnValue(false);
+    mockIsStorageHardBlocked.mockReset().mockReturnValue(false);
+    mockClearLoginSessionStorage.mockReset();
+    mockInstallChunkErrorHandling.mockReset();
+    mockReportClientError.mockReset();
+    mockRenderHardBlockedPage.mockReset();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', search: '', reload: jest.fn() },
+    });
+  });
+
+  it('hard-blocked: does not createRoot and renders the hard-blocked page', () => {
+    mockIsStorageHardBlocked.mockReturnValue(true);
+    const root = document.getElementById('root');
+
+    startStandaloneApp();
+
+    expect(mockInstallStorageFallback).toHaveBeenCalledTimes(1);
+    expect(mockRenderHardBlockedPage).toHaveBeenCalledWith(root);
+    expect(mockCreateRoot).not.toHaveBeenCalled();
+    expect(mockInstallChunkErrorHandling).not.toHaveBeenCalled();
+    expect(mockReportClientError).toHaveBeenCalledWith(expect.any(Error), '/');
+  });
+
+  it('does nothing when #root is missing', () => {
+    document.body.innerHTML = '';
+    startStandaloneApp();
+    expect(mockCreateRoot).not.toHaveBeenCalled();
+    expect(mockRenderHardBlockedPage).not.toHaveBeenCalled();
+  });
+
+  it('skips chunk-error reloads when storage is blocked (shim would not survive reload)', () => {
+    mockIsStorageBlocked.mockReturnValue(true);
+    startStandaloneApp();
+    expect(mockInstallChunkErrorHandling).not.toHaveBeenCalled();
+    expect(mockCreateRoot).toHaveBeenCalled();
+  });
+
+  it('not hard-blocked: installs fallback, chunk handling, and renders Main in BootErrorBoundary', () => {
+    startStandaloneApp();
+
+    expect(mockInstallStorageFallback).toHaveBeenCalledTimes(1);
+    expect(mockInstallChunkErrorHandling).toHaveBeenCalledTimes(1);
+    expect(mockCreateRoot).toHaveBeenCalledWith(document.getElementById('root'));
+    expect(mockRender).toHaveBeenCalledTimes(1);
+    const element = mockRender.mock.calls[0][0] as { type: unknown; props: { children: { type: unknown } } };
+    expect(element.type).toBe(BootErrorBoundary);
+    expect(element.props.children.type).toBe(Main);
+  });
+
+  it('clears login session when URL has address and signature', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', search: '?address=0x1&signature=sig', reload: jest.fn() },
+    });
+
+    startStandaloneApp();
+
+    expect(mockClearLoginSessionStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears login session when URL has session', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', search: '?session=abc', reload: jest.fn() },
+    });
+
+    startStandaloneApp();
+
+    expect(mockClearLoginSessionStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not clear login session when URL has neither', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', search: '?lang=de', reload: jest.fn() },
+    });
+
+    startStandaloneApp();
+
+    expect(mockClearLoginSessionStorage).not.toHaveBeenCalled();
+  });
+
+  it('does not clear login session when address is present without signature', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', search: '?address=0x1', reload: jest.fn() },
+    });
+
+    startStandaloneApp();
+
+    expect(mockClearLoginSessionStorage).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/client-error.test.ts
+++ b/src/__tests__/client-error.test.ts
@@ -5,10 +5,12 @@ jest.mock('src/dto/safe.dto', () => ({}));
 import {
   forgetReportedErrors,
   isChunkLoadError,
+  isEmbedded,
   reloadOnceForChunkError,
   reportClientError,
   toErrorFacts,
 } from '../util/client-error';
+import { setStorageBlockedFlag } from '../util/storage-block-flag';
 
 jest.mock('src/config/api', () => ({ Api: { url: 'https://api.example.com', version: 'v1' } }));
 jest.mock('src/version', () => ({ REACT_APP_BUILD_ID: '42-99' }));
@@ -303,6 +305,7 @@ describe('reloadOnceForChunkError', () => {
 
   beforeEach(() => {
     localStorage.clear();
+    setStorageBlockedFlag(false);
     reload = jest.fn();
     Object.defineProperty(window, 'location', { value: { ...window.location, reload }, writable: true });
   });
@@ -337,6 +340,23 @@ describe('reloadOnceForChunkError', () => {
     reloadOnceForChunkError();
 
     expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('skips the reload when the boot shim marked storage as blocked', () => {
+    setStorageBlockedFlag(true);
+    reloadOnceForChunkError();
+    expect(reload).not.toHaveBeenCalled();
+    setStorageBlockedFlag(false);
+  });
+
+  it('exposes the embedded flag after markEmbedded', () => {
+    expect(isEmbedded()).toBe(false);
+    jest.isolateModules(() => {
+      const clientError = jest.requireActual('../util/client-error');
+      expect(clientError.isEmbedded()).toBe(false);
+      clientError.markEmbedded();
+      expect(clientError.isEmbedded()).toBe(true);
+    });
   });
 
   // The widget and library builds run on a third party's page, where window is theirs. Reloading

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,32 @@
+const mockStartStandaloneApp = jest.fn();
+const mockReportWebVitals = jest.fn();
+
+jest.mock('../util/boot-standalone', () => ({
+  startStandaloneApp: (...args: unknown[]) => mockStartStandaloneApp(...args),
+}));
+
+jest.mock('../reportWebVitals', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockReportWebVitals(...args),
+}));
+
+jest.mock('../index.css', () => ({}));
+
+describe('index', () => {
+  beforeEach(() => {
+    mockStartStandaloneApp.mockClear();
+    mockReportWebVitals.mockClear();
+  });
+
+  it('calls startStandaloneApp then reportWebVitals on module load', () => {
+    jest.isolateModules(() => {
+      require('../index');
+    });
+
+    expect(mockStartStandaloneApp).toHaveBeenCalledTimes(1);
+    expect(mockReportWebVitals).toHaveBeenCalledTimes(1);
+    expect(mockStartStandaloneApp.mock.invocationCallOrder[0]).toBeLessThan(
+      mockReportWebVitals.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/src/__tests__/safe-storage.test.ts
+++ b/src/__tests__/safe-storage.test.ts
@@ -1,0 +1,459 @@
+const mockReportClientError = jest.fn();
+
+jest.mock('../util/client-error', () => ({
+  reportClientError: (...args: unknown[]) => mockReportClientError(...args),
+}));
+
+type SafeStorageModule = typeof import('../util/safe-storage');
+
+function createMemoryLikeStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      const value = map.get(key);
+      return value === undefined ? null : value;
+    },
+    setItem(key: string, value: string) {
+      map.set(key, String(value));
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    key(index: number) {
+      if (index < 0 || index >= map.size) return null;
+      return Array.from(map.keys())[index] ?? null;
+    },
+  };
+}
+
+function installWorkingStorage(): { local: Storage; session: Storage } {
+  const local = createMemoryLikeStorage();
+  const session = createMemoryLikeStorage();
+  Object.defineProperty(window, 'localStorage', { value: local, configurable: true });
+  Object.defineProperty(window, 'sessionStorage', { value: session, configurable: true });
+  return { local, session };
+}
+
+function installThrowingStorage(): void {
+  Object.defineProperty(window, 'localStorage', {
+    get() {
+      throw new DOMException('Denied', 'SecurityError');
+    },
+    configurable: true,
+  });
+  Object.defineProperty(window, 'sessionStorage', {
+    get() {
+      throw new DOMException('Denied', 'SecurityError');
+    },
+    configurable: true,
+  });
+}
+
+function loadSafeStorage(): SafeStorageModule & { getStorageBlockedFlag: () => boolean } {
+  let mod: (SafeStorageModule & { getStorageBlockedFlag: () => boolean }) | undefined;
+  jest.isolateModules(() => {
+    /* isolateModules needs require so each case gets a fresh installAttempted */
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    mod = Object.assign(require('../util/safe-storage'), {
+      getStorageBlockedFlag: require('../util/storage-block-flag').getStorageBlockedFlag,
+    });
+    /* eslint-enable @typescript-eslint/no-var-requires */
+  });
+  if (!mod) throw new Error('failed to load safe-storage');
+  return mod;
+}
+
+describe('safe-storage', () => {
+  const originalLocalDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+  const originalSessionDescriptor = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+  const reloadMock = jest.fn();
+
+  beforeEach(() => {
+    mockReportClientError.mockClear();
+    reloadMock.mockClear();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, pathname: '/boot', reload: reloadMock, search: '' },
+    });
+    installWorkingStorage();
+  });
+
+  afterEach(() => {
+    if (originalLocalDescriptor) {
+      Object.defineProperty(window, 'localStorage', originalLocalDescriptor);
+    }
+    if (originalSessionDescriptor) {
+      Object.defineProperty(window, 'sessionStorage', originalSessionDescriptor);
+    }
+    jest.restoreAllMocks();
+  });
+
+  it('roundtrips get/set/remove on localStorage and sessionStorage', () => {
+    const { storageGet, storageSet, storageRemove } = loadSafeStorage();
+
+    storageSet('localStorage', 'a', '1');
+    expect(storageGet('localStorage', 'a')).toBe('1');
+    storageRemove('localStorage', 'a');
+    expect(storageGet('localStorage', 'a')).toBeUndefined();
+
+    storageSet('sessionStorage', 'b', '2');
+    expect(storageGet('sessionStorage', 'b')).toBe('2');
+    storageRemove('sessionStorage', 'b');
+    expect(storageGet('sessionStorage', 'b')).toBeUndefined();
+  });
+
+  it('storageGet returns undefined for a missing key', () => {
+    const { storageGet } = loadSafeStorage();
+    expect(storageGet('localStorage', 'missing')).toBeUndefined();
+  });
+
+  it('does not throw when window.localStorage getter throws SecurityError', () => {
+    installThrowingStorage();
+    const { storageGet, storageSet, storageRemove, storageClear } = loadSafeStorage();
+
+    expect(storageGet('localStorage', 'k')).toBeUndefined();
+    expect(() => storageSet('localStorage', 'k', 'v')).not.toThrow();
+    expect(() => storageRemove('localStorage', 'k')).not.toThrow();
+    expect(() => storageClear('sessionStorage')).not.toThrow();
+  });
+
+  it('storageGet/remove/clear do not throw when Storage methods throw', () => {
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => {
+          throw new Error('get failed');
+        },
+        setItem: () => undefined,
+        removeItem: () => {
+          throw new Error('remove failed');
+        },
+        clear: () => undefined,
+        key: () => null,
+        length: 0,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+      value: {
+        getItem: () => null,
+        setItem: () => undefined,
+        removeItem: () => undefined,
+        clear: () => {
+          throw new Error('clear failed');
+        },
+        key: () => null,
+        length: 0,
+      },
+      configurable: true,
+    });
+
+    const { storageGet, storageRemove, storageClear } = loadSafeStorage();
+    expect(storageGet('localStorage', 'k')).toBeUndefined();
+    expect(() => storageRemove('localStorage', 'k')).not.toThrow();
+    expect(() => storageClear('sessionStorage')).not.toThrow();
+  });
+
+  it('storageGetJson returns undefined for a missing key', () => {
+    const { storageGetJson } = loadSafeStorage();
+    expect(storageGetJson('localStorage', 'missing')).toBeUndefined();
+  });
+
+  it('storageGetJson returns a parsed value for valid JSON', () => {
+    const { storageGetJson, storageSet } = loadSafeStorage();
+    storageSet('localStorage', 'obj', JSON.stringify({ ok: true }));
+    expect(storageGetJson<{ ok: boolean }>('localStorage', 'obj')).toEqual({ ok: true });
+  });
+
+  it.each(['undefined', '<!doctype html>', '{kaputt'])(
+    'storageGetJson of %j returns undefined and removes the key',
+    (raw) => {
+      const { local } = installWorkingStorage();
+      local.setItem('bad', raw);
+      const { storageGetJson } = loadSafeStorage();
+
+      expect(storageGetJson('localStorage', 'bad')).toBeUndefined();
+      expect(local.getItem('bad')).toBeNull();
+    },
+  );
+
+  it('storageSetJson roundtrips', () => {
+    const { storageSetJson, storageGetJson } = loadSafeStorage();
+    storageSetJson('sessionStorage', 'params', { mode: 'buy' });
+    expect(storageGetJson('sessionStorage', 'params')).toEqual({ mode: 'buy' });
+  });
+
+  it('storageSetJson(undefined) does not write the string "undefined"', () => {
+    const { local } = installWorkingStorage();
+    const { storageSetJson } = loadSafeStorage();
+    storageSetJson('localStorage', 'u', undefined as unknown as string);
+    expect(local.getItem('u')).toBeNull();
+  });
+
+  it('storageSet and storageSetJson swallow QuotaExceededError by name', () => {
+    const quota = new Error('quota');
+    quota.name = 'QuotaExceededError';
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw quota;
+        },
+        removeItem: () => undefined,
+        clear: () => undefined,
+        key: () => null,
+        length: 0,
+      },
+      configurable: true,
+    });
+    const { storageSet, storageSetJson } = loadSafeStorage();
+    expect(() => storageSet('localStorage', 'k', 'v')).not.toThrow();
+    expect(() => storageSetJson('localStorage', 'k', { a: 1 })).not.toThrow();
+  });
+
+  it('storageSet swallows QuotaExceededError as DOMException and SecurityError', () => {
+    const quota = new DOMException('Quota exceeded', 'QuotaExceededError');
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw quota;
+        },
+        removeItem: () => undefined,
+        clear: () => undefined,
+        key: () => null,
+        length: 0,
+      },
+      configurable: true,
+    });
+    const { storageSet } = loadSafeStorage();
+    expect(() => storageSet('localStorage', 'k', 'v')).not.toThrow();
+
+    const security = new DOMException('Denied', 'SecurityError');
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw security;
+        },
+        removeItem: () => undefined,
+        clear: () => undefined,
+        key: () => null,
+        length: 0,
+      },
+      configurable: true,
+    });
+    expect(() => storageSet('localStorage', 'k', 'v')).not.toThrow();
+  });
+
+  it('storageClear clears sessionStorage keys and does not throw when blocked', () => {
+    const { session } = installWorkingStorage();
+    session.setItem('a', '1');
+    const { storageClear } = loadSafeStorage();
+    storageClear('sessionStorage');
+    expect(session.getItem('a')).toBeNull();
+
+    installThrowingStorage();
+    expect(() => storageClear('sessionStorage')).not.toThrow();
+  });
+
+  it('installStorageFallback leaves flags false when native storage works and is idempotent', () => {
+    const { local, session } = installWorkingStorage();
+    const mod = loadSafeStorage();
+
+    mod.installStorageFallback();
+    expect(mod.isStorageBlocked()).toBe(false);
+    expect(mod.isStorageHardBlocked()).toBe(false);
+    expect(mod.getStorageBlockedFlag()).toBe(false);
+    expect(local.getItem('__dfx.probe')).toBeNull();
+    expect(session.getItem('__dfx.probe')).toBeNull();
+
+    const setItemSpy = jest.spyOn(local, 'setItem');
+    mod.installStorageFallback();
+    expect(setItemSpy).not.toHaveBeenCalledWith('__dfx.probe', expect.anything());
+  });
+
+  it('shims only sessionStorage when localStorage still works', () => {
+    const { local } = installWorkingStorage();
+    local.setItem('dfx.srv.language', 'de');
+    Object.defineProperty(window, 'sessionStorage', {
+      get() {
+        throw new DOMException('Denied', 'SecurityError');
+      },
+      configurable: true,
+    });
+    const mod = loadSafeStorage();
+    mod.installStorageFallback();
+    expect(mod.isStorageBlocked()).toBe(true);
+    expect(mod.isStorageHardBlocked()).toBe(false);
+    expect(mod.getStorageBlockedFlag()).toBe(true);
+    expect(local.getItem('dfx.srv.language')).toBe('de');
+  });
+
+  it('shims only localStorage when sessionStorage still works', () => {
+    const { session } = installWorkingStorage();
+    session.setItem('keep', '1');
+    Object.defineProperty(window, 'localStorage', {
+      get() {
+        throw new DOMException('Denied', 'SecurityError');
+      },
+      configurable: true,
+    });
+    const mod = loadSafeStorage();
+    mod.installStorageFallback();
+    expect(mod.isStorageBlocked()).toBe(true);
+    expect(mod.isStorageHardBlocked()).toBe(false);
+    expect(mod.getStorageBlockedFlag()).toBe(true);
+    expect(session.getItem('keep')).toBe('1');
+  });
+
+  it('blocked storage with successful shim uses memory storage', () => {
+    installThrowingStorage();
+    const mod = loadSafeStorage();
+
+    mod.installStorageFallback();
+    expect(mod.isStorageBlocked()).toBe(true);
+    expect(mod.isStorageHardBlocked()).toBe(false);
+    expect(mod.getStorageBlockedFlag()).toBe(true);
+
+    mod.storageSet('localStorage', 'k', 'v');
+    expect(mod.storageGet('localStorage', 'k')).toBe('v');
+
+    const memory = window.localStorage;
+    memory.setItem('x', '1');
+    expect(memory.getItem('x')).toBe('1');
+    expect(memory.key(0)).not.toBeNull();
+    expect(memory.length).toBeGreaterThan(0);
+    memory.removeItem('x');
+    expect(memory.getItem('x')).toBeNull();
+    memory.setItem('y', '2');
+    memory.clear();
+    expect(memory.length).toBe(0);
+    expect(memory.key(0)).toBeNull();
+    expect(memory.key(-1)).toBeNull();
+  });
+
+  it('hard-blocked when probe fails and defineProperty throws', () => {
+    installThrowingStorage();
+    const defineSpy = jest.spyOn(Object, 'defineProperty').mockImplementation((target, prop, descriptor) => {
+      if (prop === 'localStorage' || prop === 'sessionStorage') {
+        throw new TypeError('Cannot redefine property');
+      }
+      return Reflect.defineProperty(target as object, prop as PropertyKey, descriptor as PropertyDescriptor);
+    });
+
+    const mod = loadSafeStorage();
+    mod.installStorageFallback();
+    expect(mod.isStorageBlocked()).toBe(true);
+    expect(mod.isStorageHardBlocked()).toBe(true);
+    expect(mod.getStorageBlockedFlag()).toBe(true);
+    expect(() => mod.storageGet('localStorage', 'k')).not.toThrow();
+    expect(() => mod.storageSet('localStorage', 'k', 'v')).not.toThrow();
+    expect(() => mod.storageRemove('localStorage', 'k')).not.toThrow();
+    expect(() => mod.storageClear('sessionStorage')).not.toThrow();
+    defineSpy.mockRestore();
+  });
+
+  it('clearLoginSessionStorage removes login keys and clears sessionStorage', () => {
+    const { local, session } = installWorkingStorage();
+    local.setItem('dfx.authenticationToken', 'tok');
+    local.setItem('dfx.srv.activeWallet', 'MetaMask');
+    local.setItem('dfx.srv.queryParams', '{}');
+    local.setItem('dfx.srv.language', 'de');
+    session.setItem('other', '1');
+
+    const { clearLoginSessionStorage } = loadSafeStorage();
+    clearLoginSessionStorage();
+
+    expect(local.getItem('dfx.authenticationToken')).toBeNull();
+    expect(local.getItem('dfx.srv.activeWallet')).toBeNull();
+    expect(local.getItem('dfx.srv.queryParams')).toBeNull();
+    expect(local.getItem('dfx.srv.language')).toBe('de');
+    expect(session.getItem('other')).toBeNull();
+
+    installThrowingStorage();
+    expect(() => clearLoginSessionStorage()).not.toThrow();
+  });
+
+  it('resetDfxStorageAndReload removes dfx. keys, leaves others, and reloads', () => {
+    const { local, session } = installWorkingStorage();
+    local.setItem('dfx.srv.language', 'de');
+    local.setItem('keep.local', '1');
+    session.setItem('dfx.bankTx.1', '{}');
+    session.setItem('keep.session', '2');
+
+    const { resetDfxStorageAndReload } = loadSafeStorage();
+    resetDfxStorageAndReload();
+
+    expect(local.getItem('dfx.srv.language')).toBeNull();
+    expect(local.getItem('keep.local')).toBe('1');
+    expect(session.getItem('dfx.bankTx.1')).toBeNull();
+    expect(session.getItem('keep.session')).toBe('2');
+    expect(reloadMock).toHaveBeenCalled();
+
+    installThrowingStorage();
+    expect(() => resetDfxStorageAndReload()).not.toThrow();
+    expect(reloadMock).toHaveBeenCalled();
+  });
+
+  it('resetDfxStorageAndReload skips null keys while listing', () => {
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        length: 1,
+        key: () => null,
+        getItem: () => null,
+        setItem: () => undefined,
+        removeItem: () => undefined,
+        clear: () => undefined,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+      value: createMemoryLikeStorage(),
+      configurable: true,
+    });
+
+    const { resetDfxStorageAndReload } = loadSafeStorage();
+    expect(() => resetDfxStorageAndReload()).not.toThrow();
+    expect(reloadMock).toHaveBeenCalled();
+  });
+
+  it('reportClientError is called at most once for multiple failures', () => {
+    installThrowingStorage();
+    const { storageGet, storageGetJson, storageSet } = loadSafeStorage();
+
+    storageGet('localStorage', 'a');
+    storageGet('sessionStorage', 'b');
+    storageSet('localStorage', 'c', 'x');
+    installWorkingStorage();
+    window.localStorage.setItem('bad', '{kaputt');
+    storageGetJson('localStorage', 'bad');
+
+    expect(mockReportClientError).toHaveBeenCalledTimes(1);
+    expect(mockReportClientError.mock.calls[0][0]).toEqual(expect.any(Error));
+    expect(mockReportClientError.mock.calls[0][1]).toBe('/boot');
+  });
+
+  it('reports once when install detects blocked storage', () => {
+    installThrowingStorage();
+    const mod = loadSafeStorage();
+    mod.installStorageFallback();
+    mod.storageGet('localStorage', 'a');
+    expect(mockReportClientError).toHaveBeenCalledTimes(1);
+    expect((mockReportClientError.mock.calls[0][0] as Error).message).toBe('Storage blocked');
+  });
+
+  it('reports Invalid JSON in storage on parse failure', () => {
+    installWorkingStorage();
+    window.localStorage.setItem('bad', '{kaputt');
+    const { storageGetJson } = loadSafeStorage();
+    storageGetJson('localStorage', 'bad');
+    expect(mockReportClientError).toHaveBeenCalledTimes(1);
+    expect((mockReportClientError.mock.calls[0][0] as Error).message).toBe('Invalid JSON in storage');
+  });
+});

--- a/src/__tests__/session-store.test.tsx
+++ b/src/__tests__/session-store.test.tsx
@@ -1,3 +1,5 @@
+jest.mock('../util/client-error', () => ({ reportClientError: jest.fn() }));
+
 import { renderHook, act } from '@testing-library/react';
 import { useSessionStore } from '../hooks/session-store.hook';
 
@@ -18,10 +20,11 @@ const sessionStorageMock = (() => {
   };
 })();
 
-Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock });
+Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock, configurable: true });
 
 describe('useSessionStore', () => {
   beforeEach(() => {
+    Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock, configurable: true });
     sessionStorageMock.clear();
   });
 
@@ -148,6 +151,33 @@ describe('useSessionStore', () => {
       expect(result2.current.supportIssueUid.get()).toBe('persisted-uid');
       expect(result2.current.paymentLinkApiUrlStore.get()).toBe('https://persisted.example.com');
       expect(result2.current.editMailReturn.get()).toBe('/persisted-path');
+    });
+  });
+
+  describe('blocked sessionStorage', () => {
+    it('get/set/remove do not throw when storage operations fail', () => {
+      Object.defineProperty(window, 'sessionStorage', {
+        value: {
+          getItem: () => {
+            throw new DOMException('Denied', 'SecurityError');
+          },
+          setItem: () => {
+            throw new DOMException('Denied', 'SecurityError');
+          },
+          removeItem: () => {
+            throw new DOMException('Denied', 'SecurityError');
+          },
+          clear: () => undefined,
+        },
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useSessionStore());
+      expect(result.current.supportIssueUid.get()).toBeUndefined();
+      expect(() => result.current.supportIssueUid.set('x')).not.toThrow();
+      expect(() => result.current.supportIssueUid.remove()).not.toThrow();
+      expect(() => result.current.paymentLinkApiUrlStore.set('y')).not.toThrow();
+      expect(() => result.current.editMailReturn.set('z')).not.toThrow();
     });
   });
 });

--- a/src/__tests__/storage-block-flag.test.ts
+++ b/src/__tests__/storage-block-flag.test.ts
@@ -1,0 +1,15 @@
+import { getStorageBlockedFlag, setStorageBlockedFlag } from '../util/storage-block-flag';
+
+describe('storage-block-flag', () => {
+  afterEach(() => {
+    setStorageBlockedFlag(false);
+  });
+
+  it('defaults to false and round-trips', () => {
+    expect(getStorageBlockedFlag()).toBe(false);
+    setStorageBlockedFlag(true);
+    expect(getStorageBlockedFlag()).toBe(true);
+    setStorageBlockedFlag(false);
+    expect(getStorageBlockedFlag()).toBe(false);
+  });
+});

--- a/src/__tests__/store.hook.test.ts
+++ b/src/__tests__/store.hook.test.ts
@@ -1,3 +1,5 @@
+jest.mock('../util/client-error', () => ({ reportClientError: jest.fn() }));
+
 import { renderHook, act } from '@testing-library/react';
 import { useStore } from '../hooks/store.hook';
 
@@ -18,10 +20,11 @@ const localStorageMock = (() => {
   };
 })();
 
-Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+Object.defineProperty(window, 'localStorage', { value: localStorageMock, configurable: true });
 
 describe('useStore', () => {
   beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', { value: localStorageMock, configurable: true });
     localStorageMock.clear();
   });
 
@@ -63,6 +66,17 @@ describe('useStore', () => {
       
       expect(result.current.balances.get()).toBe('100.50');
     });
+
+    it('should remove balances', () => {
+      const { result } = renderHook(() => useStore());
+
+      act(() => {
+        result.current.balances.set('100.50');
+        result.current.balances.remove();
+      });
+
+      expect(result.current.balances.get()).toBeUndefined();
+    });
   });
 
   describe('language', () => {
@@ -88,6 +102,17 @@ describe('useStore', () => {
         expect(result.current.language.get()).toBe(lang);
       });
     });
+
+    it('should remove language', () => {
+      const { result } = renderHook(() => useStore());
+
+      act(() => {
+        result.current.language.set('de');
+        result.current.language.remove();
+      });
+
+      expect(result.current.language.get()).toBeUndefined();
+    });
   });
 
   describe('activeWallet', () => {
@@ -99,6 +124,17 @@ describe('useStore', () => {
       });
       
       expect(result.current.activeWallet.get()).toBe('MetaMask');
+    });
+
+    it('should remove activeWallet', () => {
+      const { result } = renderHook(() => useStore());
+
+      act(() => {
+        result.current.activeWallet.set('MetaMask' as any);
+        result.current.activeWallet.remove();
+      });
+
+      expect(result.current.activeWallet.get()).toBeUndefined();
     });
   });
 
@@ -117,6 +153,17 @@ describe('useStore', () => {
 
     it('should return undefined when not set', () => {
       const { result } = renderHook(() => useStore());
+      expect(result.current.infoBanner.get()).toBeUndefined();
+    });
+
+    it('should remove infoBanner', () => {
+      const { result } = renderHook(() => useStore());
+
+      act(() => {
+        result.current.infoBanner.set({ message: 'Test banner', type: 'info' } as any);
+        result.current.infoBanner.remove();
+      });
+
       expect(result.current.infoBanner.get()).toBeUndefined();
     });
   });
@@ -150,6 +197,17 @@ describe('useStore', () => {
       
       expect(result.current.queryParams.get()).toEqual(params);
     });
+
+    it('should remove queryParams', () => {
+      const { result } = renderHook(() => useStore());
+
+      act(() => {
+        result.current.queryParams.set({ mode: 'buy', blockchain: 'Bitcoin' } as any);
+        result.current.queryParams.remove();
+      });
+
+      expect(result.current.queryParams.get()).toBeUndefined();
+    });
   });
 
   describe('persistence', () => {
@@ -163,6 +221,72 @@ describe('useStore', () => {
       const { result: result2 } = renderHook(() => useStore());
       
       expect(result2.current.language.get()).toBe('de');
+    });
+  });
+
+  describe('blocked and invalid storage', () => {
+    it('useStore does not throw when window.localStorage getter throws', () => {
+      Object.defineProperty(window, 'localStorage', {
+        get() {
+          throw new DOMException('Denied', 'SecurityError');
+        },
+        configurable: true,
+      });
+
+      expect(() => renderHook(() => useStore())).not.toThrow();
+      const { result } = renderHook(() => useStore());
+      expect(result.current.redirectUri.get()).toBeUndefined();
+      expect(() => result.current.redirectUri.set('x')).not.toThrow();
+      expect(() => result.current.redirectUri.remove()).not.toThrow();
+    });
+
+    it.each(['undefined', '<!doctype html>', '{kaputt'])(
+      'queryParams.get on stored %j returns undefined and removes the key',
+      (raw) => {
+        localStorageMock.setItem('dfx.srv.queryParams', raw);
+        const { result } = renderHook(() => useStore());
+        expect(result.current.queryParams.get()).toBeUndefined();
+        expect(localStorageMock.getItem('dfx.srv.queryParams')).toBeNull();
+      },
+    );
+
+    it('set and setJson do not throw on QuotaExceededError by name', () => {
+      const quota = new Error('quota');
+      quota.name = 'QuotaExceededError';
+      Object.defineProperty(window, 'localStorage', {
+        value: {
+          getItem: () => null,
+          setItem: () => {
+            throw quota;
+          },
+          removeItem: () => undefined,
+          clear: () => undefined,
+        },
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useStore());
+      expect(() => result.current.redirectUri.set('x')).not.toThrow();
+      expect(() => result.current.queryParams.set({ mode: 'buy' } as any)).not.toThrow();
+    });
+
+    it('set does not throw on QuotaExceededError DOMException', () => {
+      const quota = new DOMException('Quota exceeded', 'QuotaExceededError');
+      Object.defineProperty(window, 'localStorage', {
+        value: {
+          getItem: () => null,
+          setItem: () => {
+            throw quota;
+          },
+          removeItem: () => undefined,
+          clear: () => undefined,
+        },
+        configurable: true,
+      });
+
+      const { result } = renderHook(() => useStore());
+      expect(() => result.current.language.set('de')).not.toThrow();
+      expect(() => result.current.infoBanner.set({ message: 'x' } as any)).not.toThrow();
     });
   });
 });

--- a/src/components/boot-error-boundary.tsx
+++ b/src/components/boot-error-boundary.tsx
@@ -1,0 +1,137 @@
+import { Component, PropsWithChildren, ReactNode } from 'react';
+import { reportClientError } from '../util/client-error';
+import { isStorageBlocked, isStorageHardBlocked, resetDfxStorageAndReload } from '../util/safe-storage';
+
+interface StorageCopy {
+  message: string;
+  button: string;
+}
+
+const STORAGE_COPY: Record<string, StorageCopy> = {
+  en: {
+    message:
+      'This browser is blocking saved data. Allow cookies for this site and reload. Otherwise a login will not survive refresh.',
+    button: 'Reload',
+  },
+  de: {
+    message:
+      'Dieser Browser blockiert gespeicherte Daten. Erlauben Sie Cookies für diese Seite und laden Sie neu. Sonst übersteht eine Anmeldung kein Neuladen.',
+    button: 'Neu laden',
+  },
+  fr: {
+    message:
+      'Ce navigateur bloque les données enregistrées. Autorisez les cookies pour ce site et rechargez. Sinon une connexion ne survivra pas au rechargement.',
+    button: 'Recharger',
+  },
+  it: {
+    message:
+      'Questo browser sta bloccando i dati salvati. Consenti i cookie per questo sito e ricarica. Altrimenti un accesso non sopravvive al ricaricamento.',
+    button: 'Ricarica',
+  },
+};
+
+function languagePrefix(): string {
+  const raw = (navigator.language || navigator.languages?.[0] || 'en').toLowerCase();
+  return raw.split('-')[0];
+}
+
+function resolveCopy<T>(table: Record<string, T>, fallback: T): T {
+  return table[languagePrefix()] ?? fallback;
+}
+
+function resolveStorageCopy(): StorageCopy {
+  return resolveCopy(STORAGE_COPY, STORAGE_COPY.en);
+}
+
+const BOOT_COPY: Record<string, StorageCopy> = {
+  en: {
+    message: 'Something went wrong while starting the app.',
+    button: 'Reset saved data and reload',
+  },
+  de: {
+    message: 'Beim Start der App ist ein Fehler aufgetreten.',
+    button: 'Gespeicherte Daten zurücksetzen und neu laden',
+  },
+  fr: {
+    message: "Une erreur s'est produite au démarrage de l'application.",
+    button: 'Réinitialiser les données enregistrées et recharger',
+  },
+  it: {
+    message: "Si è verificato un errore all'avvio dell'app.",
+    button: 'Reimposta i dati salvati e ricarica',
+  },
+};
+
+interface BootErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class BootErrorBoundary extends Component<PropsWithChildren, BootErrorBoundaryState> {
+  state: BootErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): BootErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error): void {
+    reportClientError(error, window.location.pathname);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      const copy = resolveCopy(BOOT_COPY, BOOT_COPY.en);
+      return (
+        <div role="alert" className="p-8 text-center text-dfxBlue-800">
+          <p className="mb-4">{copy.message}</p>
+          <button
+            type="button"
+            className="rounded bg-dfxBlue-800 px-4 py-2 text-white"
+            onClick={() => resetDfxStorageAndReload()}
+          >
+            {copy.button}
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export function StorageBlockedBanner(): JSX.Element | null {
+  if (!isStorageBlocked() || isStorageHardBlocked()) return null;
+
+  const copy = resolveStorageCopy();
+
+  return (
+    <div role="status" className="bg-dfxBlue-800 px-4 py-3 text-center text-sm text-white">
+      <p className="mb-2">{copy.message}</p>
+      <button type="button" className="underline" onClick={() => window.location.reload()}>
+        {copy.button}
+      </button>
+    </div>
+  );
+}
+
+export function renderHardBlockedPage(root: HTMLElement): void {
+  const copy = resolveStorageCopy();
+  root.textContent = '';
+
+  const wrap = document.createElement('div');
+  wrap.style.cssText =
+    'display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;padding:1.5rem;text-align:center;font-family:sans-serif;color:#072440;';
+
+  const message = document.createElement('p');
+  message.textContent = copy.message;
+  message.style.marginBottom = '1rem';
+  message.style.maxWidth = '32rem';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = copy.button;
+  button.style.cssText = 'padding:0.5rem 1rem;cursor:pointer;';
+  button.onclick = () => window.location.reload();
+
+  wrap.append(message, button);
+  root.append(wrap);
+}

--- a/src/hooks/session-store.hook.ts
+++ b/src/hooks/session-store.hook.ts
@@ -1,3 +1,5 @@
+import { storageGet, storageRemove, storageSet } from '../util/safe-storage';
+
 export interface SessionStoreItem<T> {
   get: () => T | undefined;
   set: (item: T) => void;
@@ -18,15 +20,15 @@ enum SessionStoreKey {
 
 export function useSessionStore(): SessionStoreInterface {
   function set(key: SessionStoreKey, value: string) {
-    sessionStorage.setItem(key, value);
+    storageSet('sessionStorage', key, value);
   }
 
   function get(key: SessionStoreKey): string | undefined {
-    return sessionStorage.getItem(key) ?? undefined;
+    return storageGet('sessionStorage', key);
   }
 
   function remove(key: SessionStoreKey) {
-    sessionStorage.removeItem(key);
+    storageRemove('sessionStorage', key);
   }
 
   return {

--- a/src/hooks/store.hook.ts
+++ b/src/hooks/store.hook.ts
@@ -1,6 +1,7 @@
 import { InfoBanner } from '@dfx.swiss/react';
 import { AppParams } from '../contexts/app-handling.context';
 import { WalletType } from '../contexts/wallet.context';
+import { storageGet, storageGetJson, storageRemove, storageSet, storageSetJson } from '../util/safe-storage';
 
 export interface StoreItem<T> {
   get: () => T | undefined;
@@ -18,7 +19,6 @@ export interface StoreInterface {
 }
 
 enum StoreKey {
-  AUTH_TOKEN = 'dfx.authenticationToken',
   REDIRECT_URI = 'dfx.srv.redirectUri',
   BALANCES = 'dfx.srv.balances',
   LANGUAGE = 'dfx.srv.language',
@@ -28,27 +28,24 @@ enum StoreKey {
 }
 
 export function useStore(): StoreInterface {
-  const { localStorage } = window;
-
   function set(key: StoreKey, value: string) {
-    localStorage.setItem(key, value);
+    storageSet('localStorage', key, value);
   }
 
   function get(key: StoreKey): string | undefined {
-    return localStorage.getItem(key) ?? undefined;
+    return storageGet('localStorage', key);
   }
 
   function remove(key: StoreKey) {
-    localStorage.removeItem(key);
+    storageRemove('localStorage', key);
   }
 
   function getJson<T>(key: StoreKey): T | undefined {
-    const item = localStorage.getItem(key);
-    return item ? JSON.parse(item) : undefined;
+    return storageGetJson<T>('localStorage', key);
   }
 
   function setJson<T>(key: StoreKey, value: T) {
-    localStorage.setItem(key, JSON.stringify(value));
+    storageSetJson('localStorage', key, value);
   }
 
   return {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,27 +1,6 @@
-import ReactDOM from 'react-dom/client';
-import Main from './Main';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
-import { installChunkErrorHandling } from './util/client-error';
+import { startStandaloneApp } from './util/boot-standalone';
 
-// Clear session data when URL contains new login credentials
-// This must happen BEFORE React initializes to prevent the @dfx.swiss/react
-// package from loading a stale session from storage
-// Only clear session-related keys, preserve user preferences (language, etc.)
-const urlParams = new URLSearchParams(window.location.search);
-if ((urlParams.has('address') && urlParams.has('signature')) || urlParams.has('session')) {
-  localStorage.removeItem('dfx.authenticationToken');
-  localStorage.removeItem('dfx.srv.activeWallet');
-  localStorage.removeItem('dfx.srv.queryParams');
-  sessionStorage.clear();
-}
-
-installChunkErrorHandling();
-
-const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-root.render(<Main />);
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+startStandaloneApp();
 reportWebVitals();

--- a/src/util/bank-tx-cache.ts
+++ b/src/util/bank-tx-cache.ts
@@ -1,4 +1,5 @@
 import { BankTxSearchResult } from 'src/hooks/compliance.hook';
+import * as safeStorage from './safe-storage';
 
 // Used to carry a bank-tx row from the compliance search list into the
 // details screen. sessionStorage is needed because app-handling.context
@@ -7,13 +8,16 @@ import { BankTxSearchResult } from 'src/hooks/compliance.hook';
 const BANK_TX_CACHE_PREFIX = 'dfx.bankTx.';
 
 export function cacheBankTx(bankTx: BankTxSearchResult): void {
-  sessionStorage.setItem(`${BANK_TX_CACHE_PREFIX}${bankTx.id}`, JSON.stringify(bankTx));
+  try {
+    safeStorage.storageSetJson('sessionStorage', `${BANK_TX_CACHE_PREFIX}${bankTx.id}`, bankTx);
+  } catch {
+    // no-op
+  }
 }
 
 export function readCachedBankTx(id: string): BankTxSearchResult | undefined {
   try {
-    const cached = sessionStorage.getItem(`${BANK_TX_CACHE_PREFIX}${id}`);
-    return cached ? (JSON.parse(cached) as BankTxSearchResult) : undefined;
+    return safeStorage.storageGetJson<BankTxSearchResult>('sessionStorage', `${BANK_TX_CACHE_PREFIX}${id}`);
   } catch {
     return undefined;
   }

--- a/src/util/boot-standalone.ts
+++ b/src/util/boot-standalone.ts
@@ -1,0 +1,41 @@
+import { createElement } from 'react';
+import ReactDOM from 'react-dom/client';
+import Main from '../Main';
+import { BootErrorBoundary, renderHardBlockedPage } from '../components/boot-error-boundary';
+import { installChunkErrorHandling, reportClientError } from './client-error';
+import {
+  clearLoginSessionStorage,
+  installStorageFallback,
+  isStorageBlocked,
+  isStorageHardBlocked,
+} from './safe-storage';
+
+export function startStandaloneApp(): void {
+  installStorageFallback();
+
+  const rootEl = document.getElementById('root');
+  if (!rootEl) return;
+
+  if (isStorageHardBlocked()) {
+    renderHardBlockedPage(rootEl);
+    reportClientError(new Error('Storage blocked'), window.location.pathname);
+    return;
+  }
+
+  // Clear session data when URL contains new login credentials.
+  // This must happen BEFORE React initializes to prevent the @dfx.swiss/react
+  // package from loading a stale session from storage.
+  // Only clear session-related keys, preserve user preferences (language, etc.).
+  const urlParams = new URLSearchParams(window.location.search);
+  if ((urlParams.has('address') && urlParams.has('signature')) || urlParams.has('session')) {
+    clearLoginSessionStorage();
+  }
+
+  // A memory shim makes the chunk-reload guard ephemeral: reload wipes it, so a
+  // leftover chunk error would loop. Report still happens via the error boundary.
+  if (!isStorageBlocked()) {
+    installChunkErrorHandling();
+  }
+
+  ReactDOM.createRoot(rootEl).render(createElement(BootErrorBoundary, null, createElement(Main)));
+}

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -1,6 +1,7 @@
 import { isRouteErrorResponse } from 'react-router-dom';
 import { Api } from 'src/config/api';
 import { REACT_APP_BUILD_ID } from 'src/version';
+import { getStorageBlockedFlag } from './storage-block-flag';
 import { url } from './utils';
 
 // Must match the field limits of the ingest endpoint, so a long message is trimmed here instead of
@@ -152,6 +153,8 @@ export function isEmbedded(): boolean {
 // wrapped because embedded/iframe contexts can block it.
 export function reloadOnceForChunkError(error?: unknown): void {
   if (embedded) return;
+  // A memory shim does not survive reload, so the localStorage guard cannot stop a loop.
+  if (getStorageBlockedFlag()) return;
 
   try {
     const last = Number(localStorage.getItem(CHUNK_RELOAD_KEY) ?? 0);

--- a/src/util/safe-storage.ts
+++ b/src/util/safe-storage.ts
@@ -1,0 +1,200 @@
+import { reportClientError } from './client-error';
+import { setStorageBlockedFlag } from './storage-block-flag';
+
+type StorageName = 'localStorage' | 'sessionStorage';
+
+const PROBE_KEY = '__dfx.probe';
+
+let installAttempted = false;
+let storageBlocked = false;
+let storageHardBlocked = false;
+let storageFailureReported = false;
+
+function reportStorageFailure(message: string): void {
+  if (storageFailureReported) return;
+  storageFailureReported = true;
+  reportClientError(new Error(message), window.location.pathname);
+}
+
+function createMemoryStorage(): Storage {
+  const map = new Map<string, string>();
+
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string): string | null {
+      const value = map.get(key);
+      return value === undefined ? null : value;
+    },
+    setItem(key: string, value: string): void {
+      map.set(key, String(value));
+    },
+    removeItem(key: string): void {
+      map.delete(key);
+    },
+    key(index: number): string | null {
+      const keys = Array.from(map.keys());
+      if (index < 0 || index >= keys.length) return null;
+      return keys[index];
+    },
+  };
+}
+
+function getStorage(name: StorageName): Storage | undefined {
+  try {
+    return window[name];
+  } catch {
+    reportStorageFailure('Storage blocked');
+    return undefined;
+  }
+}
+
+function probeStorage(name: StorageName): boolean {
+  try {
+    const storage = window[name];
+    storage.setItem(PROBE_KEY, '1');
+    storage.getItem(PROBE_KEY);
+    storage.removeItem(PROBE_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function storageGet(storage: StorageName, key: string): string | undefined {
+  try {
+    const store = getStorage(storage);
+    if (!store) return undefined;
+    return store.getItem(key) ?? undefined;
+  } catch {
+    reportStorageFailure('Storage blocked');
+    return undefined;
+  }
+}
+
+export function storageSet(storage: StorageName, key: string, value: string): void {
+  try {
+    const store = getStorage(storage);
+    if (!store) return;
+    store.setItem(key, value);
+  } catch {
+    // SecurityError / QuotaExceededError (and any other write failure)
+  }
+}
+
+export function storageRemove(storage: StorageName, key: string): void {
+  try {
+    const store = getStorage(storage);
+    if (!store) return;
+    store.removeItem(key);
+  } catch {
+    // never throw
+  }
+}
+
+export function storageGetJson<T>(storage: StorageName, key: string): T | undefined {
+  const raw = storageGet(storage, key);
+  if (raw === undefined) return undefined;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    reportStorageFailure('Invalid JSON in storage');
+    storageRemove(storage, key);
+    return undefined;
+  }
+}
+
+export function storageSetJson<T>(storage: StorageName, key: string, value: T): void {
+  const serialized = JSON.stringify(value);
+  if (typeof serialized !== 'string') return;
+  storageSet(storage, key, serialized);
+}
+
+export function storageClear(storage: 'sessionStorage'): void {
+  try {
+    const store = getStorage(storage);
+    if (!store) return;
+    store.clear();
+  } catch {
+    // never throw
+  }
+}
+
+/** Probe; if blocked, try Object.defineProperty memory shim. Idempotent. */
+export function installStorageFallback(): void {
+  if (installAttempted) return;
+  installAttempted = true;
+
+  const localOk = probeStorage('localStorage');
+  const sessionOk = probeStorage('sessionStorage');
+
+  if (localOk && sessionOk) {
+    storageBlocked = false;
+    storageHardBlocked = false;
+    setStorageBlockedFlag(false);
+    return;
+  }
+
+  storageBlocked = true;
+  setStorageBlockedFlag(true);
+  reportStorageFailure('Storage blocked');
+
+  const localUsable = localOk || shimStorage('localStorage');
+  const sessionUsable = sessionOk || shimStorage('sessionStorage');
+  storageHardBlocked = !localUsable && !sessionUsable;
+}
+
+function shimStorage(name: StorageName): boolean {
+  try {
+    Object.defineProperty(window, name, {
+      value: createMemoryStorage(),
+      configurable: true,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isStorageBlocked(): boolean {
+  return storageBlocked;
+}
+
+export function isStorageHardBlocked(): boolean {
+  return storageHardBlocked;
+}
+
+/** Remove login keys; never throw. */
+export function clearLoginSessionStorage(): void {
+  storageRemove('localStorage', 'dfx.authenticationToken');
+  storageRemove('localStorage', 'dfx.srv.activeWallet');
+  storageRemove('localStorage', 'dfx.srv.queryParams');
+  storageClear('sessionStorage');
+}
+
+function collectDfxKeys(name: StorageName): string[] {
+  const keys: string[] = [];
+  try {
+    const store = window[name];
+    for (let i = 0; i < store.length; i++) {
+      const key = store.key(i);
+      if (key != null && key.startsWith('dfx.')) keys.push(key);
+    }
+  } catch {
+    // ignore listing failures
+  }
+  return keys;
+}
+
+/** Keys starting with `dfx.` on both storages, then reload. Never throw on the clears. */
+export function resetDfxStorageAndReload(): void {
+  const localKeys = collectDfxKeys('localStorage');
+  const sessionKeys = collectDfxKeys('sessionStorage');
+  for (const key of localKeys) storageRemove('localStorage', key);
+  for (const key of sessionKeys) storageRemove('sessionStorage', key);
+  window.location.reload();
+}

--- a/src/util/storage-block-flag.ts
+++ b/src/util/storage-block-flag.ts
@@ -1,0 +1,9 @@
+let blocked = false;
+
+export function setStorageBlockedFlag(value: boolean): void {
+  blocked = value;
+}
+
+export function getStorageBlockedFlag(): boolean {
+  return blocked;
+}


### PR DESCRIPTION
EN:
The app no longer goes blank when the browser blocks storage or a stored value is not valid JSON.
Blocked storage is replaced in memory, and the user is told that a login will not survive reload.
Invalid JSON is deleted on read; chunk auto-reload is skipped while storage is blocked.
The app depends on `@dfx.swiss/react` 1.8.1, which includes the matching SDK guard.

DE:
Die App bleibt nicht mehr leer, wenn der Browser den Speicher blockiert oder ein gespeicherter Wert kein gültiges JSON ist.
Blockierter Speicher wird im Arbeitsspeicher ersetzt, und der Nutzer sieht, dass eine Anmeldung den Reload nicht übersteht.
Ungültiges JSON wird beim Lesen gelöscht; Chunk-Auto-Reload ist bei blockiertem Speicher aus.
Die App hängt an `@dfx.swiss/react` 1.8.1, das denselben Guard im SDK mitbringt.

<details>
<summary>Details</summary>

One commit on `develop`. Storage is probed before React mounts. If the getter throws, a memory shim is installed for the failed store only; if that fails, a static page asks the user to allow cookies and reload. `useStore` / `useSessionStore` never throw. `reloadOnceForChunkError` no-ops when boot marked storage as blocked.

`package.json` pins `@dfx.swiss/react` to `^1.8.1` (lockfile 1.8.1).

Coverage (build host, Node 20) is 100% statement / branch / function / line on every instrumented file this change touches:

- `src/Main.tsx`
- `src/Main.widget.tsx`
- `src/index.tsx`
- `src/components/boot-error-boundary.tsx`
- `src/hooks/session-store.hook.ts`
- `src/hooks/store.hook.ts`
- `src/util/bank-tx-cache.ts`
- `src/util/boot-standalone.ts`
- `src/util/client-error.ts`
- `src/util/safe-storage.ts`
- `src/util/storage-block-flag.ts`

Declared deviation from handbook completeness: last-resort boot surfaces (no route). The failure modes are unit-tested. A Playwright baseline cannot stably show a `SecurityError` on the `localStorage` getter as a product screen.

Replaces #1479 (same tree, seven commits squashed).

</details>