### PR TITLE
01a0944e - Pin A38 guard so conflicted Ready PRs return to Draft

### DIFF
--- a/.github/workflows/a38-guard.yml
+++ b/.github/workflows/a38-guard.yml
@@ -41,7 +41,7 @@ jobs:
       # from its own action_path (DFXswiss/agent) and reads the base manifest
       # / head workflow YAML via the GitHub API as data only.
       - name: dfx pr guard
-        uses: DFXswiss/agent/.github/actions/a38-guard@278732be433b97096cf5df48b80c3e581446940a
+        uses: DFXswiss/agent/.github/actions/a38-guard@c4a88edb023d1d837d9eaf31253f7282d9985204
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,11 +51,11 @@ Compliance and lower. Prefer Fail or Reset so the automatic AML pipeline can re-
 ### A38
 
 This repository requires A38 according to the canonical A38 standard in
-[DFXswiss/agent](https://github.com/DFXswiss/agent/blob/278732be433b97096cf5df48b80c3e581446940a/docs/a38.md)
-at commit `278732be433b97096cf5df48b80c3e581446940a`. Repo job selection:
+[DFXswiss/agent](https://github.com/DFXswiss/agent/blob/c4a88edb023d1d837d9eaf31253f7282d9985204/docs/a38.md)
+at commit `c4a88edb023d1d837d9eaf31253f7282d9985204`. Repo job selection:
 `.github/a38.json`. Target-branch applicability and fork workflow approval:
 `.github/pr-guard.json`. `dfx pr guard` is
-[wired in](https://github.com/DFXswiss/agent/blob/278732be433b97096cf5df48b80c3e581446940a/docs/a38-guard.md#how-fork-github-actions-are-meant-to-work).
+[wired in](https://github.com/DFXswiss/agent/blob/c4a88edb023d1d837d9eaf31253f7282d9985204/docs/a38-guard.md#how-fork-github-actions-are-meant-to-work).
 
 This is a **public** repository. GitHub-hosted runners execute the heavy suite
 (Jest, `build:dev`, `widget:dev`, handbook smoke, full-stack E2E, CodeQL).


### PR DESCRIPTION
EN:
Pins the A38 guard so Ready pull requests with merge conflicts return to Draft, including when the author has write.
GitHub-hosted CI and the light local A38 report are unchanged. The merger does not click Approve and run workflows.

DE:
Pinnt den A38-Guard, damit Ready-PRs mit Merge-Konflikten wieder Draft werden, auch wenn der Autor Write hat.
Die GitHub-CI und der leichte lokale A38-Report bleiben unverändert. Der Merger klickt nicht Approve and run workflows.

<details>
<summary>Details</summary>

The previous pin (`278732be`) held Ready for write collaborators even with confirmed merge conflicts. The new pin is `c4a88edb023d1d837d9eaf31253f7282d9985204` (agent#95): confirmed conflicts always return Ready to Draft.

Files: `.github/workflows/a38-guard.yml` `uses:` line, and the three A38 documentation links in `CONTRIBUTING.md`.

</details>