### PR TITLE
28835ea3 - Only auto-connect wallets that are available

### DIFF
--- a/src/__tests__/connect-alby-redirect.test.tsx
+++ b/src/__tests__/connect-alby-redirect.test.tsx
@@ -1,19 +1,22 @@
-// Component-level: ConnectAlby merges redirectPath + current search into the Alby
-// auth redirect's `redirect` query param via relativeUrl (personal-iban survival).
+// Component-level coverage for ConnectAlby: Alby auth redirect (personal-iban survival),
+// pubkey login, install-hint gate via isAvailable, Content error/loading branches, and
+// appParams / redirectPath guards.
 
 const mockEnable = jest.fn();
 const mockSignMessage = jest.fn();
-const mockIsInstalled = jest.fn();
+const mockIsAvailable = jest.fn();
 const mockRedirectPath = jest.fn();
 const mockAppParams = jest.fn();
 const mockOnCancel = jest.fn();
 const mockOnLogin = jest.fn();
 const mockOnSwitch = jest.fn();
+const mockLogin = jest.fn();
 
 jest.mock('@dfx.swiss/react', () => ({
   Blockchain: { LIGHTNING: 'Lightning' },
   useAuthContext: () => ({ session: undefined }),
   useSessionContext: () => ({ logout: jest.fn() }),
+  useUserContext: () => ({ user: undefined }),
 }));
 
 jest.mock('@dfx.swiss/react-components', () => ({
@@ -24,8 +27,18 @@ jest.mock('@dfx.swiss/react-components', () => ({
     </button>
   ),
   StyledButtonColor: { GRAY_OUTLINE: 'gray-outline' },
-  StyledButtonWidth: { MIN: 'min' },
+  StyledButtonWidth: { MIN: 'min', SM: 'sm' },
   StyledLoadingSpinner: () => null,
+  StyledVerticalStack: ({ children }: any) => <div>{children}</div>,
+  StyledLink: ({ label }: any) => <a>{label}</a>,
+}));
+
+jest.mock('react-i18next', () => ({
+  Trans: ({ children }: any) => <>{children}</>,
+}));
+
+jest.mock('../hooks/report-displayed-error.hook', () => ({
+  useReportDisplayedError: () => undefined,
 }));
 
 jest.mock('../config/api', () => ({
@@ -50,7 +63,7 @@ jest.mock('../contexts/wallet.context', () => ({
   WalletBlockchains: { Alby: ['Lightning'] },
   supportsBlockchain: () => true,
   useWalletContext: () => ({
-    login: jest.fn(),
+    login: mockLogin,
     setSession: jest.fn(),
     switchBlockchain: jest.fn(),
     activeWallet: undefined,
@@ -59,7 +72,7 @@ jest.mock('../contexts/wallet.context', () => ({
 
 jest.mock('../hooks/wallets/alby.hook', () => ({
   useAlby: () => ({
-    isInstalled: mockIsInstalled,
+    isAvailable: mockIsAvailable,
     enable: mockEnable,
     signMessage: mockSignMessage,
   }),
@@ -73,7 +86,7 @@ jest.mock('../util/utils', () => {
   };
 });
 
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { createRef } from 'react';
 import ConnectAlby from '../components/home/wallet/connect-alby';
 import { WalletType } from '../contexts/wallet.context';
@@ -85,10 +98,11 @@ describe('ConnectAlby login redirect', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedLocation = undefined;
-    mockIsInstalled.mockResolvedValue(true);
+    mockIsAvailable.mockResolvedValue(true);
     mockEnable.mockResolvedValue({ node: { alias: 'getalby.com' } });
     mockAppParams.mockReturnValue({});
     mockOnCancel.mockClear();
+    mockLogin.mockResolvedValue(undefined);
 
     locationStub = {
       href: 'http://localhost/connect',
@@ -177,5 +191,179 @@ describe('ConnectAlby login redirect', () => {
     const redirect = getRedirectParamFromCapturedLocation();
     expect(redirect).toBe('/buy');
     expect(redirect).not.toContain('?');
+  });
+});
+
+describe('ConnectAlby', () => {
+  let capturedLocation: string | undefined;
+  let locationStub: { href: string; search: string; origin: string; pathname: string };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedLocation = undefined;
+    mockIsAvailable.mockResolvedValue(true);
+    mockEnable.mockResolvedValue({ node: { alias: 'getalby.com' } });
+    mockAppParams.mockReturnValue({});
+    mockRedirectPath.mockReturnValue('/buy');
+    mockLogin.mockResolvedValue(undefined);
+    mockSignMessage.mockResolvedValue('signed');
+
+    locationStub = {
+      href: 'http://localhost/connect',
+      search: '',
+      origin: 'http://localhost',
+      pathname: '/connect',
+    };
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      get() {
+        return locationStub;
+      },
+      set(value: string) {
+        capturedLocation = value;
+      },
+    });
+  });
+
+  function renderConnectAlby() {
+    return render(
+      <ConnectAlby
+        rootRef={createRef<HTMLDivElement>()}
+        wallet={WalletType.ALBY}
+        blockchain={undefined}
+        isConnect={false}
+        onLogin={mockOnLogin}
+        onCancel={mockOnCancel}
+        onSwitch={mockOnSwitch}
+      />,
+    );
+  }
+
+  it('does not auto-connect when isAvailable resolves false', async () => {
+    mockIsAvailable.mockResolvedValue(false);
+
+    await act(async () => {
+      renderConnectAlby();
+    });
+
+    await waitFor(() => expect(mockIsAvailable).toHaveBeenCalled());
+    expect(mockEnable).not.toHaveBeenCalled();
+  });
+
+  it('shows Permission denied error and Back calls onCancel when enable returns falsy', async () => {
+    mockEnable.mockResolvedValue(undefined);
+
+    await act(async () => {
+      renderConnectAlby();
+    });
+
+    await waitFor(() => expect(screen.getByText('Permission denied or account not verified')).toBeInTheDocument());
+    expect(screen.getByText('Connection failed!')).toBeInTheDocument();
+
+    screen.getByText('Back').click();
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+
+  it('logs in with LNNID + uppercased pubkey', async () => {
+    mockEnable.mockResolvedValue({ node: { pubkey: 'aBcDeF123' } });
+
+    await act(async () => {
+      renderConnectAlby();
+    });
+
+    await waitFor(() =>
+      expect(mockLogin).toHaveBeenCalledWith(
+        WalletType.ALBY,
+        'LNNIDABCDEF123',
+        'Lightning',
+        expect.any(Function),
+        undefined,
+      ),
+    );
+  });
+
+  it('forwards signMessage through the login signer callback', async () => {
+    mockEnable.mockResolvedValue({ node: { pubkey: 'abc' } });
+    mockLogin.mockImplementation((_wallet, _address, _blockchain, signer) => signer('some-address', 'some-message'));
+
+    await act(async () => {
+      renderConnectAlby();
+    });
+
+    await waitFor(() => expect(mockSignMessage).toHaveBeenCalledWith('some-message'));
+  });
+
+  it('redirects when alias ends with .getalby.com', async () => {
+    mockEnable.mockResolvedValue({ node: { alias: 'foo.getalby.com' } });
+
+    await act(async () => {
+      renderConnectAlby();
+    });
+
+    await waitFor(() => expect(capturedLocation).toBeDefined());
+    expect(capturedLocation).toContain('https://api.example.com/v1/auth/alby');
+  });
+
+  it('shows No login method found when alias does not match Alby', async () => {
+    mockEnable.mockResolvedValue({ node: { alias: 'other-node.example' } });
+
+    await act(async () => {
+      renderConnectAlby();
+    });
+
+    await waitFor(() => expect(screen.getByText('No login method found')).toBeInTheDocument());
+  });
+
+  it('shows No login method found when node is absent', async () => {
+    mockEnable.mockResolvedValue({});
+
+    await act(async () => {
+      renderConnectAlby();
+    });
+
+    await waitFor(() => expect(screen.getByText('No login method found')).toBeInTheDocument());
+  });
+
+  it('omits redirect search param when redirectPath is falsy', async () => {
+    mockRedirectPath.mockReturnValue(undefined);
+    mockEnable.mockResolvedValue({ node: { alias: 'getalby.com' } });
+
+    await act(async () => {
+      renderConnectAlby();
+    });
+
+    await waitFor(() => expect(capturedLocation).toBeDefined());
+    const albyUrl = new URL(capturedLocation as string);
+    const redirectUri = albyUrl.searchParams.get('redirectUri');
+    expect(redirectUri).toBeTruthy();
+    const returnUrl = new URL(redirectUri as string);
+    expect(returnUrl.searchParams.get('redirect')).toBeNull();
+  });
+
+  it('forwards appParams wallet and refcode onto the Alby auth URL', async () => {
+    mockAppParams.mockReturnValue({ wallet: 'DFX', refcode: 'REF123' });
+    mockEnable.mockResolvedValue({ node: { alias: 'getalby.com' } });
+
+    await act(async () => {
+      renderConnectAlby();
+    });
+
+    await waitFor(() => expect(capturedLocation).toBeDefined());
+    const albyUrl = new URL(capturedLocation as string);
+    expect(albyUrl.searchParams.get('wallet')).toBe('DFX');
+    expect(albyUrl.searchParams.get('usedRef')).toBe('REF123');
+  });
+
+  it('shows the confirm-connection spinner text while enable is pending', async () => {
+    mockEnable.mockReturnValue(new Promise(() => undefined));
+
+    await act(async () => {
+      renderConnectAlby();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('Please confirm the connection in the Alby browser extension.')).toBeInTheDocument(),
+    );
   });
 });

--- a/src/__tests__/connect-base.test.tsx
+++ b/src/__tests__/connect-base.test.tsx
@@ -1,0 +1,378 @@
+// Component-level: ConnectBase only auto-connects to a wallet that is supported in this browser,
+// plus the connect and login flow behind the connect call.
+
+const mockLogin = jest.fn();
+const mockSetSession = jest.fn();
+const mockSwitchBlockchain = jest.fn();
+const mockLogout = jest.fn();
+const mockGetAccount = jest.fn();
+const mockSignMessage = jest.fn();
+const mockOnLogin = jest.fn();
+const mockOnCancel = jest.fn();
+const mockOnSwitch = jest.fn();
+let mockActiveWallet: string | undefined;
+let mockSession: { address?: string } | undefined;
+
+jest.mock('@dfx.swiss/react', () => ({
+  Blockchain: { ETHEREUM: 'Ethereum', POLYGON: 'Polygon', BITCOIN: 'Bitcoin' },
+  useAuthContext: () => ({ session: mockSession }),
+  useSessionContext: () => ({ logout: mockLogout }),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  SpinnerSize: { LG: 'lg' },
+  StyledLoadingSpinner: () => <div>loading</div>,
+}));
+
+jest.mock('../contexts/wallet.context', () => {
+  const WalletBlockchains: Record<string, string[] | undefined> = { MetaMask: ['Ethereum', 'Polygon'] };
+
+  return {
+    WalletType: { META_MASK: 'MetaMask', ALBY: 'Alby', WALLET_CONNECT: 'WalletConnect', MAIL: 'Mail' },
+    WalletBlockchains,
+    supportsBlockchain: (wallet: string, blockchain: string) => {
+      const chains = WalletBlockchains[wallet];
+      return !chains || chains.includes(blockchain);
+    },
+    useWalletContext: () => ({
+      login: mockLogin,
+      setSession: mockSetSession,
+      switchBlockchain: mockSwitchBlockchain,
+      activeWallet: mockActiveWallet,
+    }),
+  };
+});
+
+jest.mock('../components/home/install-hint', () => ({
+  InstallHint: ({ type, onConfirm }: { type: string; onConfirm: () => void }) => (
+    <button type="button" onClick={onConfirm}>
+      install {type}
+    </button>
+  ),
+}));
+
+jest.mock('../components/home/sign-hint', () => ({
+  SignHint: () => <div>sign hint</div>,
+}));
+
+import { Blockchain } from '@dfx.swiss/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { ComponentProps, createRef } from 'react';
+import { BitcoinAddressType } from '../config/key-path';
+import { ConnectBase } from '../components/home/connect-base';
+import { ConnectContentProps } from '../components/home/connect-shared';
+import { WalletType } from '../contexts/wallet.context';
+import { AbortError } from '../util/abort-error';
+import { WalletSwitchError } from '../util/wallet-switch-error';
+
+let contentProps: ConnectContentProps | undefined;
+
+function renderContent(props: ConnectContentProps): JSX.Element {
+  contentProps = props;
+
+  return (
+    <div>
+      content
+      {props.isConnecting && <span>connecting</span>}
+      {props.error && <span>error: {props.error}</span>}
+    </div>
+  );
+}
+
+function content(): ConnectContentProps {
+  expect(contentProps).toBeDefined();
+  return contentProps as ConnectContentProps;
+}
+
+function renderBase(overrides: Partial<ComponentProps<typeof ConnectBase>> = {}) {
+  return render(
+    <ConnectBase
+      rootRef={createRef<HTMLDivElement>()}
+      wallet={WalletType.META_MASK}
+      blockchain={Blockchain.ETHEREUM}
+      isConnect={false}
+      isSupported={() => true}
+      getAccount={mockGetAccount}
+      signMessage={mockSignMessage}
+      renderContent={renderContent}
+      onLogin={mockOnLogin}
+      onCancel={mockOnCancel}
+      onSwitch={mockOnSwitch}
+      {...overrides}
+    />,
+  );
+}
+
+async function renderReady(overrides: Partial<ComponentProps<typeof ConnectBase>> = {}) {
+  const result = renderBase(overrides);
+  await waitFor(() => expect(screen.queryByText('loading')).not.toBeInTheDocument());
+  return result;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  contentProps = undefined;
+  mockActiveWallet = undefined;
+  mockSession = undefined;
+  mockGetAccount.mockResolvedValue({ address: '0xabc' });
+  mockLogin.mockResolvedValue(undefined);
+  mockSetSession.mockResolvedValue(undefined);
+  mockSwitchBlockchain.mockResolvedValue(undefined);
+  mockLogout.mockResolvedValue(undefined);
+});
+
+describe('ConnectBase auto-connect', () => {
+  it('shows a spinner and hides the content until isSupported resolves', async () => {
+    let resolveSupported: (supported: boolean) => void = () => undefined;
+    renderBase({ isSupported: () => new Promise<boolean>((resolve) => (resolveSupported = resolve)) });
+
+    expect(screen.getByText('loading')).toBeInTheDocument();
+    expect(screen.getByText('content').parentElement).toHaveClass('hidden');
+
+    await act(async () => resolveSupported(true));
+
+    expect(screen.queryByText('loading')).not.toBeInTheDocument();
+    expect(screen.getByText('content').parentElement).not.toHaveClass('hidden');
+  });
+
+  it('does not connect an unsupported wallet and shows the install hint', async () => {
+    renderBase({ autoConnect: true, isSupported: () => false });
+
+    expect(await screen.findByText('install MetaMask')).toBeInTheDocument();
+    expect(screen.getByText('content').parentElement).toHaveClass('hidden');
+    expect(mockGetAccount).not.toHaveBeenCalled();
+    expect(mockOnSwitch).not.toHaveBeenCalled();
+    expect(screen.queryByText(/^error:/)).not.toBeInTheDocument();
+  });
+
+  it('switches to the fallback wallet instead of connecting an unsupported one', async () => {
+    renderBase({ autoConnect: true, isSupported: async () => false, fallback: WalletType.WALLET_CONNECT });
+
+    await waitFor(() => expect(mockOnSwitch).toHaveBeenCalledWith(WalletType.WALLET_CONNECT));
+    expect(mockGetAccount).not.toHaveBeenCalled();
+  });
+
+  it('connects a supported wallet right away', async () => {
+    await renderReady({ autoConnect: true });
+
+    expect(mockGetAccount).toHaveBeenCalledWith(WalletType.META_MASK, Blockchain.ETHEREUM, false);
+    await waitFor(() => expect(mockOnLogin).toHaveBeenCalled());
+  });
+
+  it('waits for an explicit connect when autoConnect is not set', async () => {
+    await renderReady();
+
+    expect(mockGetAccount).not.toHaveBeenCalled();
+
+    await act(() => content().connect());
+
+    expect(mockGetAccount).toHaveBeenCalledWith(WalletType.META_MASK, Blockchain.ETHEREUM, false);
+  });
+});
+
+describe('ConnectBase connect', () => {
+  it('uses the chain passed to connect when the wallet supports it', async () => {
+    await renderReady();
+
+    await act(() => content().connect(Blockchain.POLYGON));
+
+    expect(mockGetAccount).toHaveBeenCalledWith(WalletType.META_MASK, Blockchain.POLYGON, false);
+  });
+
+  it('falls back to the first wallet chain when the requested chain is not supported', async () => {
+    await renderReady({ blockchain: Blockchain.BITCOIN });
+
+    await act(() => content().connect());
+
+    expect(mockGetAccount).toHaveBeenCalledWith(WalletType.META_MASK, Blockchain.ETHEREUM, false);
+  });
+
+  it('falls back to the first wallet chain when no chain is given', async () => {
+    await renderReady({ blockchain: undefined });
+
+    await act(() => content().connect());
+
+    expect(mockGetAccount).toHaveBeenCalledWith(WalletType.META_MASK, Blockchain.ETHEREUM, false);
+  });
+
+  it('rejects when no blockchain can be determined for the wallet', async () => {
+    await renderReady({ wallet: WalletType.MAIL, blockchain: undefined });
+
+    await act(async () => {
+      await expect(content().connect()).rejects.toThrow('No blockchain');
+    });
+
+    expect(mockGetAccount).not.toHaveBeenCalled();
+  });
+
+  it('marks the connect as a reconnect when the wallet is already active', async () => {
+    mockActiveWallet = WalletType.META_MASK;
+    await renderReady();
+
+    await act(() => content().connect());
+
+    expect(mockGetAccount).toHaveBeenCalledWith(WalletType.META_MASK, Blockchain.ETHEREUM, true);
+  });
+
+  it('cancels when the wallet aborts', async () => {
+    mockGetAccount.mockRejectedValue(new AbortError('User cancelled'));
+    await renderReady();
+
+    await act(() => content().connect());
+
+    expect(mockOnCancel).toHaveBeenCalled();
+    expect(content().isConnecting).toBe(false);
+    expect(content().error).toBeUndefined();
+  });
+
+  it('switches the wallet and requests the account there on a wallet switch error', async () => {
+    mockGetAccount
+      .mockRejectedValueOnce(new WalletSwitchError(WalletType.ALBY))
+      .mockResolvedValueOnce({ address: 'x' });
+    await renderReady();
+
+    await act(() => content().connect());
+
+    expect(mockOnSwitch).toHaveBeenCalledWith(WalletType.ALBY);
+    expect(mockGetAccount).toHaveBeenLastCalledWith(WalletType.ALBY, Blockchain.ETHEREUM, false);
+    expect(mockOnLogin).not.toHaveBeenCalled();
+  });
+
+  it('shows the message of any other connect error', async () => {
+    mockGetAccount.mockRejectedValue(new Error('Provider not set or invalid'));
+    await renderReady();
+
+    await act(() => content().connect());
+
+    expect(screen.getByText('error: Provider not set or invalid')).toBeInTheDocument();
+    expect(screen.queryByText('connecting')).not.toBeInTheDocument();
+    expect(mockOnLogin).not.toHaveBeenCalled();
+  });
+
+  it('clears the previous error when connecting again', async () => {
+    mockGetAccount.mockRejectedValueOnce(new Error('first failure')).mockReturnValueOnce(new Promise(() => undefined));
+    await renderReady();
+
+    await act(() => content().connect());
+    expect(screen.getByText('error: first failure')).toBeInTheDocument();
+
+    act(() => {
+      content().connect();
+    });
+
+    expect(screen.queryByText('error: first failure')).not.toBeInTheDocument();
+    expect(screen.getByText('connecting')).toBeInTheDocument();
+  });
+});
+
+describe('ConnectBase login', () => {
+  it('only switches the blockchain when the active wallet returns the session address', async () => {
+    mockActiveWallet = WalletType.META_MASK;
+    mockSession = { address: '0xABC' };
+    await renderReady();
+
+    await act(() => content().connect(Blockchain.POLYGON));
+
+    expect(mockSwitchBlockchain).toHaveBeenCalledWith(Blockchain.POLYGON);
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(mockLogin).not.toHaveBeenCalled();
+    expect(mockOnLogin).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['another wallet is active', WalletType.ALBY, { address: '0xabc' }],
+    ['the address differs from the session', WalletType.META_MASK, { address: '0xdef' }],
+    ['the session has no address', WalletType.META_MASK, {}],
+    ['there is no session', WalletType.META_MASK, undefined],
+  ])('logs out and logs in again when %s', async (_case, activeWallet, session) => {
+    mockActiveWallet = activeWallet;
+    mockSession = session;
+    await renderReady();
+
+    await act(() => content().connect());
+
+    expect(mockSwitchBlockchain).not.toHaveBeenCalled();
+    expect(mockLogout).toHaveBeenCalled();
+    expect(mockLogin).toHaveBeenCalledWith(
+      WalletType.META_MASK,
+      '0xabc',
+      Blockchain.ETHEREUM,
+      expect.any(Function),
+      undefined,
+    );
+    expect(mockOnLogin).toHaveBeenCalled();
+  });
+
+  it('logs in without logging out or switching the blockchain on an explicit connect', async () => {
+    mockActiveWallet = WalletType.META_MASK;
+    mockSession = { address: '0xabc' };
+    mockGetAccount.mockResolvedValue({ address: '0xabc', key: 'public-key' });
+    await renderReady({ isConnect: true });
+
+    await act(() => content().connect());
+
+    expect(mockSwitchBlockchain).not.toHaveBeenCalled();
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(mockLogin).toHaveBeenCalledWith(
+      WalletType.META_MASK,
+      '0xabc',
+      Blockchain.ETHEREUM,
+      expect.any(Function),
+      'public-key',
+    );
+  });
+
+  it('sets the session when the wallet returns a session', async () => {
+    mockActiveWallet = WalletType.META_MASK;
+    mockGetAccount.mockResolvedValue({ session: 'access-token' });
+    await renderReady();
+
+    await act(() => content().connect());
+
+    expect(mockSwitchBlockchain).not.toHaveBeenCalled();
+    expect(mockLogout).toHaveBeenCalled();
+    expect(mockSetSession).toHaveBeenCalledWith('access-token', WalletType.META_MASK, Blockchain.ETHEREUM);
+    expect(mockLogin).not.toHaveBeenCalled();
+    expect(mockOnLogin).toHaveBeenCalled();
+  });
+
+  it('uses the signature the account already carries', async () => {
+    mockGetAccount.mockResolvedValue({ address: '0xabc', signature: 'existing-signature' });
+    mockLogin.mockImplementation((_wallet, address, _chain, sign) => sign(address, 'message'));
+    await renderReady();
+
+    await act(() => content().connect());
+
+    await expect(mockLogin.mock.results[0].value).resolves.toBe('existing-signature');
+    expect(mockSignMessage).not.toHaveBeenCalled();
+  });
+
+  it('asks the wallet to sign and shows the sign hint while it does', async () => {
+    let resolveSignature: (signature: string) => void = () => undefined;
+    mockSignMessage.mockReturnValue(new Promise<string>((resolve) => (resolveSignature = resolve)));
+    mockGetAccount.mockResolvedValue({ address: '0xabc', accountIndex: 1, index: 2, type: BitcoinAddressType.TAPROOT });
+    mockLogin.mockImplementation((_wallet, address, _chain, sign) => sign(address, 'message'));
+    await renderReady();
+
+    act(() => {
+      content().connect();
+    });
+
+    expect(await screen.findByText('sign hint')).toBeInTheDocument();
+    expect(screen.getByText('content').parentElement).toHaveClass('hidden');
+    expect(mockSignMessage).toHaveBeenCalledWith(
+      'message',
+      '0xabc',
+      Blockchain.ETHEREUM,
+      1,
+      2,
+      BitcoinAddressType.TAPROOT,
+    );
+
+    await act(async () => resolveSignature('wallet-signature'));
+
+    expect(screen.queryByText('sign hint')).not.toBeInTheDocument();
+    await expect(mockLogin.mock.results[0].value).resolves.toBe('wallet-signature');
+    expect(mockOnLogin).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/connect-base.test.tsx
+++ b/src/__tests__/connect-base.test.tsx
@@ -201,6 +201,21 @@ describe('ConnectBase auto-connect', () => {
 
     expect(mockGetAccount).toHaveBeenCalledWith(WalletType.META_MASK, Blockchain.ETHEREUM, false);
   });
+
+  it('treats a rejecting isSupported as unsupported and clears the spinner', async () => {
+    renderBase({ isSupported: () => Promise.reject(new Error('not available')) });
+
+    expect(await screen.findByText('install MetaMask')).toBeInTheDocument();
+    expect(screen.queryByText('loading')).not.toBeInTheDocument();
+    expect(mockGetAccount).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-connect when isSupported rejects', async () => {
+    renderBase({ autoConnect: true, isSupported: () => Promise.reject(new Error('not available')) });
+
+    expect(await screen.findByText('install MetaMask')).toBeInTheDocument();
+    expect(mockGetAccount).not.toHaveBeenCalled();
+  });
 });
 
 describe('ConnectBase connect', () => {
@@ -294,6 +309,9 @@ describe('ConnectBase connect', () => {
     expect(mockOnLogin).not.toHaveBeenCalled();
   });
 
+  // Declared pre-existing defect (see the pull request description): the WalletSwitchError branch does not
+  // chain the retried getAccount promise, so its result is dropped and a rejection is unhandled. The
+  // assertions below record what the code does today, not what it should do.
   it('switches the wallet and requests the account there on a wallet switch error', async () => {
     mockGetAccount
       .mockRejectedValueOnce(new WalletSwitchError(WalletType.ALBY))
@@ -462,15 +480,8 @@ describe('ConnectBase login', () => {
 
     await act(async () => resolveSignature('wallet-signature'));
 
-    expect(screen.queryByText('sign hint')).not.toBeInTheDocument();
-    expect(mockSignMessage).toHaveBeenCalledWith(
-      'message',
-      '0xabc',
-      Blockchain.ETHEREUM,
-      1,
-      2,
-      BitcoinAddressType.TAPROOT,
-    );
+    await expect(mockLogin.mock.results[0].value).resolves.toBe('wallet-signature');
+    expect(mockOnLogin).not.toHaveBeenCalled();
   });
 
   it('keeps requesting the wallet signature when sign is requested after unmount', async () => {

--- a/src/__tests__/connect-base.test.tsx
+++ b/src/__tests__/connect-base.test.tsx
@@ -135,9 +135,8 @@ describe('ConnectBase auto-connect', () => {
     expect(screen.getByText('content').parentElement).not.toHaveClass('hidden');
   });
 
-  it('does not update state when isSupported resolves after unmount', async () => {
+  it('does not auto-connect when isSupported resolves true after unmount', async () => {
     let resolveSupported: (supported: boolean) => void = () => undefined;
-    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const { unmount } = renderBase({
       autoConnect: true,
       isSupported: () => new Promise<boolean>((resolve) => (resolveSupported = resolve)),
@@ -147,15 +146,26 @@ describe('ConnectBase auto-connect', () => {
 
     unmount();
 
+    await act(async () => resolveSupported(true));
+
+    expect(mockGetAccount).not.toHaveBeenCalled();
+  });
+
+  it('does not switch to the fallback wallet when isSupported resolves false after unmount', async () => {
+    let resolveSupported: (supported: boolean) => void = () => undefined;
+    const { unmount } = renderBase({
+      autoConnect: true,
+      fallback: WalletType.WALLET_CONNECT,
+      isSupported: () => new Promise<boolean>((resolve) => (resolveSupported = resolve)),
+    });
+
+    expect(screen.getByText('loading')).toBeInTheDocument();
+
+    unmount();
+
     await act(async () => resolveSupported(false));
 
-    expect(screen.queryByText('install MetaMask')).not.toBeInTheDocument();
-    expect(mockGetAccount).not.toHaveBeenCalled();
     expect(mockOnSwitch).not.toHaveBeenCalled();
-    expect(
-      consoleError.mock.calls.some((args) => typeof args[0] === 'string' && args[0].includes('unmounted component')),
-    ).toBe(false);
-    consoleError.mockRestore();
   });
 
   it('does not connect an unsupported wallet and shows the install hint', async () => {
@@ -435,12 +445,11 @@ describe('ConnectBase login', () => {
     expect(mockOnLogin).toHaveBeenCalled();
   });
 
-  it('does not update state when signMessage resolves after unmount', async () => {
+  it('keeps the wallet signature request running after unmount', async () => {
     let resolveSignature: (signature: string) => void = () => undefined;
     mockSignMessage.mockReturnValue(new Promise<string>((resolve) => (resolveSignature = resolve)));
-    mockGetAccount.mockResolvedValue({ address: '0xabc' });
+    mockGetAccount.mockResolvedValue({ address: '0xabc', accountIndex: 1, index: 2, type: BitcoinAddressType.TAPROOT });
     mockLogin.mockImplementation((_wallet, address, _chain, sign) => sign(address, 'message'));
-    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const { unmount } = await renderReady();
 
     act(() => {
@@ -454,13 +463,17 @@ describe('ConnectBase login', () => {
     await act(async () => resolveSignature('wallet-signature'));
 
     expect(screen.queryByText('sign hint')).not.toBeInTheDocument();
-    expect(
-      consoleError.mock.calls.some((args) => typeof args[0] === 'string' && args[0].includes('unmounted component')),
-    ).toBe(false);
-    consoleError.mockRestore();
+    expect(mockSignMessage).toHaveBeenCalledWith(
+      'message',
+      '0xabc',
+      Blockchain.ETHEREUM,
+      1,
+      2,
+      BitcoinAddressType.TAPROOT,
+    );
   });
 
-  it('does not show the sign hint when sign is requested after unmount', async () => {
+  it('keeps requesting the wallet signature when sign is requested after unmount', async () => {
     let requestSign: (address: string, message: string) => Promise<string> = () => Promise.resolve('');
     mockSignMessage.mockResolvedValue('wallet-signature');
     mockGetAccount.mockResolvedValue({ address: '0xabc' });
@@ -468,7 +481,6 @@ describe('ConnectBase login', () => {
       requestSign = sign;
       return new Promise(() => undefined);
     });
-    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const { unmount } = await renderReady();
 
     act(() => {
@@ -492,9 +504,5 @@ describe('ConnectBase login', () => {
       undefined,
       undefined,
     );
-    expect(
-      consoleError.mock.calls.some((args) => typeof args[0] === 'string' && args[0].includes('unmounted component')),
-    ).toBe(false);
-    consoleError.mockRestore();
   });
 });

--- a/src/__tests__/connect-base.test.tsx
+++ b/src/__tests__/connect-base.test.tsx
@@ -216,6 +216,19 @@ describe('ConnectBase auto-connect', () => {
     expect(await screen.findByText('install MetaMask')).toBeInTheDocument();
     expect(mockGetAccount).not.toHaveBeenCalled();
   });
+
+  it('treats a synchronously throwing isSupported as unsupported', async () => {
+    renderBase({
+      autoConnect: true,
+      isSupported: () => {
+        throw new Error('no provider');
+      },
+    });
+
+    expect(await screen.findByText('install MetaMask')).toBeInTheDocument();
+    expect(screen.queryByText('loading')).not.toBeInTheDocument();
+    expect(mockGetAccount).not.toHaveBeenCalled();
+  });
 });
 
 describe('ConnectBase connect', () => {

--- a/src/__tests__/connect-base.test.tsx
+++ b/src/__tests__/connect-base.test.tsx
@@ -264,6 +264,26 @@ describe('ConnectBase connect', () => {
     expect(mockOnCancel).not.toHaveBeenCalled();
   });
 
+  it('does not log in when getAccount resolves after unmount', async () => {
+    let resolveAccount: (account: { address: string }) => void = () => undefined;
+    mockGetAccount.mockReturnValue(new Promise((resolve) => (resolveAccount = resolve)));
+    const { unmount } = await renderReady();
+
+    act(() => {
+      content().connect();
+    });
+
+    unmount();
+
+    await act(async () => resolveAccount({ address: '0xabc' }));
+
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(mockLogin).not.toHaveBeenCalled();
+    expect(mockSetSession).not.toHaveBeenCalled();
+    expect(mockSwitchBlockchain).not.toHaveBeenCalled();
+    expect(mockOnLogin).not.toHaveBeenCalled();
+  });
+
   it('switches the wallet and requests the account there on a wallet switch error', async () => {
     mockGetAccount
       .mockRejectedValueOnce(new WalletSwitchError(WalletType.ALBY))
@@ -413,5 +433,68 @@ describe('ConnectBase login', () => {
     expect(screen.queryByText('sign hint')).not.toBeInTheDocument();
     await expect(mockLogin.mock.results[0].value).resolves.toBe('wallet-signature');
     expect(mockOnLogin).toHaveBeenCalled();
+  });
+
+  it('does not update state when signMessage resolves after unmount', async () => {
+    let resolveSignature: (signature: string) => void = () => undefined;
+    mockSignMessage.mockReturnValue(new Promise<string>((resolve) => (resolveSignature = resolve)));
+    mockGetAccount.mockResolvedValue({ address: '0xabc' });
+    mockLogin.mockImplementation((_wallet, address, _chain, sign) => sign(address, 'message'));
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { unmount } = await renderReady();
+
+    act(() => {
+      content().connect();
+    });
+
+    expect(await screen.findByText('sign hint')).toBeInTheDocument();
+
+    unmount();
+
+    await act(async () => resolveSignature('wallet-signature'));
+
+    expect(screen.queryByText('sign hint')).not.toBeInTheDocument();
+    expect(
+      consoleError.mock.calls.some((args) => typeof args[0] === 'string' && args[0].includes('unmounted component')),
+    ).toBe(false);
+    consoleError.mockRestore();
+  });
+
+  it('does not show the sign hint when sign is requested after unmount', async () => {
+    let requestSign: (address: string, message: string) => Promise<string> = () => Promise.resolve('');
+    mockSignMessage.mockResolvedValue('wallet-signature');
+    mockGetAccount.mockResolvedValue({ address: '0xabc' });
+    mockLogin.mockImplementation((_wallet, _address, _chain, sign) => {
+      requestSign = sign;
+      return new Promise(() => undefined);
+    });
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { unmount } = await renderReady();
+
+    act(() => {
+      content().connect();
+    });
+
+    await waitFor(() => expect(mockLogin).toHaveBeenCalled());
+
+    unmount();
+
+    await act(async () => {
+      await requestSign('0xabc', 'message');
+    });
+
+    expect(screen.queryByText('sign hint')).not.toBeInTheDocument();
+    expect(mockSignMessage).toHaveBeenCalledWith(
+      'message',
+      '0xabc',
+      Blockchain.ETHEREUM,
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(
+      consoleError.mock.calls.some((args) => typeof args[0] === 'string' && args[0].includes('unmounted component')),
+    ).toBe(false);
+    consoleError.mockRestore();
   });
 });

--- a/src/__tests__/connect-base.test.tsx
+++ b/src/__tests__/connect-base.test.tsx
@@ -135,6 +135,29 @@ describe('ConnectBase auto-connect', () => {
     expect(screen.getByText('content').parentElement).not.toHaveClass('hidden');
   });
 
+  it('does not update state when isSupported resolves after unmount', async () => {
+    let resolveSupported: (supported: boolean) => void = () => undefined;
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { unmount } = renderBase({
+      autoConnect: true,
+      isSupported: () => new Promise<boolean>((resolve) => (resolveSupported = resolve)),
+    });
+
+    expect(screen.getByText('loading')).toBeInTheDocument();
+
+    unmount();
+
+    await act(async () => resolveSupported(false));
+
+    expect(screen.queryByText('install MetaMask')).not.toBeInTheDocument();
+    expect(mockGetAccount).not.toHaveBeenCalled();
+    expect(mockOnSwitch).not.toHaveBeenCalled();
+    expect(
+      consoleError.mock.calls.some((args) => typeof args[0] === 'string' && args[0].includes('unmounted component')),
+    ).toBe(false);
+    consoleError.mockRestore();
+  });
+
   it('does not connect an unsupported wallet and shows the install hint', async () => {
     renderBase({ autoConnect: true, isSupported: () => false });
 
@@ -223,6 +246,22 @@ describe('ConnectBase connect', () => {
     expect(mockOnCancel).toHaveBeenCalled();
     expect(content().isConnecting).toBe(false);
     expect(content().error).toBeUndefined();
+  });
+
+  it('does not call onCancel when AbortError arrives after unmount', async () => {
+    let rejectAccount: (error: Error) => void = () => undefined;
+    mockGetAccount.mockReturnValue(new Promise<never>((_resolve, reject) => (rejectAccount = reject)));
+    const { unmount } = await renderReady();
+
+    act(() => {
+      content().connect();
+    });
+
+    unmount();
+
+    await act(async () => rejectAccount(new AbortError('Forwarded to Phantom app')));
+
+    expect(mockOnCancel).not.toHaveBeenCalled();
   });
 
   it('switches the wallet and requests the account there on a wallet switch error', async () => {

--- a/src/__tests__/connect-tron-wallets.test.tsx
+++ b/src/__tests__/connect-tron-wallets.test.tsx
@@ -1,0 +1,274 @@
+// Component-level coverage for ConnectTrustTrx and ConnectTronLinkTrx: isAvailable gate,
+// auto-connect, reconnect, connect error / Back, spinner text, and signMessage forwarding.
+
+const mockTrustIsAvailable = jest.fn();
+const mockTrustConnect = jest.fn();
+const mockTrustSignMessage = jest.fn();
+const mockTronLinkIsAvailable = jest.fn();
+const mockTronLinkConnect = jest.fn();
+const mockTronLinkSignMessage = jest.fn();
+const mockOnCancel = jest.fn();
+const mockOnLogin = jest.fn();
+const mockOnSwitch = jest.fn();
+const mockLogin = jest.fn();
+const mockLogout = jest.fn();
+const mockSetSession = jest.fn();
+const mockSwitchBlockchain = jest.fn();
+
+let mockIsMobile = false;
+let mockActiveWallet: string | undefined;
+let mockSession: { address?: string } | undefined;
+
+jest.mock('@dfx.swiss/react', () => ({
+  Blockchain: { TRON: 'Tron' },
+  useAuthContext: () => ({ session: mockSession }),
+  useSessionContext: () => ({ logout: mockLogout }),
+  useUserContext: () => ({ user: undefined }),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  SpinnerSize: { SM: 'sm', LG: 'lg' },
+  StyledButton: ({ label, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {label}
+    </button>
+  ),
+  StyledButtonColor: { GRAY_OUTLINE: 'gray-outline' },
+  StyledButtonWidth: { MIN: 'min', SM: 'sm' },
+  StyledLoadingSpinner: () => null,
+  StyledVerticalStack: ({ children }: any) => <div>{children}</div>,
+  StyledLink: ({ label }: any) => <a>{label}</a>,
+  DfxIcon: () => null,
+  IconVariant: { SIGNATURE_POPUP: 'signature-popup' },
+}));
+
+jest.mock('react-i18next', () => ({
+  Trans: ({ children }: any) => <>{children}</>,
+}));
+
+jest.mock('react-device-detect', () => ({
+  get isMobile() {
+    return mockIsMobile;
+  },
+}));
+
+jest.mock('../hooks/report-displayed-error.hook', () => ({
+  useReportDisplayedError: () => undefined,
+}));
+
+jest.mock('../contexts/settings.context', () => ({
+  useSettingsContext: () => ({
+    translate: (_ns: string, key: string) => key,
+  }),
+}));
+
+jest.mock('../contexts/wallet.context', () => {
+  const WalletBlockchains: Record<string, string[] | undefined> = {
+    TrustTrx: ['Tron'],
+    TronLinkTrx: ['Tron'],
+  };
+
+  return {
+    WalletType: { TRUST_TRX: 'TrustTrx', TRONLINK_TRX: 'TronLinkTrx' },
+    WalletBlockchains,
+    supportsBlockchain: (wallet: string, blockchain: string) => {
+      const chains = WalletBlockchains[wallet];
+      return !chains || chains.includes(blockchain);
+    },
+    useWalletContext: () => ({
+      login: mockLogin,
+      setSession: mockSetSession,
+      switchBlockchain: mockSwitchBlockchain,
+      activeWallet: mockActiveWallet,
+    }),
+  };
+});
+
+jest.mock('src/hooks/wallets/trust-trx.hook', () => ({
+  useTrustTrx: () => ({
+    isAvailable: (...args: unknown[]) => mockTrustIsAvailable(...args),
+    connect: (...args: unknown[]) => mockTrustConnect(...args),
+    signMessage: (...args: unknown[]) => mockTrustSignMessage(...args),
+  }),
+}));
+
+jest.mock('src/hooks/wallets/tronlink-trx.hook', () => ({
+  useTronLinkTrx: () => ({
+    isAvailable: (...args: unknown[]) => mockTronLinkIsAvailable(...args),
+    connect: (...args: unknown[]) => mockTronLinkConnect(...args),
+    signMessage: (...args: unknown[]) => mockTronLinkSignMessage(...args),
+  }),
+}));
+
+import { Blockchain } from '@dfx.swiss/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { createRef } from 'react';
+import ConnectTronLinkTrx from '../components/home/wallet/connect-tronlink-trx';
+import ConnectTrustTrx from '../components/home/wallet/connect-trust-trx';
+import { WalletType } from '../contexts/wallet.context';
+
+describe.each([
+  {
+    name: 'ConnectTrustTrx',
+    Component: ConnectTrustTrx,
+    walletType: WalletType.TRUST_TRX,
+    walletName: 'Trust',
+    confirmText: 'Please confirm the connection in your Trust browser extension.',
+    mockIsAvailable: mockTrustIsAvailable,
+    mockConnect: mockTrustConnect,
+    mockSignMessage: mockTrustSignMessage,
+  },
+  {
+    name: 'ConnectTronLinkTrx',
+    Component: ConnectTronLinkTrx,
+    walletType: WalletType.TRONLINK_TRX,
+    walletName: 'TronLink',
+    confirmText: 'Please confirm the connection in your TronLink browser extension.',
+    mockIsAvailable: mockTronLinkIsAvailable,
+    mockConnect: mockTronLinkConnect,
+    mockSignMessage: mockTronLinkSignMessage,
+  },
+])('$name', ({ Component, walletType, walletName, confirmText, mockIsAvailable, mockConnect, mockSignMessage }) => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsMobile = false;
+    mockActiveWallet = undefined;
+    mockSession = undefined;
+    mockIsAvailable.mockResolvedValue(true);
+    mockConnect.mockResolvedValue('TronAddress');
+    mockSignMessage.mockResolvedValue('signature');
+    mockLogin.mockResolvedValue(undefined);
+    mockLogout.mockResolvedValue(undefined);
+    mockSwitchBlockchain.mockResolvedValue(undefined);
+  });
+
+  function renderComponent(isConnect = false) {
+    return render(
+      <Component
+        rootRef={createRef<HTMLDivElement>()}
+        wallet={walletType}
+        blockchain={Blockchain.TRON}
+        isConnect={isConnect}
+        onLogin={mockOnLogin}
+        onCancel={mockOnCancel}
+        onSwitch={mockOnSwitch}
+      />,
+    );
+  }
+
+  it('shows the install hint and does not connect when isAvailable resolves false', async () => {
+    mockIsAvailable.mockResolvedValue(false);
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    await waitFor(() => expect(screen.getByText(`Please install ${walletName}!`)).toBeInTheDocument());
+    expect(mockConnect).not.toHaveBeenCalled();
+    expect(mockOnSwitch).not.toHaveBeenCalled();
+  });
+
+  it('switches to the mobile fallback when isAvailable is false on mobile', async () => {
+    mockIsMobile = true;
+    mockIsAvailable.mockResolvedValue(false);
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    await waitFor(() => expect(mockOnSwitch).toHaveBeenCalledWith(walletType));
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it('auto-connects and logs in with the returned address when isAvailable is true', async () => {
+    await act(async () => {
+      renderComponent();
+    });
+
+    await waitFor(() =>
+      expect(mockLogin).toHaveBeenCalledWith(
+        walletType,
+        'TronAddress',
+        Blockchain.TRON,
+        expect.any(Function),
+        undefined,
+      ),
+    );
+    expect(mockConnect).toHaveBeenCalled();
+    expect(mockOnLogin).toHaveBeenCalled();
+  });
+
+  it('reuses the session address on reconnect and does not call connect', async () => {
+    mockActiveWallet = walletType;
+    mockSession = { address: 'SessionAddress' };
+
+    await act(async () => {
+      renderComponent(true);
+    });
+
+    await waitFor(() =>
+      expect(mockLogin).toHaveBeenCalledWith(
+        walletType,
+        'SessionAddress',
+        Blockchain.TRON,
+        expect.any(Function),
+        undefined,
+      ),
+    );
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it('calls connect on reconnect when the session has no address', async () => {
+    mockActiveWallet = walletType;
+    mockSession = undefined;
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockLogin).toHaveBeenCalledWith(
+        walletType,
+        'TronAddress',
+        Blockchain.TRON,
+        expect.any(Function),
+        undefined,
+      ),
+    );
+  });
+
+  it('renders the connect error and Back calls onCancel when connect rejects', async () => {
+    mockConnect.mockRejectedValue(new Error('User rejected'));
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    await waitFor(() => expect(screen.getByText('User rejected')).toBeInTheDocument());
+    expect(screen.getByText('Connection failed!')).toBeInTheDocument();
+
+    screen.getByText('Back').click();
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+
+  it('shows the confirm-connection spinner text while connect is pending', async () => {
+    mockConnect.mockReturnValue(new Promise(() => undefined));
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    await waitFor(() => expect(screen.getByText(confirmText)).toBeInTheDocument());
+  });
+
+  it('forwards signMessage through the login signer callback', async () => {
+    mockLogin.mockImplementation((_wallet, _address, _blockchain, signer) => signer('some-address', 'some-message'));
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    await waitFor(() => expect(mockSignMessage).toHaveBeenCalledWith('some-address', 'some-message'));
+  });
+});

--- a/src/components/home/connect-base.tsx
+++ b/src/components/home/connect-base.tsx
@@ -61,7 +61,7 @@ export function ConnectBase({
     setShowInstallHint(!supported);
     setIsLoading(false);
 
-    if (autoConnect) connect();
+    if (autoConnect && supported) connect();
   }
 
   async function connect(chain?: Blockchain) {

--- a/src/components/home/connect-base.tsx
+++ b/src/components/home/connect-base.tsx
@@ -83,8 +83,10 @@ export function ConnectBase({
     if (!usedChain) throw new Error('No blockchain');
 
     await getAccount(wallet, usedChain, activeWallet === wallet)
-      .then((a) => doLogin({ ...a, blockchain: usedChain }))
-      .then(onLogin)
+      .then((a) => (isMounted.current ? doLogin({ ...a, blockchain: usedChain }) : undefined))
+      .then(() => {
+        if (isMounted.current) onLogin();
+      })
       .catch((e) => {
         if (!isMounted.current) return;
 
@@ -140,10 +142,11 @@ export function ConnectBase({
     index?: number,
     addressType?: BitcoinAddressType,
   ): Promise<string> {
-    setShowSignHint(true);
-    return signMessage(message, address, blockchain, accountIndex, index, addressType).finally(() =>
-      setShowSignHint(false),
-    );
+    if (isMounted.current) setShowSignHint(true);
+
+    return signMessage(message, address, blockchain, accountIndex, index, addressType).finally(() => {
+      if (isMounted.current) setShowSignHint(false);
+    });
   }
 
   const contentOverride = isLoading ? (

--- a/src/components/home/connect-base.tsx
+++ b/src/components/home/connect-base.tsx
@@ -1,6 +1,6 @@
 import { Blockchain, useAuthContext, useSessionContext } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { WalletSwitchError } from 'src/util/wallet-switch-error';
 import { BitcoinAddressType } from '../../config/key-path';
 import { WalletBlockchains, WalletType, supportsBlockchain, useWalletContext } from '../../contexts/wallet.context';
@@ -50,12 +50,21 @@ export function ConnectBase({
   const [isConnecting, setIsConnecting] = useState(false);
   const [connectError, setConnectError] = useState<string>();
 
+  const isMounted = useRef(true);
+
   useEffect(() => {
+    isMounted.current = true;
     init();
+
+    return () => {
+      isMounted.current = false;
+    };
   }, []);
 
   async function init() {
     const supported = await isSupported();
+    if (!isMounted.current) return;
+
     if (!supported && fallback) onSwitch(fallback);
 
     setShowInstallHint(!supported);
@@ -77,6 +86,8 @@ export function ConnectBase({
       .then((a) => doLogin({ ...a, blockchain: usedChain }))
       .then(onLogin)
       .catch((e) => {
+        if (!isMounted.current) return;
+
         setIsConnecting(false);
 
         if (e instanceof AbortError) {

--- a/src/components/home/connect-base.tsx
+++ b/src/components/home/connect-base.tsx
@@ -62,7 +62,13 @@ export function ConnectBase({
   }, []);
 
   async function init() {
-    const supported = await isSupported();
+    let supported = false;
+    try {
+      supported = await isSupported();
+    } catch {
+      supported = false;
+    }
+
     if (!isMounted.current) return;
 
     if (!supported && fallback) onSwitch(fallback);

--- a/src/components/home/wallet/connect-alby.tsx
+++ b/src/components/home/wallet/connect-alby.tsx
@@ -19,7 +19,7 @@ import { Account, ConnectContentProps, ConnectError, ConnectProps } from '../con
 
 export default function ConnectAlby(props: ConnectProps): JSX.Element {
   const { redirectPath, params: appParams } = useAppHandlingContext();
-  const { isInstalled, enable, signMessage } = useAlby();
+  const { isAvailable, enable, signMessage } = useAlby();
 
   async function getAccount(): Promise<Account> {
     const account = await enable();
@@ -64,7 +64,7 @@ export default function ConnectAlby(props: ConnectProps): JSX.Element {
 
   return (
     <ConnectBase
-      isSupported={isInstalled}
+      isSupported={isAvailable}
       getAccount={getAccount}
       signMessage={(msg) => signMessage(msg)}
       renderContent={Content}

--- a/src/components/home/wallet/connect-tronlink-trx.tsx
+++ b/src/components/home/wallet/connect-tronlink-trx.tsx
@@ -14,7 +14,7 @@ import { ConnectBase } from '../connect-base';
 import { Account, ConnectContentProps, ConnectError, ConnectProps } from '../connect-shared';
 
 export default function ConnectTronLinkTrx(props: Readonly<ConnectProps>): JSX.Element {
-  const { isInstalled, connect, signMessage } = useTronLinkTrx();
+  const { isAvailable, connect, signMessage } = useTronLinkTrx();
   const { session } = useAuthContext();
 
   async function getAccount(_w: WalletType, _b: Blockchain, isReconnect: boolean): Promise<Account> {
@@ -27,7 +27,7 @@ export default function ConnectTronLinkTrx(props: Readonly<ConnectProps>): JSX.E
 
   return (
     <ConnectBase
-      isSupported={isInstalled}
+      isSupported={isAvailable}
       fallback={isMobile ? WalletType.TRONLINK_TRX : undefined}
       getAccount={getAccount}
       signMessage={(msg, addr) => signMessage(addr, msg)}

--- a/src/components/home/wallet/connect-trust-trx.tsx
+++ b/src/components/home/wallet/connect-trust-trx.tsx
@@ -14,7 +14,7 @@ import { ConnectBase } from '../connect-base';
 import { Account, ConnectContentProps, ConnectError, ConnectProps } from '../connect-shared';
 
 export default function ConnectTrustTrx(props: Readonly<ConnectProps>): JSX.Element {
-  const { isInstalled, connect, signMessage } = useTrustTrx();
+  const { isAvailable, connect, signMessage } = useTrustTrx();
   const { session } = useAuthContext();
 
   async function getAccount(_w: WalletType, _b: Blockchain, isReconnect: boolean): Promise<Account> {
@@ -27,7 +27,7 @@ export default function ConnectTrustTrx(props: Readonly<ConnectProps>): JSX.Elem
 
   return (
     <ConnectBase
-      isSupported={isInstalled}
+      isSupported={isAvailable}
       fallback={isMobile ? WalletType.TRUST_TRX : undefined}
       getAccount={getAccount}
       signMessage={(msg, addr) => signMessage(addr, msg)}

--- a/src/hooks/wallets/__tests__/alby.hook.test.ts
+++ b/src/hooks/wallets/__tests__/alby.hook.test.ts
@@ -1,0 +1,215 @@
+// useAlby: WebLN detection (including late extension injection via isAvailable), enable,
+// signMessage, sendPayment, and AbortError mapping for user-rejection paths.
+
+const mockDelay = jest.fn();
+jest.mock('../../../util/utils', () => ({ delay: (...args: unknown[]) => mockDelay(...args) }));
+
+import { act, renderHook } from '@testing-library/react';
+import { AbortError } from '../../../util/abort-error';
+import { useAlby } from '../alby.hook';
+
+function setWebln(webln: unknown) {
+  (window as any).webln = webln;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDelay.mockImplementation(() => Promise.resolve());
+});
+
+afterEach(() => {
+  delete (window as any).webln;
+});
+
+describe('useAlby isInstalled', () => {
+  it('returns true when window.webln is present', () => {
+    setWebln({});
+    const { result } = renderHook(() => useAlby());
+    expect(result.current.isInstalled()).toBe(true);
+  });
+
+  it('returns false when window.webln is absent', () => {
+    const { result } = renderHook(() => useAlby());
+    expect(result.current.isInstalled()).toBe(false);
+  });
+});
+
+describe('useAlby isAvailable', () => {
+  it('resolves true immediately when window.webln is already present', async () => {
+    setWebln({});
+    const { result } = renderHook(() => useAlby());
+
+    await expect(result.current.isAvailable()).resolves.toBe(true);
+  });
+
+  it('resolves true when window.webln appears after a couple of delay attempts', async () => {
+    let calls = 0;
+    mockDelay.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 2) {
+        setWebln({});
+      }
+    });
+
+    const { result } = renderHook(() => useAlby());
+
+    await expect(result.current.isAvailable()).resolves.toBe(true);
+    expect(mockDelay).toHaveBeenCalled();
+  });
+
+  it('resolves false after 10 attempts when window.webln never appears', async () => {
+    const { result } = renderHook(() => useAlby());
+
+    await expect(result.current.isAvailable()).resolves.toBe(false);
+    expect(mockDelay).toHaveBeenCalledTimes(10);
+    expect(mockDelay.mock.calls.every((call) => call[0] === 0.01)).toBe(true);
+  });
+});
+
+describe('useAlby enable', () => {
+  it('enables WebLN, returns getInfo, and flips isEnabled after rerender', async () => {
+    const info = { node: { alias: 'getalby.com' } };
+    const enable = jest.fn().mockResolvedValue(undefined);
+    const getInfo = jest.fn().mockResolvedValue(info);
+    setWebln({ enable, getInfo });
+
+    const { result, rerender } = renderHook(() => useAlby());
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.enable();
+    });
+
+    expect(resolved).toEqual(info);
+    expect(enable).toHaveBeenCalled();
+    expect(getInfo).toHaveBeenCalled();
+
+    rerender();
+    expect(result.current.isEnabled).toBe(true);
+  });
+
+  it('rejects with Timeout when window.webln never appears and leaves isEnabled false', async () => {
+    const { result, rerender } = renderHook(() => useAlby());
+
+    await expect(result.current.enable()).rejects.toMatchObject({ message: 'Timeout' });
+    rerender();
+    expect(result.current.isEnabled).toBe(false);
+  });
+
+  it('maps User rejected to AbortError', async () => {
+    setWebln({
+      enable: jest.fn().mockRejectedValue(new Error('User rejected')),
+      getInfo: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useAlby());
+
+    await expect(result.current.enable()).rejects.toEqual(expect.any(AbortError));
+    await expect(result.current.enable()).rejects.toMatchObject({ message: 'User cancelled' });
+  });
+
+  it('maps Permission denied to AbortError', async () => {
+    setWebln({
+      enable: jest.fn().mockRejectedValue(new Error('Permission denied by user')),
+      getInfo: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useAlby());
+
+    await expect(result.current.enable()).rejects.toEqual(expect.any(AbortError));
+    await expect(result.current.enable()).rejects.toMatchObject({ message: 'User cancelled' });
+  });
+
+  it('rethrows other errors as-is', async () => {
+    setWebln({
+      enable: jest.fn().mockRejectedValue(new Error('Something else broke')),
+      getInfo: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useAlby());
+
+    let caught: unknown;
+    try {
+      await result.current.enable();
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(AbortError);
+    expect((caught as Error).message).toBe('Something else broke');
+  });
+});
+
+describe('useAlby signMessage', () => {
+  it('returns the signature from webln.signMessage', async () => {
+    setWebln({
+      signMessage: jest.fn().mockResolvedValue({ signature: 'sig123' }),
+    });
+
+    const { result } = renderHook(() => useAlby());
+
+    await expect(result.current.signMessage('msg')).resolves.toBe('sig123');
+  });
+
+  it('maps User rejected to AbortError', async () => {
+    setWebln({
+      signMessage: jest.fn().mockRejectedValue(new Error('User rejected')),
+    });
+
+    const { result } = renderHook(() => useAlby());
+
+    await expect(result.current.signMessage('msg')).rejects.toEqual(expect.any(AbortError));
+    await expect(result.current.signMessage('msg')).rejects.toMatchObject({ message: 'User cancelled' });
+  });
+});
+
+describe('useAlby sendPayment', () => {
+  it('calls enable first when not yet enabled, then sendPayment', async () => {
+    const paymentResult = { preimage: 'pre' };
+    const enable = jest.fn().mockResolvedValue(undefined);
+    const getInfo = jest.fn().mockResolvedValue({ node: { alias: 'getalby.com' } });
+    const sendPayment = jest.fn().mockResolvedValue(paymentResult);
+    setWebln({ enable, getInfo, sendPayment });
+
+    const { result } = renderHook(() => useAlby());
+    expect(result.current.isEnabled).toBe(false);
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.sendPayment('lnbcrequest');
+    });
+
+    expect(enable).toHaveBeenCalled();
+    expect(sendPayment).toHaveBeenCalledWith('lnbcrequest');
+    expect(resolved).toEqual(paymentResult);
+  });
+
+  it('skips enable when already enabled', async () => {
+    const paymentResult = { preimage: 'pre2' };
+    const enable = jest.fn().mockResolvedValue(undefined);
+    const getInfo = jest.fn().mockResolvedValue({ node: { alias: 'getalby.com' } });
+    const sendPayment = jest.fn().mockResolvedValue(paymentResult);
+    setWebln({ enable, getInfo, sendPayment });
+
+    const { result, rerender } = renderHook(() => useAlby());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    rerender();
+    expect(result.current.isEnabled).toBe(true);
+
+    enable.mockClear();
+    getInfo.mockClear();
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.sendPayment('lnbcrequest2');
+    });
+
+    expect(enable).not.toHaveBeenCalled();
+    expect(sendPayment).toHaveBeenCalledWith('lnbcrequest2');
+    expect(resolved).toEqual(paymentResult);
+  });
+});

--- a/src/hooks/wallets/__tests__/alby.hook.test.ts
+++ b/src/hooks/wallets/__tests__/alby.hook.test.ts
@@ -64,6 +64,21 @@ describe('useAlby isAvailable', () => {
     expect(mockDelay).toHaveBeenCalledTimes(10);
     expect(mockDelay.mock.calls.every((call) => call[0] === 0.01)).toBe(true);
   });
+
+  it('resolves true when window.webln appears during the last delay', async () => {
+    let calls = 0;
+    mockDelay.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 10) {
+        setWebln({});
+      }
+    });
+
+    const { result } = renderHook(() => useAlby());
+
+    await expect(result.current.isAvailable()).resolves.toBe(true);
+    expect(mockDelay).toHaveBeenCalledTimes(10);
+  });
 });
 
 describe('useAlby enable', () => {
@@ -94,6 +109,33 @@ describe('useAlby enable', () => {
     await expect(result.current.enable()).rejects.toMatchObject({ message: 'Timeout' });
     rerender();
     expect(result.current.isEnabled).toBe(false);
+  });
+
+  it('succeeds when window.webln appears during the last delay', async () => {
+    const info = { node: { alias: 'getalby.com' } };
+    const enable = jest.fn().mockResolvedValue(undefined);
+    const getInfo = jest.fn().mockResolvedValue(info);
+
+    let calls = 0;
+    mockDelay.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 10) {
+        setWebln({ enable, getInfo });
+      }
+    });
+
+    const { result, rerender } = renderHook(() => useAlby());
+
+    let resolved: unknown;
+    await act(async () => {
+      resolved = await result.current.enable();
+    });
+
+    expect(resolved).toEqual(info);
+    expect(mockDelay).toHaveBeenCalledTimes(10);
+
+    rerender();
+    expect(result.current.isEnabled).toBe(true);
   });
 
   it('maps User rejected to AbortError', async () => {

--- a/src/hooks/wallets/__tests__/solana-wallets.hook.test.ts
+++ b/src/hooks/wallets/__tests__/solana-wallets.hook.test.ts
@@ -21,6 +21,7 @@ const mockAdapterCreated = jest.fn();
 const mockCreateCoinTransaction = jest.fn();
 const mockCreateTokenTransaction = jest.fn();
 const mockBroadcastTransaction = jest.fn();
+const mockDelay = jest.fn();
 
 jest.mock('@dfx.swiss/react', () => ({ AssetType: { COIN: 'Coin', TOKEN: 'Token' } }));
 
@@ -49,10 +50,13 @@ jest.mock('../../solana.hook', () => ({
   }),
 }));
 
+jest.mock('../../../util/utils', () => ({ delay: (...args: unknown[]) => mockDelay(...args) }));
+
 import { Asset, AssetType } from '@dfx.swiss/react';
 import { WalletReadyState } from '@solana/wallet-adapter-base';
 import { renderHook } from '@testing-library/react';
 import BigNumber from 'bignumber.js';
+import { AbortError } from '../../../util/abort-error';
 import { usePhantom } from '../phantom.hook';
 import { useTrustSol } from '../trust-sol.hook';
 
@@ -60,6 +64,7 @@ import { useTrustSol } from '../trust-sol.hook';
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockDelay.mockResolvedValue(undefined);
 
   for (const adapter of [mockPhantomAdapter, mockTrustAdapter]) {
     adapter.readyState = WalletReadyState.NotDetected;
@@ -93,6 +98,28 @@ describe('useTrustSol isInstalled', () => {
     mockTrustAdapter.readyState = readyState;
 
     expect(renderHook(() => useTrustSol()).result.current.isInstalled()).toBe(expected);
+  });
+});
+
+describe('usePhantom connect redirect', () => {
+  it('aborts after forwarding to the Phantom app when Loadable and no public key', async () => {
+    mockPhantomAdapter.readyState = WalletReadyState.Loadable;
+    mockPhantomAdapter.connect.mockResolvedValue(undefined);
+
+    const connectPromise = renderHook(() => usePhantom()).result.current.connect();
+    await expect(connectPromise).rejects.toBeInstanceOf(AbortError);
+    await expect(connectPromise).rejects.toHaveProperty('message', 'Forwarded to Phantom app');
+    expect(mockDelay).toHaveBeenCalledWith(5);
+  });
+});
+
+describe('useTrustSol connect with Loadable', () => {
+  it('still fails with no public key when Loadable', async () => {
+    mockTrustAdapter.readyState = WalletReadyState.Loadable;
+    mockTrustAdapter.connect.mockResolvedValue(undefined);
+
+    await expect(renderHook(() => useTrustSol()).result.current.connect()).rejects.toThrow('No public key found');
+    expect(mockDelay).not.toHaveBeenCalled();
   });
 });
 

--- a/src/hooks/wallets/__tests__/solana-wallets.hook.test.ts
+++ b/src/hooks/wallets/__tests__/solana-wallets.hook.test.ts
@@ -1,0 +1,205 @@
+// Hooks for the Solana browser wallets (Phantom, Trust): wallet detection, which must match what the
+// adapter's connect can actually reach, and the connect, sign and transaction calls around the adapter.
+
+import { TextEncoder as NodeTextEncoder } from 'util';
+
+interface MockSolanaAdapter {
+  readyState: string;
+  publicKey: { toBase58: () => string } | null;
+  connect: jest.Mock;
+  signMessage: jest.Mock;
+  signTransaction: jest.Mock;
+}
+
+function createMockAdapter(): MockSolanaAdapter {
+  return { readyState: '', publicKey: null, connect: jest.fn(), signMessage: jest.fn(), signTransaction: jest.fn() };
+}
+
+const mockPhantomAdapter = createMockAdapter();
+const mockTrustAdapter = createMockAdapter();
+const mockAdapterCreated = jest.fn();
+const mockCreateCoinTransaction = jest.fn();
+const mockCreateTokenTransaction = jest.fn();
+const mockBroadcastTransaction = jest.fn();
+
+jest.mock('@dfx.swiss/react', () => ({ AssetType: { COIN: 'Coin', TOKEN: 'Token' } }));
+
+// plain constructor functions: CRA resets jest.fn implementations before every test
+jest.mock('@solana/wallet-adapter-phantom', () => ({
+  PhantomWalletAdapter: function PhantomWalletAdapter() {
+    mockAdapterCreated('Phantom');
+    return mockPhantomAdapter;
+  },
+}));
+
+jest.mock('@solana/wallet-adapter-trust', () => ({
+  TrustWalletAdapter: function TrustWalletAdapter() {
+    mockAdapterCreated('Trust');
+    return mockTrustAdapter;
+  },
+}));
+
+jest.mock('ethers', () => ({ encodeBase58: (bytes: Uint8Array) => `base58(${Array.from(bytes).join(',')})` }));
+
+jest.mock('../../solana.hook', () => ({
+  useSolana: () => ({
+    createCoinTransaction: mockCreateCoinTransaction,
+    createTokenTransaction: mockCreateTokenTransaction,
+    broadcastTransaction: mockBroadcastTransaction,
+  }),
+}));
+
+import { Asset, AssetType } from '@dfx.swiss/react';
+import { WalletReadyState } from '@solana/wallet-adapter-base';
+import { renderHook } from '@testing-library/react';
+import BigNumber from 'bignumber.js';
+import { usePhantom } from '../phantom.hook';
+import { useTrustSol } from '../trust-sol.hook';
+
+(global as any).TextEncoder ??= NodeTextEncoder;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  for (const adapter of [mockPhantomAdapter, mockTrustAdapter]) {
+    adapter.readyState = WalletReadyState.NotDetected;
+    adapter.publicKey = null;
+    adapter.connect.mockReset();
+    adapter.signMessage.mockReset();
+    adapter.signTransaction.mockReset();
+  }
+});
+
+describe('usePhantom isInstalled', () => {
+  it.each([
+    [WalletReadyState.Installed, true],
+    [WalletReadyState.Loadable, true],
+    [WalletReadyState.NotDetected, false],
+    [WalletReadyState.Unsupported, false],
+  ])('treats the adapter state %s as %p', (readyState, expected) => {
+    mockPhantomAdapter.readyState = readyState;
+
+    expect(renderHook(() => usePhantom()).result.current.isInstalled()).toBe(expected);
+  });
+});
+
+describe('useTrustSol isInstalled', () => {
+  it.each([
+    [WalletReadyState.Installed, true],
+    [WalletReadyState.Loadable, false],
+    [WalletReadyState.NotDetected, false],
+    [WalletReadyState.Unsupported, false],
+  ])('treats the adapter state %s as %p', (readyState, expected) => {
+    mockTrustAdapter.readyState = readyState;
+
+    expect(renderHook(() => useTrustSol()).result.current.isInstalled()).toBe(expected);
+  });
+});
+
+describe.each([
+  { name: 'usePhantom', useHook: usePhantom, walletName: 'Phantom', adapter: mockPhantomAdapter },
+  { name: 'useTrustSol', useHook: useTrustSol, walletName: 'Trust', adapter: mockTrustAdapter },
+])('$name', ({ useHook, walletName, adapter }) => {
+  function setup() {
+    return renderHook(() => useHook()).result.current;
+  }
+
+  it('creates its adapter once', () => {
+    const { rerender } = renderHook(() => useHook());
+    rerender();
+
+    expect(mockAdapterCreated).toHaveBeenCalledTimes(1);
+    expect(mockAdapterCreated).toHaveBeenCalledWith(walletName);
+  });
+
+  it('reads the adapter state when asked, so a wallet detected later counts', () => {
+    const { isInstalled } = setup();
+    expect(isInstalled()).toBe(false);
+
+    adapter.readyState = WalletReadyState.Installed;
+
+    expect(isInstalled()).toBe(true);
+  });
+
+  describe('connect', () => {
+    it('returns the public key of the connected wallet', async () => {
+      adapter.connect.mockImplementation(async () => {
+        adapter.publicKey = { toBase58: () => 'SolanaAddress' };
+      });
+
+      await expect(setup().connect()).resolves.toBe('SolanaAddress');
+    });
+
+    it('fails when the wallet provides no public key', async () => {
+      adapter.connect.mockResolvedValue(undefined);
+
+      await expect(setup().connect()).rejects.toThrow('No public key found');
+    });
+
+    it('rethrows the wallet error message', async () => {
+      adapter.connect.mockRejectedValue(new Error('User rejected the request.'));
+
+      await expect(setup().connect()).rejects.toThrow('User rejected the request.');
+    });
+
+    it('uses a generic message when the wallet error has none', async () => {
+      adapter.connect.mockRejectedValue({});
+
+      await expect(setup().connect()).rejects.toThrow('An unexpected error occurred.');
+    });
+  });
+
+  describe('signMessage', () => {
+    it('signs the encoded message and returns the signature in base58', async () => {
+      adapter.signMessage.mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+      await expect(setup().signMessage('SolanaAddress', 'hi')).resolves.toBe('base58(1,2,3)');
+      expect(Array.from(adapter.signMessage.mock.calls[0][0])).toEqual([104, 105]);
+    });
+
+    it('rethrows the signing error message', async () => {
+      adapter.signMessage.mockRejectedValue(new Error('Signing rejected'));
+
+      await expect(setup().signMessage('SolanaAddress', 'hi')).rejects.toThrow('Signing rejected');
+    });
+  });
+
+  describe('createTransaction', () => {
+    const amount = new BigNumber(1.5);
+
+    beforeEach(() => {
+      mockCreateCoinTransaction.mockResolvedValue('coin-transaction');
+      mockCreateTokenTransaction.mockResolvedValue('token-transaction');
+      adapter.signTransaction.mockImplementation(async (transaction: string) => `signed-${transaction}`);
+      mockBroadcastTransaction.mockResolvedValue('transaction-id');
+    });
+
+    it('signs and broadcasts a coin transaction', async () => {
+      const asset = { type: AssetType.COIN } as Asset;
+
+      await expect(setup().createTransaction(amount, asset, 'from', 'to')).resolves.toBe('transaction-id');
+
+      expect(mockCreateCoinTransaction).toHaveBeenCalledWith('from', 'to', amount);
+      expect(mockCreateTokenTransaction).not.toHaveBeenCalled();
+      expect(mockBroadcastTransaction).toHaveBeenCalledWith('signed-coin-transaction');
+    });
+
+    it('signs and broadcasts a token transaction', async () => {
+      const asset = { type: AssetType.TOKEN } as Asset;
+
+      await expect(setup().createTransaction(amount, asset, 'from', 'to')).resolves.toBe('transaction-id');
+
+      expect(mockCreateTokenTransaction).toHaveBeenCalledWith('from', 'to', asset, amount);
+      expect(mockCreateCoinTransaction).not.toHaveBeenCalled();
+      expect(mockBroadcastTransaction).toHaveBeenCalledWith('signed-token-transaction');
+    });
+
+    it('rethrows the transaction error message', async () => {
+      mockBroadcastTransaction.mockRejectedValue(new Error('Blockhash not found'));
+
+      await expect(setup().createTransaction(amount, { type: AssetType.COIN } as Asset, 'from', 'to')).rejects.toThrow(
+        'Blockhash not found',
+      );
+    });
+  });
+});

--- a/src/hooks/wallets/__tests__/tron-wallets.hook.test.ts
+++ b/src/hooks/wallets/__tests__/tron-wallets.hook.test.ts
@@ -163,6 +163,22 @@ describe.each([
     expect(mockDelay).toHaveBeenCalledTimes(20);
     expect(mockDelay.mock.calls.every((call) => call[0] === 0.1)).toBe(true);
   });
+
+  it('resolves true when the wallet appears during the last delay', async () => {
+    let calls = 0;
+    mockDelay.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 20) {
+        mockSupport.mockReturnValue(true);
+      }
+    });
+
+    const { result } = renderHook(() => useHook());
+
+    await expect(result.current.isAvailable()).resolves.toBe(true);
+    expect(mockDelay).toHaveBeenCalledTimes(20);
+    expect(mockDelay.mock.calls.every((call) => call[0] === 0.1)).toBe(true);
+  });
 });
 
 describe.each([
@@ -250,6 +266,22 @@ describe.each([
 
       await expect(setup().connect()).rejects.toThrow('The user rejected connection.');
       expect(mockDelay).not.toHaveBeenCalled();
+    });
+
+    it('rethrows the original error when the redirect predicate flips during connect', async () => {
+      mockSupport.mockReturnValue(true);
+      mockIsInMobileBrowser.mockReturnValue(false);
+      mockInWalletApp.mockReturnValue(false);
+
+      adapter.connect.mockImplementation(async () => {
+        mockSupport.mockReturnValue(false);
+        mockIsInMobileBrowser.mockReturnValue(mobileMatch);
+        mockInWalletApp.mockReturnValue(false);
+        throw new Error('The user rejected connection.');
+      });
+
+      await expect(setup().connect()).rejects.toThrow('The user rejected connection.');
+      expect(mockDelay).not.toHaveBeenCalledWith(5);
     });
   });
 

--- a/src/hooks/wallets/__tests__/tron-wallets.hook.test.ts
+++ b/src/hooks/wallets/__tests__/tron-wallets.hook.test.ts
@@ -31,8 +31,8 @@ jest.mock('@tronweb3/tronwallet-abstract-adapter', () => ({ isInMobileBrowser: (
 
 // plain constructor functions: CRA resets jest.fn implementations before every test
 jest.mock('@tronweb3/tronwallet-adapter-trust', () => ({
-  TrustAdapter: function TrustAdapter() {
-    mockAdapterCreated('Trust');
+  TrustAdapter: function TrustAdapter(config?: unknown) {
+    mockAdapterCreated('Trust', config);
     return mockTrustAdapter;
   },
   supportTrust: () => mockSupportTrust(),
@@ -40,8 +40,8 @@ jest.mock('@tronweb3/tronwallet-adapter-trust', () => ({
 }));
 
 jest.mock('@tronweb3/tronwallet-adapter-tronlink', () => ({
-  TronLinkAdapter: function TronLinkAdapter() {
-    mockAdapterCreated('TronLink');
+  TronLinkAdapter: function TronLinkAdapter(config?: unknown) {
+    mockAdapterCreated('TronLink', config);
     return mockTronLinkAdapter;
   },
   supportTronLink: () => mockSupportTronLink(),
@@ -77,6 +77,16 @@ beforeEach(() => {
     adapter.signMessage.mockReset();
     adapter.signTransaction.mockReset();
   }
+});
+
+describe('adapter construction', () => {
+  it('gives Trust a checkTimeout that outlives isAvailable, and leaves TronLink on the package default', () => {
+    renderHook(() => useTrustTrx());
+    renderHook(() => useTronLinkTrx());
+
+    expect(mockAdapterCreated).toHaveBeenCalledWith('Trust', { checkTimeout: 3000 });
+    expect(mockAdapterCreated).toHaveBeenCalledWith('TronLink', undefined);
+  });
 });
 
 describe.each([
@@ -210,7 +220,7 @@ describe.each([
     rerender();
 
     expect(mockAdapterCreated).toHaveBeenCalledTimes(1);
-    expect(mockAdapterCreated).toHaveBeenCalledWith(walletName);
+    expect(mockAdapterCreated.mock.calls[0][0]).toBe(walletName);
   });
 
   describe('connect', () => {

--- a/src/hooks/wallets/__tests__/tron-wallets.hook.test.ts
+++ b/src/hooks/wallets/__tests__/tron-wallets.hook.test.ts
@@ -23,6 +23,7 @@ const mockIsInTronLinkApp = jest.fn();
 const mockCreateCoinTransaction = jest.fn();
 const mockCreateTokenTransaction = jest.fn();
 const mockBroadcastTransaction = jest.fn();
+const mockDelay = jest.fn();
 
 jest.mock('@dfx.swiss/react', () => ({ AssetType: { COIN: 'Coin', TOKEN: 'Token' } }));
 
@@ -55,9 +56,12 @@ jest.mock('../../tron.hook', () => ({
   }),
 }));
 
+jest.mock('../../../util/utils', () => ({ delay: (...args: unknown[]) => mockDelay(...args) }));
+
 import { Asset, AssetType } from '@dfx.swiss/react';
 import { renderHook } from '@testing-library/react';
 import BigNumber from 'bignumber.js';
+import { AbortError } from '../../../util/abort-error';
 import { useTronLinkTrx } from '../tronlink-trx.hook';
 import { useTrustTrx } from '../trust-trx.hook';
 
@@ -65,6 +69,7 @@ const mobileMatch = ['iPhone'];
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockDelay.mockResolvedValue(undefined);
 
   for (const adapter of [mockTrustAdapter, mockTronLinkAdapter]) {
     adapter.address = null;
@@ -93,7 +98,8 @@ describe.each([
   it.each([
     [`${walletName} is injected into the page`, true, null, false, true],
     [`a mobile browser outside the ${walletName} app, where connect opens that app`, false, mobileMatch, false, true],
-    [`the ${walletName} app without an injected wallet`, false, mobileMatch, true, false],
+    [`the ${walletName} app without an injected wallet`, false, mobileMatch, true, true],
+    [`the ${walletName} app on desktop without an injected wallet`, false, null, true, true],
     [`a desktop browser without ${walletName}`, false, null, false, false],
     ['no browser at all', false, false, false, false],
   ])('for %s', (_case, isSupported, mobileBrowser, isInWalletApp, expected) => {
@@ -106,9 +112,25 @@ describe.each([
 });
 
 describe.each([
-  { name: 'useTrustTrx', useHook: useTrustTrx, walletName: 'Trust', adapter: mockTrustAdapter },
-  { name: 'useTronLinkTrx', useHook: useTronLinkTrx, walletName: 'TronLink', adapter: mockTronLinkAdapter },
-])('$name', ({ useHook, walletName, adapter }) => {
+  {
+    name: 'useTrustTrx',
+    useHook: useTrustTrx,
+    walletName: 'Trust',
+    adapter: mockTrustAdapter,
+    mockSupport: mockSupportTrust,
+    mockInWalletApp: mockIsTrustApp,
+    abortMessage: 'Forwarded to Trust app',
+  },
+  {
+    name: 'useTronLinkTrx',
+    useHook: useTronLinkTrx,
+    walletName: 'TronLink',
+    adapter: mockTronLinkAdapter,
+    mockSupport: mockSupportTronLink,
+    mockInWalletApp: mockIsInTronLinkApp,
+    abortMessage: 'Forwarded to TronLink app',
+  },
+])('$name', ({ useHook, walletName, adapter, mockSupport, mockInWalletApp, abortMessage }) => {
   function setup() {
     return renderHook(() => useHook()).result.current;
   }
@@ -137,15 +159,43 @@ describe.each([
     });
 
     it('rethrows the wallet error message', async () => {
+      mockSupport.mockReturnValue(true);
+      mockIsInMobileBrowser.mockReturnValue(false);
+      mockInWalletApp.mockReturnValue(false);
       adapter.connect.mockRejectedValue(new Error('The user rejected connection.'));
 
       await expect(setup().connect()).rejects.toThrow('The user rejected connection.');
     });
 
     it('uses a generic message when the wallet error has none', async () => {
+      mockSupport.mockReturnValue(true);
+      mockIsInMobileBrowser.mockReturnValue(false);
+      mockInWalletApp.mockReturnValue(false);
       adapter.connect.mockRejectedValue({});
 
       await expect(setup().connect()).rejects.toThrow('An unexpected error occurred.');
+    });
+
+    it(`aborts after forwarding to the ${walletName} app on mobile`, async () => {
+      mockSupport.mockReturnValue(false);
+      mockIsInMobileBrowser.mockReturnValue(mobileMatch);
+      mockInWalletApp.mockReturnValue(false);
+      adapter.connect.mockRejectedValue(new Error('Wallet not found'));
+
+      const connectPromise = setup().connect();
+      await expect(connectPromise).rejects.toBeInstanceOf(AbortError);
+      await expect(connectPromise).rejects.toHaveProperty('message', abortMessage);
+      expect(mockDelay).toHaveBeenCalledWith(5);
+    });
+
+    it(`rethrows when already inside the ${walletName} app on mobile`, async () => {
+      mockSupport.mockReturnValue(false);
+      mockIsInMobileBrowser.mockReturnValue(mobileMatch);
+      mockInWalletApp.mockReturnValue(true);
+      adapter.connect.mockRejectedValue(new Error('The user rejected connection.'));
+
+      await expect(setup().connect()).rejects.toThrow('The user rejected connection.');
+      expect(mockDelay).not.toHaveBeenCalled();
     });
   });
 

--- a/src/hooks/wallets/__tests__/tron-wallets.hook.test.ts
+++ b/src/hooks/wallets/__tests__/tron-wallets.hook.test.ts
@@ -1,0 +1,205 @@
+// Hooks for the Tron browser wallets (Trust, TronLink): wallet detection, which must match what the
+// adapter's connect can actually reach, and the connect, sign and transaction calls around the adapter.
+
+interface MockTronAdapter {
+  address: string | null;
+  connect: jest.Mock;
+  signMessage: jest.Mock;
+  signTransaction: jest.Mock;
+}
+
+function createMockAdapter(): MockTronAdapter {
+  return { address: null, connect: jest.fn(), signMessage: jest.fn(), signTransaction: jest.fn() };
+}
+
+const mockTrustAdapter = createMockAdapter();
+const mockTronLinkAdapter = createMockAdapter();
+const mockAdapterCreated = jest.fn();
+const mockIsInMobileBrowser = jest.fn();
+const mockSupportTrust = jest.fn();
+const mockIsTrustApp = jest.fn();
+const mockSupportTronLink = jest.fn();
+const mockIsInTronLinkApp = jest.fn();
+const mockCreateCoinTransaction = jest.fn();
+const mockCreateTokenTransaction = jest.fn();
+const mockBroadcastTransaction = jest.fn();
+
+jest.mock('@dfx.swiss/react', () => ({ AssetType: { COIN: 'Coin', TOKEN: 'Token' } }));
+
+jest.mock('@tronweb3/tronwallet-abstract-adapter', () => ({ isInMobileBrowser: () => mockIsInMobileBrowser() }));
+
+// plain constructor functions: CRA resets jest.fn implementations before every test
+jest.mock('@tronweb3/tronwallet-adapter-trust', () => ({
+  TrustAdapter: function TrustAdapter() {
+    mockAdapterCreated('Trust');
+    return mockTrustAdapter;
+  },
+  supportTrust: () => mockSupportTrust(),
+  isTrustApp: () => mockIsTrustApp(),
+}));
+
+jest.mock('@tronweb3/tronwallet-adapter-tronlink', () => ({
+  TronLinkAdapter: function TronLinkAdapter() {
+    mockAdapterCreated('TronLink');
+    return mockTronLinkAdapter;
+  },
+  supportTronLink: () => mockSupportTronLink(),
+  isInTronLinkApp: () => mockIsInTronLinkApp(),
+}));
+
+jest.mock('../../tron.hook', () => ({
+  useTron: () => ({
+    createCoinTransaction: mockCreateCoinTransaction,
+    createTokenTransaction: mockCreateTokenTransaction,
+    broadcastTransaction: mockBroadcastTransaction,
+  }),
+}));
+
+import { Asset, AssetType } from '@dfx.swiss/react';
+import { renderHook } from '@testing-library/react';
+import BigNumber from 'bignumber.js';
+import { useTronLinkTrx } from '../tronlink-trx.hook';
+import { useTrustTrx } from '../trust-trx.hook';
+
+const mobileMatch = ['iPhone'];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  for (const adapter of [mockTrustAdapter, mockTronLinkAdapter]) {
+    adapter.address = null;
+    adapter.connect.mockReset();
+    adapter.signMessage.mockReset();
+    adapter.signTransaction.mockReset();
+  }
+});
+
+describe.each([
+  {
+    name: 'useTrustTrx',
+    useHook: useTrustTrx,
+    walletName: 'Trust',
+    mockSupport: mockSupportTrust,
+    mockInWalletApp: mockIsTrustApp,
+  },
+  {
+    name: 'useTronLinkTrx',
+    useHook: useTronLinkTrx,
+    walletName: 'TronLink',
+    mockSupport: mockSupportTronLink,
+    mockInWalletApp: mockIsInTronLinkApp,
+  },
+])('$name isInstalled', ({ useHook, walletName, mockSupport, mockInWalletApp }) => {
+  it.each([
+    [`${walletName} is injected into the page`, true, null, false, true],
+    [`a mobile browser outside the ${walletName} app, where connect opens that app`, false, mobileMatch, false, true],
+    [`the ${walletName} app without an injected wallet`, false, mobileMatch, true, false],
+    [`a desktop browser without ${walletName}`, false, null, false, false],
+    ['no browser at all', false, false, false, false],
+  ])('for %s', (_case, isSupported, mobileBrowser, isInWalletApp, expected) => {
+    mockSupport.mockReturnValue(isSupported);
+    mockIsInMobileBrowser.mockReturnValue(mobileBrowser);
+    mockInWalletApp.mockReturnValue(isInWalletApp);
+
+    expect(renderHook(() => useHook()).result.current.isInstalled()).toBe(expected);
+  });
+});
+
+describe.each([
+  { name: 'useTrustTrx', useHook: useTrustTrx, walletName: 'Trust', adapter: mockTrustAdapter },
+  { name: 'useTronLinkTrx', useHook: useTronLinkTrx, walletName: 'TronLink', adapter: mockTronLinkAdapter },
+])('$name', ({ useHook, walletName, adapter }) => {
+  function setup() {
+    return renderHook(() => useHook()).result.current;
+  }
+
+  it('creates its adapter once', () => {
+    const { rerender } = renderHook(() => useHook());
+    rerender();
+
+    expect(mockAdapterCreated).toHaveBeenCalledTimes(1);
+    expect(mockAdapterCreated).toHaveBeenCalledWith(walletName);
+  });
+
+  describe('connect', () => {
+    it('returns the address of the connected wallet', async () => {
+      adapter.connect.mockImplementation(async () => {
+        adapter.address = 'TronAddress';
+      });
+
+      await expect(setup().connect()).resolves.toBe('TronAddress');
+    });
+
+    it('fails when the wallet provides no address', async () => {
+      adapter.connect.mockResolvedValue(undefined);
+
+      await expect(setup().connect()).rejects.toThrow('No address found');
+    });
+
+    it('rethrows the wallet error message', async () => {
+      adapter.connect.mockRejectedValue(new Error('The user rejected connection.'));
+
+      await expect(setup().connect()).rejects.toThrow('The user rejected connection.');
+    });
+
+    it('uses a generic message when the wallet error has none', async () => {
+      adapter.connect.mockRejectedValue({});
+
+      await expect(setup().connect()).rejects.toThrow('An unexpected error occurred.');
+    });
+  });
+
+  describe('signMessage', () => {
+    it('returns the signature of the message', async () => {
+      adapter.signMessage.mockResolvedValue('signature');
+
+      await expect(setup().signMessage('TronAddress', 'message')).resolves.toBe('signature');
+      expect(adapter.signMessage).toHaveBeenCalledWith('message');
+    });
+
+    it('rethrows the signing error message', async () => {
+      adapter.signMessage.mockRejectedValue(new Error('Signing rejected'));
+
+      await expect(setup().signMessage('TronAddress', 'message')).rejects.toThrow('Signing rejected');
+    });
+  });
+
+  describe('createTransaction', () => {
+    const amount = new BigNumber(10);
+
+    beforeEach(() => {
+      mockCreateCoinTransaction.mockResolvedValue('coin-transaction');
+      mockCreateTokenTransaction.mockResolvedValue('token-transaction');
+      adapter.signTransaction.mockImplementation(async (transaction: string) => `signed-${transaction}`);
+      mockBroadcastTransaction.mockResolvedValue('transaction-id');
+    });
+
+    it('signs and broadcasts a coin transaction', async () => {
+      const asset = { type: AssetType.COIN } as Asset;
+
+      await expect(setup().createTransaction(amount, asset, 'from', 'to')).resolves.toBe('transaction-id');
+
+      expect(mockCreateCoinTransaction).toHaveBeenCalledWith('from', 'to', amount);
+      expect(mockCreateTokenTransaction).not.toHaveBeenCalled();
+      expect(mockBroadcastTransaction).toHaveBeenCalledWith('signed-coin-transaction');
+    });
+
+    it('signs and broadcasts a token transaction', async () => {
+      const asset = { type: AssetType.TOKEN } as Asset;
+
+      await expect(setup().createTransaction(amount, asset, 'from', 'to')).resolves.toBe('transaction-id');
+
+      expect(mockCreateTokenTransaction).toHaveBeenCalledWith('from', 'to', asset, amount);
+      expect(mockCreateCoinTransaction).not.toHaveBeenCalled();
+      expect(mockBroadcastTransaction).toHaveBeenCalledWith('signed-token-transaction');
+    });
+
+    it('rethrows the transaction error message', async () => {
+      mockBroadcastTransaction.mockRejectedValue(new Error('Transaction expired'));
+
+      await expect(setup().createTransaction(amount, { type: AssetType.COIN } as Asset, 'from', 'to')).rejects.toThrow(
+        'Transaction expired',
+      );
+    });
+  });
+});

--- a/src/hooks/wallets/__tests__/tron-wallets.hook.test.ts
+++ b/src/hooks/wallets/__tests__/tron-wallets.hook.test.ts
@@ -115,6 +115,60 @@ describe.each([
   {
     name: 'useTrustTrx',
     useHook: useTrustTrx,
+    mockSupport: mockSupportTrust,
+    mockInWalletApp: mockIsTrustApp,
+  },
+  {
+    name: 'useTronLinkTrx',
+    useHook: useTronLinkTrx,
+    mockSupport: mockSupportTronLink,
+    mockInWalletApp: mockIsInTronLinkApp,
+  },
+])('$name isAvailable', ({ useHook, mockSupport, mockInWalletApp }) => {
+  beforeEach(() => {
+    mockSupport.mockReturnValue(false);
+    mockIsInMobileBrowser.mockReturnValue(false);
+    mockInWalletApp.mockReturnValue(false);
+  });
+
+  it('resolves true immediately when the wallet is already detected', async () => {
+    mockSupport.mockReturnValue(true);
+
+    const { result } = renderHook(() => useHook());
+
+    await expect(result.current.isAvailable()).resolves.toBe(true);
+    expect(mockDelay).not.toHaveBeenCalled();
+  });
+
+  it('resolves true when the wallet appears after a few delay attempts', async () => {
+    let calls = 0;
+    mockDelay.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 3) {
+        mockSupport.mockReturnValue(true);
+      }
+    });
+
+    const { result } = renderHook(() => useHook());
+
+    await expect(result.current.isAvailable()).resolves.toBe(true);
+    expect(mockDelay).toHaveBeenCalled();
+    expect(mockDelay.mock.calls.every((call) => call[0] === 0.1)).toBe(true);
+  });
+
+  it('resolves false after 20 attempts when the wallet never appears', async () => {
+    const { result } = renderHook(() => useHook());
+
+    await expect(result.current.isAvailable()).resolves.toBe(false);
+    expect(mockDelay).toHaveBeenCalledTimes(20);
+    expect(mockDelay.mock.calls.every((call) => call[0] === 0.1)).toBe(true);
+  });
+});
+
+describe.each([
+  {
+    name: 'useTrustTrx',
+    useHook: useTrustTrx,
     walletName: 'Trust',
     adapter: mockTrustAdapter,
     mockSupport: mockSupportTrust,

--- a/src/hooks/wallets/alby.hook.ts
+++ b/src/hooks/wallets/alby.hook.ts
@@ -5,6 +5,7 @@ import { delay } from '../../util/utils';
 
 export interface AlbyInterface {
   isInstalled: () => boolean;
+  isAvailable: () => Promise<boolean>;
   isEnabled: boolean;
   enable: () => Promise<GetInfoResponse>;
   signMessage: (msg: string) => Promise<string>;
@@ -20,6 +21,14 @@ export function useAlby(): AlbyInterface {
 
   function isInstalled() {
     return Boolean(webln());
+  }
+
+  // the extension may inject window.webln shortly after the page loaded
+  async function isAvailable(): Promise<boolean> {
+    return waitForWebln().then(
+      () => true,
+      () => false,
+    );
   }
 
   async function enable(): Promise<GetInfoResponse> {
@@ -75,11 +84,12 @@ export function useAlby(): AlbyInterface {
   return useMemo(
     () => ({
       isInstalled,
+      isAvailable,
       isEnabled,
       enable,
       signMessage,
       sendPayment,
     }),
-    [],
+    [isEnabled],
   );
 }

--- a/src/hooks/wallets/alby.hook.ts
+++ b/src/hooks/wallets/alby.hook.ts
@@ -70,6 +70,8 @@ export function useAlby(): AlbyInterface {
       await delay(0.01);
     }
 
+    if (isInstalled()) return;
+
     throw new Error('Timeout');
   }
 

--- a/src/hooks/wallets/phantom.hook.ts
+++ b/src/hooks/wallets/phantom.hook.ts
@@ -1,4 +1,5 @@
 import { Asset, AssetType } from '@dfx.swiss/react';
+import { WalletReadyState } from '@solana/wallet-adapter-base';
 import { PhantomWalletAdapter } from '@solana/wallet-adapter-phantom';
 import BigNumber from 'bignumber.js';
 import { encodeBase58 } from 'ethers';
@@ -22,7 +23,8 @@ export function usePhantom(): PhantomInterface {
   }
 
   function isInstalled(): boolean {
-    return (window as any).phantom?.solana.isPhantom;
+    // Loadable on iOS Safari, where connect opens the page in the Phantom app instead
+    return [WalletReadyState.Installed, WalletReadyState.Loadable].includes(wallet.readyState);
   }
 
   async function connect(): Promise<string> {

--- a/src/hooks/wallets/phantom.hook.ts
+++ b/src/hooks/wallets/phantom.hook.ts
@@ -4,6 +4,8 @@ import { PhantomWalletAdapter } from '@solana/wallet-adapter-phantom';
 import BigNumber from 'bignumber.js';
 import { encodeBase58 } from 'ethers';
 import { useMemo } from 'react';
+import { AbortError } from '../../util/abort-error';
+import { delay } from '../../util/utils';
 import { useSolana } from '../solana.hook';
 
 export interface PhantomInterface {
@@ -32,11 +34,19 @@ export function usePhantom(): PhantomInterface {
 
     try {
       await provider.connect();
-      if (provider.publicKey) return provider.publicKey.toBase58();
-      throw new Error('No public key found');
     } catch (error) {
       handleError(error);
     }
+
+    if (provider.publicKey) return provider.publicKey.toBase58();
+
+    // on iOS Safari the adapter opens the page in the Phantom app instead of connecting
+    if (provider.readyState === WalletReadyState.Loadable) {
+      await delay(5);
+      throw new AbortError('Forwarded to Phantom app');
+    }
+
+    throw new Error('No public key found');
   }
 
   async function signMessage(_address: string, message: string): Promise<string> {

--- a/src/hooks/wallets/tronlink-trx.hook.ts
+++ b/src/hooks/wallets/tronlink-trx.hook.ts
@@ -1,5 +1,6 @@
 import { Asset, AssetType } from '@dfx.swiss/react';
-import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink';
+import { isInMobileBrowser } from '@tronweb3/tronwallet-abstract-adapter';
+import { TronLinkAdapter, isInTronLinkApp, supportTronLink } from '@tronweb3/tronwallet-adapter-tronlink';
 import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
 import { useTron } from '../tron.hook';
@@ -21,7 +22,8 @@ export function useTronLinkTrx(): TronLinkInterface {
   }
 
   function isInstalled(): boolean {
-    return Boolean((window as any).tronLink);
+    // on a mobile browser outside the TronLink app, connect opens the page in the TronLink app instead
+    return supportTronLink() || (Boolean(isInMobileBrowser()) && !isInTronLinkApp());
   }
 
   async function connect(): Promise<string> {

--- a/src/hooks/wallets/tronlink-trx.hook.ts
+++ b/src/hooks/wallets/tronlink-trx.hook.ts
@@ -9,6 +9,7 @@ import { useTron } from '../tron.hook';
 
 export interface TronLinkInterface {
   isInstalled: () => boolean;
+  isAvailable: () => Promise<boolean>;
   connect: () => Promise<string>;
   signMessage: (address: string, message: string) => Promise<string>;
   createTransaction: (amount: BigNumber, asset: Asset, from: string, to: string) => Promise<string>;
@@ -30,6 +31,17 @@ export function useTronLinkTrx(): TronLinkInterface {
   function isInstalled(): boolean {
     // inside the TronLink app the adapter waits for a late injected wallet, outside it on mobile it opens the app
     return supportTronLink() || isInTronLinkApp() || opensTronLinkApp();
+  }
+
+  // the extension may inject the wallet shortly after the page loaded; the adapter waits for it too
+  async function isAvailable(): Promise<boolean> {
+    for (let i = 0; i < 20; i++) {
+      if (isInstalled()) return true;
+
+      await delay(0.1);
+    }
+
+    return false;
   }
 
   async function connect(): Promise<string> {
@@ -86,6 +98,7 @@ export function useTronLinkTrx(): TronLinkInterface {
   return useMemo(
     () => ({
       isInstalled,
+      isAvailable,
       connect,
       signMessage,
       createTransaction,

--- a/src/hooks/wallets/tronlink-trx.hook.ts
+++ b/src/hooks/wallets/tronlink-trx.hook.ts
@@ -3,6 +3,8 @@ import { isInMobileBrowser } from '@tronweb3/tronwallet-abstract-adapter';
 import { TronLinkAdapter, isInTronLinkApp, supportTronLink } from '@tronweb3/tronwallet-adapter-tronlink';
 import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
+import { AbortError } from '../../util/abort-error';
+import { delay } from '../../util/utils';
 import { useTron } from '../tron.hook';
 
 export interface TronLinkInterface {
@@ -21,9 +23,13 @@ export function useTronLinkTrx(): TronLinkInterface {
     return wallet;
   }
 
+  function opensTronLinkApp(): boolean {
+    return !supportTronLink() && Boolean(isInMobileBrowser()) && !isInTronLinkApp();
+  }
+
   function isInstalled(): boolean {
-    // on a mobile browser outside the TronLink app, connect opens the page in the TronLink app instead
-    return supportTronLink() || (Boolean(isInMobileBrowser()) && !isInTronLinkApp());
+    // inside the TronLink app the adapter waits for a late injected wallet, outside it on mobile it opens the app
+    return supportTronLink() || isInTronLinkApp() || opensTronLinkApp();
   }
 
   async function connect(): Promise<string> {
@@ -31,11 +37,18 @@ export function useTronLinkTrx(): TronLinkInterface {
 
     try {
       await provider.connect();
-      if (provider.address) return provider.address;
-      throw new Error('No address found');
     } catch (error) {
+      // the adapter opened the page in the TronLink app instead of connecting
+      if (opensTronLinkApp()) {
+        await delay(5);
+        throw new AbortError('Forwarded to TronLink app');
+      }
+
       handleError(error);
     }
+
+    if (provider.address) return provider.address;
+    throw new Error('No address found');
   }
 
   async function signMessage(address: string, message: string): Promise<string> {

--- a/src/hooks/wallets/tronlink-trx.hook.ts
+++ b/src/hooks/wallets/tronlink-trx.hook.ts
@@ -41,17 +41,18 @@ export function useTronLinkTrx(): TronLinkInterface {
       await delay(0.1);
     }
 
-    return false;
+    return isInstalled();
   }
 
   async function connect(): Promise<string> {
     const provider = getProvider();
+    const opensApp = opensTronLinkApp();
 
     try {
       await provider.connect();
     } catch (error) {
       // the adapter opened the page in the TronLink app instead of connecting
-      if (opensTronLinkApp()) {
+      if (opensApp) {
         await delay(5);
         throw new AbortError('Forwarded to TronLink app');
       }

--- a/src/hooks/wallets/trust-sol.hook.ts
+++ b/src/hooks/wallets/trust-sol.hook.ts
@@ -1,4 +1,5 @@
 import { Asset, AssetType } from '@dfx.swiss/react';
+import { WalletReadyState } from '@solana/wallet-adapter-base';
 import { TrustWalletAdapter } from '@solana/wallet-adapter-trust';
 import BigNumber from 'bignumber.js';
 import { encodeBase58 } from 'ethers';
@@ -22,7 +23,7 @@ export function useTrustSol(): TrustInterface {
   }
 
   function isInstalled(): boolean {
-    return (window as any).ethereum?.isTrustWallet;
+    return wallet.readyState === WalletReadyState.Installed;
   }
 
   async function connect(): Promise<string> {

--- a/src/hooks/wallets/trust-trx.hook.ts
+++ b/src/hooks/wallets/trust-trx.hook.ts
@@ -18,7 +18,8 @@ export interface TrustInterface {
 export function useTrustTrx(): TrustInterface {
   const { createCoinTransaction, createTokenTransaction, broadcastTransaction } = useTron();
 
-  const wallet = useMemo(() => new TrustAdapter(), []);
+  // our own isAvailable() poll runs 2 s; the adapter caches its readiness verdict, so its check must outlive ours
+  const wallet = useMemo(() => new TrustAdapter({ checkTimeout: 3000 }), []);
 
   function getProvider() {
     return wallet;

--- a/src/hooks/wallets/trust-trx.hook.ts
+++ b/src/hooks/wallets/trust-trx.hook.ts
@@ -9,6 +9,7 @@ import { useTron } from '../tron.hook';
 
 export interface TrustInterface {
   isInstalled: () => boolean;
+  isAvailable: () => Promise<boolean>;
   connect: () => Promise<string>;
   signMessage: (address: string, message: string) => Promise<string>;
   createTransaction: (amount: BigNumber, asset: Asset, from: string, to: string) => Promise<string>;
@@ -30,6 +31,17 @@ export function useTrustTrx(): TrustInterface {
   function isInstalled(): boolean {
     // inside the Trust app the adapter waits for a late injected wallet, outside it on mobile it opens the app
     return supportTrust() || isTrustApp() || opensTrustApp();
+  }
+
+  // the extension may inject the wallet shortly after the page loaded; the adapter waits for it too
+  async function isAvailable(): Promise<boolean> {
+    for (let i = 0; i < 20; i++) {
+      if (isInstalled()) return true;
+
+      await delay(0.1);
+    }
+
+    return false;
   }
 
   async function connect(): Promise<string> {
@@ -86,6 +98,7 @@ export function useTrustTrx(): TrustInterface {
   return useMemo(
     () => ({
       isInstalled,
+      isAvailable,
       connect,
       signMessage,
       createTransaction,

--- a/src/hooks/wallets/trust-trx.hook.ts
+++ b/src/hooks/wallets/trust-trx.hook.ts
@@ -41,17 +41,18 @@ export function useTrustTrx(): TrustInterface {
       await delay(0.1);
     }
 
-    return false;
+    return isInstalled();
   }
 
   async function connect(): Promise<string> {
     const provider = getProvider();
+    const opensApp = opensTrustApp();
 
     try {
       await provider.connect();
     } catch (error) {
       // the adapter opened the page in the Trust app instead of connecting
-      if (opensTrustApp()) {
+      if (opensApp) {
         await delay(5);
         throw new AbortError('Forwarded to Trust app');
       }

--- a/src/hooks/wallets/trust-trx.hook.ts
+++ b/src/hooks/wallets/trust-trx.hook.ts
@@ -3,6 +3,8 @@ import { isInMobileBrowser } from '@tronweb3/tronwallet-abstract-adapter';
 import { TrustAdapter, isTrustApp, supportTrust } from '@tronweb3/tronwallet-adapter-trust';
 import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
+import { AbortError } from '../../util/abort-error';
+import { delay } from '../../util/utils';
 import { useTron } from '../tron.hook';
 
 export interface TrustInterface {
@@ -21,9 +23,13 @@ export function useTrustTrx(): TrustInterface {
     return wallet;
   }
 
+  function opensTrustApp(): boolean {
+    return Boolean(isInMobileBrowser()) && !isTrustApp();
+  }
+
   function isInstalled(): boolean {
-    // on a mobile browser outside the Trust app, connect opens the page in the Trust app instead
-    return supportTrust() || (Boolean(isInMobileBrowser()) && !isTrustApp());
+    // inside the Trust app the adapter waits for a late injected wallet, outside it on mobile it opens the app
+    return supportTrust() || isTrustApp() || opensTrustApp();
   }
 
   async function connect(): Promise<string> {
@@ -31,11 +37,18 @@ export function useTrustTrx(): TrustInterface {
 
     try {
       await provider.connect();
-      if (provider.address) return provider.address;
-      throw new Error('No address found');
     } catch (error) {
+      // the adapter opened the page in the Trust app instead of connecting
+      if (opensTrustApp()) {
+        await delay(5);
+        throw new AbortError('Forwarded to Trust app');
+      }
+
       handleError(error);
     }
+
+    if (provider.address) return provider.address;
+    throw new Error('No address found');
   }
 
   async function signMessage(address: string, message: string): Promise<string> {

--- a/src/hooks/wallets/trust-trx.hook.ts
+++ b/src/hooks/wallets/trust-trx.hook.ts
@@ -1,5 +1,6 @@
 import { Asset, AssetType } from '@dfx.swiss/react';
-import { TrustAdapter } from '@tronweb3/tronwallet-adapter-trust';
+import { isInMobileBrowser } from '@tronweb3/tronwallet-abstract-adapter';
+import { TrustAdapter, isTrustApp, supportTrust } from '@tronweb3/tronwallet-adapter-trust';
 import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
 import { useTron } from '../tron.hook';
@@ -21,7 +22,8 @@ export function useTrustTrx(): TrustInterface {
   }
 
   function isInstalled(): boolean {
-    return (window as any).ethereum?.isTrustWallet;
+    // on a mobile browser outside the Trust app, connect opens the page in the Trust app instead
+    return supportTrust() || (Boolean(isInMobileBrowser()) && !isTrustApp());
   }
 
   async function connect(): Promise<string> {


### PR DESCRIPTION
EN:
Wallet connect screens no longer start a connect attempt for a wallet that is not available in the browser; that attempt failed behind the install hint and was reported as a client error. Because the availability check now decides whether a connect happens, each hook detects its wallet the way its own connect path does: through the adapter's state for Phantom and Trust on Solana, through a short wait for a wallet injected after the page loaded for Alby and the two Tron wallets, and through the mobile redirects into the wallet apps wherever the adapter performs them. When the page is sent to a wallet app and the app does not take over, the screen returns to the wallet selection instead of showing and reporting an error, and an unmounted ConnectBase starts no login and reports nothing for that attempt, so a wallet approved after the user moved on can no longer log that wallet in. This PR declares a deviation from the handbook rule, explained in the details.

DE:
Die Wallet-Connect-Screens starten keinen Verbindungsversuch mehr für eine Wallet, die im Browser nicht verfügbar ist; dieser Versuch schlug hinter dem Installationshinweis fehl und wurde als Client-Error gemeldet. Weil die Verfügbarkeitsprüfung jetzt über den Connect entscheidet, erkennt jeder Hook seine Wallet so wie sein eigener Connect-Pfad: über den Adapter-Zustand bei Phantom und Trust auf Solana, über ein kurzes Warten auf eine nach dem Laden injizierte Wallet bei Alby und den beiden Tron-Wallets und über die mobilen Weiterleitungen in die Wallet-Apps, wo der Adapter sie ausführt. Wird die Seite an eine Wallet-App übergeben und die App übernimmt nicht, kehrt der Screen zur Wallet-Auswahl zurück, statt einen Fehler anzuzeigen und zu melden, und ein unmountetes ConnectBase startet keinen Login mehr und meldet für diesen Versuch nichts, sodass eine nach dem Weggehen freigegebene Wallet nicht mehr eingeloggt werden kann. Dieser PR deklariert eine Abweichung von der Handbook-Regel, begründet in den Details.

<details>
<summary>Details</summary>

## Problem

`ConnectBase.init()` computed `supported = await isSupported()`, showed the install hint when it was false, and then called `connect()` anyway whenever `autoConnect` was set:

```ts
if (autoConnect) connect();
```

For MetaMask without an extension, `new Web3(Web3.givenProvider)` has no provider, `web3.eth.requestAccounts()` throws web3's `Provider not set or invalid`, `connect()` stores it as the connect error, and `ConnectError` reports it through `useReportDisplayedError` as a `HandledError`, although the user only sees the install hint (the content with the error is rendered hidden behind it). The same applies to every other wallet component whose availability check can come back false while `autoConnect` is set, each with its own SDK's error text. Taro and WalletConnect set `autoConnect` unconditionally as well, but their `isSupported` is always true, so the pattern never arose there.

## Change

### `connect-base.tsx`

```ts
if (autoConnect && supported) connect();
```

The `autoConnect` props of the wallet components stay unconditional on purpose: gating them on `activeWallet === props.wallet` (like BitBox, CLI, Ledger, Trezor) would also stop auto-connecting on a wallet switch, which is a different behavior.

### Wallet detection reviewed

Before this change, a wallet that `isSupported()` missed could still connect, because the hidden `connect()` ran anyway — including the waits the wallet SDKs perform internally. With the gate that path is gone, so each `isSupported()` has to answer "can this wallet's connect path succeed from here", not just "is some global set at this instant".

| Component | `isSupported` before | Result |
| --- | --- | --- |
| Taro | `() => true` | Correct: LNURL login via QR code or app link, no browser wallet involved. Unchanged. |
| WalletConnect | `() => true` | Correct: QR code or deep link, no browser wallet involved. Unchanged. |
| Trust (Solana) | `window.ethereum?.isTrustWallet` | **Fixed.** Checks the EVM provider, while the adapter connects through `window.trustwallet.solana`; false whenever another extension (MetaMask, Rabby) owns `window.ethereum`. Now: adapter `readyState` is `Installed`. The adapter's `connect()` does not wait for a late wallet, so a check at mount matches it. |
| Phantom | `window.phantom?.solana.isPhantom` | **Fixed.** Throws a `TypeError` when `window.phantom` has no `solana` provider (the promise in `init()` then rejects and the spinner never ends), ignores `window.solana`, and is false on iOS Safari, where the adapter opens the page in the Phantom app. Now: adapter `readyState` is `Installed` or `Loadable`. |
| Alby | `Boolean(window.webln)` | **Fixed.** `enable()` waits up to ~100 ms (`waitForWebln`) for a late injected `window.webln`, but that wait was only reachable through `connect()`. Now `isSupported` is the new `useAlby().isAvailable()`, which uses the same wait. |
| Trust (Tron) | `window.ethereum?.isTrustWallet` | **Fixed.** Same EVM check, while the adapter connects through `window.trustwallet.tronLink`, waits for a late wallet, and on a mobile browser outside the Trust app opens the page in the app. Now: `isInstalled()` is `supportTrust() \|\| isTrustApp() \|\| (isInMobileBrowser() && !isTrustApp())`, and `isSupported` is the new `isAvailable()`, which retries it. |
| TronLink | `Boolean(window.tronLink)` | **Fixed.** The adapter also accepts `window.tron` (TIP-1193) and `window.tronWeb`, waits for a late wallet, and on a mobile browser outside the app opens the page in the app. Now: `isInstalled()` is `supportTronLink() \|\| isInTronLinkApp() \|\| (!supportTronLink() && isInMobileBrowser() && !isInTronLinkApp())`, and `isSupported` is the new `isAvailable()`. |

`WalletReadyState` and `isInMobileBrowser` come from the adapters' base packages, which are installed as their dependencies; `src/hooks/tron.hook.ts` already imports from `@tronweb3/tronwallet-abstract-adapter` the same way.

### Waiting for a wallet that is injected late

Both Tron adapters tolerate a wallet that appears after the page loaded: their constructor starts `_checkWallet()` and `connect()` awaits it, polling every 100 ms. Since the gate decides once at mount, the hooks now do the same through `isAvailable()`, which retries `isInstalled()` every 100 ms — the delay-retry shape `alby.hook.ts` already uses for `window.webln` — and checks once more after the last wait, so the closing window is not missed.

The wait is deliberately capped at 2 s for both, instead of following the adapters' own `checkTimeout` (2 s for Trust, **30 s** for TronLink): the check runs before anything is shown, so the cap is what a user without the extension waits before seeing the install hint. Two seconds matches the Trust adapter's own default and covers a slow content script; a 30 s spinner would not be acceptable for the far more common case of a wallet that is simply not installed.

The cap is therefore a deliberate trade-off, not full parity with the adapter: a TronLink wallet that only appears between 2 s and 30 s after the screen opened is shown as unavailable, although the adapter alone would still have found it. Reopening the wallet re-runs the check, and the install hint is the honest answer for everything slower than the cap.

The Trust adapter needed one more thing: it runs its own readiness poll from its constructor and caches the verdict, with a default window of 2 s — the same length as ours, but started earlier, during render rather than in the effect. Its cached "not found" could therefore be older than our own decision, and `connect()` would answer from that cache: open trustwallet.com in a new tab and throw. It is now constructed with `checkTimeout: 3000`, so its window always outlives ours. TronLink needs no such change; its default is 30 s.

### Redirects into a wallet app

On three paths the adapter does not connect but navigates the page into the wallet app: Phantom on iOS Safari (`connect()` sets `location.href` and returns without a public key), and Trust (Tron) / TronLink on a mobile browser outside their app (`connect()` sets `location.href` and throws `WalletNotFoundError`). The hooks surfaced these as `No public key found` / `The wallet is not found.`, which `ConnectError` showed and reported. The hooks now wait 5 s and throw `AbortError`, the pattern `ConnectAlby` already uses after its own redirect; `ConnectBase` maps it to `onCancel`, which only resets the wallet selection state. For the two Tron wallets the redirect decision is taken before the adapter is called, the same moment the adapter itself decides, so a failure that happens for any other reason is never reclassified as a redirect.

### Results arriving after unmount

`ConnectBase` ran `init()` from a `useEffect` without cleanup, and both continuations of `connect()` ran whenever they eventually settled. Two ways that hurts: with the 5 s redirect windows above, a user who leaves the wallet in the meantime was thrown back to the wallet selection by the stale instance's `.catch`; and a wallet prompt approved after the user had moved on resolved the stale `getAccount`, whose success chain calls `doLogin` — `logout()`, `login()`, `setSession()`, `switchBlockchain()` — and could therefore log out a newer session and log the abandoned wallet in.

`init()` also treats a failing availability check as "not available" — `await isSupported()` sits in a `try`, and the `catch` leaves `supported` false — instead of leaving the spinner up forever with an unhandled rejection. The `try` also covers an implementation that throws synchronously, which the prop's `() => boolean | Promise<boolean>` type allows. No wallet hook rejects today, but the gate now depends on that call, so the failure mode is closed rather than documented.

`ConnectBase` now keeps a mounted ref and checks it at every point where a settled promise would act on the component or the app: it does not start `doLogin`, does not call `onLogin`, `onCancel` or `onSwitch`, and does not touch the sign hint once it is gone. The attempt is dropped rather than reported.

Two things deliberately still finish. A `doLogin` that already started runs to its end — it begins with `logout()`, so stopping in the middle would leave the user logged out and nothing else. And the wallet's own `signMessage` call is not cancelled; only the hint around it is suppressed, since the signature request lives in the wallet, not in this component.

### Found while touching `alby.hook.ts`

Two defects in code this pull request touches, both fixed here:

- `useAlby` memoized its return value with an empty dependency list, so `isEnabled` and the `sendPayment` closure stayed at the first render's `false`. The dependency list is now `[isEnabled]`.
- `waitForWebln()` checked ten times and then threw `Timeout` without looking once more after its last wait — the same off-by-one the two Tron hooks had. It matters more now, because `isAvailable()` wraps it and decides whether the install hint is shown. It now checks once more before giving up, which `enable()` benefits from as well.

### Behavior changes

- A browser without the wallet shows the install hint and nothing else: no connect error, no client error report. On desktop, TronLink and Trust (Tron) no longer open tronlink.org / trustwallet.com in a new tab, which their adapters did when the hidden connect ran without a wallet.
- For the two Tron wallets, that hint now appears up to 2 s after the screen opens, because the availability check waits that long for a late injected wallet.
- On a mobile browser, TronLink, Trust (Tron) and Phantom (iOS Safari) still open the page in the wallet app; if the app does not open, the user is back at the wallet selection after 5 s instead of seeing an error.
- Inside the Trust or TronLink app the connect still happens, and so it does for a wallet injected within the availability wait — about 100 ms for Alby, 2 s for the two Tron wallets. A TronLink extension that only appears after those 2 s is shown as unavailable, although the adapter's own 30 s wait would still have found it.
- Trust users whose `window.ethereum` belongs to another extension no longer see "Please install Trust!".

## Tests

- `src/__tests__/connect-base.test.tsx` (new): auto-connect gate, fallback switch, chain selection, abort / wallet switch / error handling, the login paths, three cases where the availability check itself fails (a rejected promise, with and without `autoConnect`, and an implementation that throws synchronously), and six unmount cases: no auto-connect, no fallback switch, no login, no `onCancel` — each of which fails without its guard — plus the two that document what deliberately continues (the wallet's signature request).
- `src/__tests__/connect-alby-redirect.test.tsx` (extended): the remaining `ConnectAlby` login branches.
- `src/__tests__/connect-tron-wallets.test.tsx` (new): `ConnectTrustTrx` and `ConnectTronLinkTrx` — install hint, mobile fallback, auto-connect, reconnect, connect error and signature forwarding.
- `src/hooks/wallets/__tests__/alby.hook.test.ts` (new): detection, the availability wait, enable / sign / payment including the `isEnabled` fix.
- `src/hooks/wallets/__tests__/solana-wallets.hook.test.ts` (new): Phantom and Trust (Solana) detection per adapter ready state, connect including the Phantom redirect, sign, transactions.
- `src/hooks/wallets/__tests__/tron-wallets.hook.test.ts` (new): Trust (Tron) and TronLink detection for injected wallet / in-app / mobile browser / desktop / no browser, the `isAvailable()` retries, connect including the app redirect, sign, transactions.

Coverage per touched file (`npm run test -- --coverage --collectCoverageFrom=<file>`):

| File | Statements | Branches | Functions | Lines |
| --- | --- | --- | --- | --- |
| `src/components/home/connect-base.tsx` | 100 % | 100 % | 100 % | 100 % |
| `src/components/home/wallet/connect-alby.tsx` | 100 % | 100 % | 100 % | 100 % |
| `src/components/home/wallet/connect-tronlink-trx.tsx` | 100 % | 100 % | 100 % | 100 % |
| `src/components/home/wallet/connect-trust-trx.tsx` | 100 % | 100 % | 100 % | 100 % |
| `src/hooks/wallets/alby.hook.ts` | 100 % | 100 % | 100 % | 100 % |
| `src/hooks/wallets/phantom.hook.ts` | 100 % | 100 % | 100 % | 100 % |
| `src/hooks/wallets/tronlink-trx.hook.ts` | 100 % | 100 % | 100 % | 100 % |
| `src/hooks/wallets/trust-sol.hook.ts` | 100 % | 100 % | 100 % | 100 % |
| `src/hooks/wallets/trust-trx.hook.ts` | 100 % | 100 % | 100 % | 100 % |

Locally on Node 20: `npm run lint`, Prettier on all touched files, `npm run build:dev`, `npm run widget:dev`, and the full Jest suite (157 suites, 2439 tests) are green.

## Declared deviation: handbook coverage

Guideline: CONTRIBUTING.md › Handbook, "Every screen or flow a pull request changes has to be represented there" (a committed Playwright baseline per visual variant plus a `scripts/handbook/metadata.json` entry).

This PR changes the wallet connect flow: which of the existing states (install hint, connecting, connect error, back to the wallet selection) a user reaches depends now on the corrected wallet detection. It adds no new visual variant and does not change how any of these states look. None of these states has a baseline or a spec today; the existing login baselines (`login-process`, `user-flows`, `responsive`) authenticate with a session token and never render `ConnectBase`.

Reason for not adding baselines in this PR: every state this PR changes depends on the presence and timing of a browser wallet extension or a wallet in-app browser (injected, injected late, iOS Safari, inside the Trust or TronLink app), which the Playwright harness cannot reproduce; only the install hint without any extension would be capturable, and its appearance is unchanged. The state matrix is covered by the unit tests above instead. Whether this deviation is accepted is the reviewer's decision.

## Reported, not fixed here: the account after a wallet switch

When `getAccount` rejects with a `WalletSwitchError`, `connect()` switches the wallet and asks the new one for an account — but that call sits in the terminal `.catch()`, so its result goes nowhere: it never reaches `doLogin`, and a rejection has no handler. A BitBox user who picks the Ethereum entry on a Bitcoin-only device is switched to the Bitcoin wallet, selects an address, and is simply not logged in.

The code is unchanged by this pull request (identical on `develop`), but this pull request adds the first test that covers the path, and that test records the current behaviour. Repairing it means restructuring `connect()` so the retry re-enters the same login pipeline, which changes how every wallet switch behaves — a different change from the availability gate this pull request is about. Reported here for the reviewer to route, per CONTRIBUTING.md's rule on pre-existing defects.

## Reported, not fixed here: a login that has already started

Once `doLogin` has begun, it runs to completion even if `ConnectBase` unmounts in the meantime: `useWalletContext().login` fetches the sign message, asks the wallet to sign, calls `createSession`, sets the active wallet and blockchain, and reloads the user. A user who closes the connect screen while the wallet prompt is still open and then signs anyway therefore ends up logged in with that wallet, although the screen reported nothing.

This is not introduced by this pull request — before it, no continuation was guarded at all — and it is not this repository's wallet detection: stopping it properly means carrying a cancellation signal into `login()` in `src/contexts/wallet.context.tsx`, which every wallet shares, and deciding what a half-finished login should leave behind (`login()` starts after `logout()`, so an abort in the wrong place logs the user out and nothing else). Fixing that here would widen this pull request well beyond the connect gate it is about, so it is reported and left for the reviewer to route, per CONTRIBUTING.md's rule on pre-existing defects.

## Not part of this change

- Error classification for client error reports and anything outside this repository: the fix removes the source of the errors instead of reclassifying them.
- Full-stack E2E: the harness runs without a browser wallet extension, so the states this change turns on — injected, injected a moment late, inside a wallet's own app, redirected into one — cannot be reached there; the unit tests above cover them. The plain "no wallet at all" case would be reachable, but no full-stack spec opens an individual connect screen today (`e2e-stack/specs/auth.spec.ts` checks the wallet grid), and this change does not add the first one. No fakes were added or changed, so the reality declaration is unchanged.

</details>
